### PR TITLE
Add persistent local DICOM library

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -39,15 +39,17 @@ This viewer requires **Google Chrome** (version 86 or later) or **Microsoft Edge
 **Your DICOM Images**
 You'll need a folder containing your DICOM files. These files might have a `.dcm` extension, or they might have no extension at all - both are common. If you received your images on a CD, you may need to copy the contents to your computer first.
 
+### Quick Launch (macOS)
+
+Double-click `launch.command` in Finder to start the server and open the viewer in your browser. If you downloaded the file from GitHub, you may need to make it executable first: `chmod +x launch.command`.
+
 ### Loading Your Images
 
-1. **Open the viewer** in Chrome or Edge
-2. **Drag and drop** your folder onto the upload area in the center of the screen
-   - You can drop the entire folder, even if it contains multiple studies
-3. **Wait for scanning** to complete - a progress indicator will show how many files have been processed
-4. **View your studies** in the library table that appears
+**Persistent library**: When running locally, place DICOM files in `~/DICOMs` and they will load automatically every time you launch the viewer. Click **Refresh Library** to rescan after adding new files.
 
-The viewer will automatically organize your images by patient and study, even if you drop a folder containing multiple scans from different dates.
+**Drag and drop**: You can also drag and drop any folder onto the upload area. This overrides the library for the current session.
+
+The viewer will automatically organize your images by patient and study, even if your folder contains multiple scans from different dates.
 
 ---
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -218,6 +218,22 @@ header .subtitle {
     font-weight: normal;
 }
 
+.library-refresh-btn {
+    padding: 0.35rem 0.7rem;
+    border: 1px solid #444;
+    border-radius: 4px;
+    background-color: transparent;
+    color: #888;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.library-refresh-btn:hover {
+    border-color: #4a9eff;
+    color: #4a9eff;
+}
+
 .loading {
     text-align: center;
     padding: 2rem;

--- a/docs/index.html
+++ b/docs/index.html
@@ -3352,7 +3352,7 @@ Copyright (c) 2026 Divergent Health Technologies
 
             for (const study of studiesArray) {
                 const seriesMap = {};
-                for (const series of study.series) {
+                for (const series of (study.series || [])) {
                     seriesMap[series.seriesInstanceUid] = {
                         seriesInstanceUid: series.seriesInstanceUid,
                         seriesDescription: series.seriesDescription,
@@ -3414,7 +3414,9 @@ Copyright (c) 2026 Divergent Health Technologies
                 const result = normalizeStudiesPayload(payload, '/api/library');
                 state.libraryAvailable = !!result.available;
                 if (result.folder) state.libraryFolder = result.folder;
-                state.studies = result.studies;
+                if (Object.keys(result.studies).length > 0) {
+                    state.studies = result.studies;
+                }
                 await displayStudies();
             } catch (e) {
                 alert(`Failed to refresh library: ${e.message}`);

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,9 +77,10 @@ Copyright (c) 2026 Divergent Health Technologies
 
         <section class="studies-section">
             <h2>Studies <span id="studyCount" class="count"></span></h2>
+            <button id="refreshLibraryBtn" class="library-refresh-btn" style="display: none; margin-bottom: 0.75rem;">Refresh Library</button>
             <div id="emptyState" class="empty-state">
                 <p>No studies loaded</p>
-                <p class="small">Drop a DICOM folder above to get started</p>
+                <p id="emptyStateHint" class="small">Drop a DICOM folder above to get started</p>
             </div>
             <table id="studiesTable" class="studies-table" style="display: none;">
                 <thead>
@@ -283,6 +284,8 @@ Copyright (c) 2026 Divergent Health Technologies
             currentSeries: null,
             currentSliceIndex: 0,
             sliceCache: new LRUCache(SLICE_CACHE_MAX_ENTRIES),
+            libraryAvailable: false,
+            libraryFolder: '',
             // Viewing tools state
             currentTool: 'wl',
             viewTransform: { panX: 0, panY: 0, zoom: 1 },
@@ -308,7 +311,9 @@ Copyright (c) 2026 Divergent Health Technologies
         const studiesTable = $('studiesTable');
         const studiesBody = $('studiesBody');
         const emptyState = $('emptyState');
+        const emptyStateHint = $('emptyStateHint');
         const studyCount = $('studyCount');
+        const refreshLibraryBtn = $('refreshLibraryBtn');
         const uploadProgress = $('uploadProgress');
         const progressText = $('progressText');
         const progressDetail = $('progressDetail');
@@ -1640,11 +1645,19 @@ Copyright (c) 2026 Divergent Health Technologies
             await migrateIfNeeded();
             await loadNotesForStudies();
 
+            refreshLibraryBtn.style.display = state.libraryAvailable ? 'inline-block' : 'none';
+
             const studies = Object.values(state.studies);
             if (!studies.length) {
                 emptyState.style.display = 'block';
                 studiesTable.style.display = 'none';
                 studyCount.textContent = '';
+                if (state.libraryAvailable) {
+                    const folderLabel = state.libraryFolder || 'your library folder';
+                    emptyStateHint.textContent = `No DICOM files found in ${folderLabel}.`;
+                } else {
+                    emptyStateHint.textContent = 'Drop a DICOM folder above to get started';
+                }
                 return;
             }
             emptyState.style.display = 'none';
@@ -2620,6 +2633,10 @@ Copyright (c) 2026 Divergent Health Technologies
                         buf = await file.arrayBuffer();
                     } else if (slice.blob) {
                         buf = await slice.blob.arrayBuffer();
+                    } else if (slice.apiBase) {
+                        const resp = await fetch(`${slice.apiBase}/dicom/${slice.studyId}/${slice.seriesId}/${slice.sliceIndex}`);
+                        if (!resp.ok) throw new Error(`Failed to load slice: ${resp.status}`);
+                        buf = await resp.arrayBuffer();
                     }
                     dataSet = dicomParser.parseDicom(new Uint8Array(buf));
                     state.sliceCache.set(index, dataSet);
@@ -2692,7 +2709,13 @@ Copyright (c) 2026 Divergent Health Technologies
                         // Handle both file handles and blobs
                         const getBuffer = s.fileHandle
                             ? s.fileHandle.getFile().then(f => f.arrayBuffer())
-                            : s.blob ? s.blob.arrayBuffer() : Promise.reject();
+                            : s.blob ? s.blob.arrayBuffer()
+                            : s.apiBase
+                                ? fetch(`${s.apiBase}/dicom/${s.studyId}/${s.seriesId}/${s.sliceIndex}`).then(r => {
+                                    if (!r.ok) throw new Error(`Failed to preload slice: ${r.status}`);
+                                    return r.arrayBuffer();
+                                })
+                                : Promise.reject();
                         getBuffer.then(buf => {
                             state.sliceCache.set(i, dicomParser.parseDicom(new Uint8Array(buf)));
                         }).catch(() => {});
@@ -3033,6 +3056,10 @@ Copyright (c) 2026 Divergent Health Technologies
         folderZone.addEventListener('drop', async e => {
             e.preventDefault();
             folderZone.classList.remove('dragover');
+            if (libraryAbort) {
+                libraryAbort.abort();
+                libraryAbort = null;
+            }
 
             uploadProgress.style.display = 'flex';
             progressText.textContent = 'Reading folder...';
@@ -3076,6 +3103,10 @@ Copyright (c) 2026 Divergent Health Technologies
 
         // Load sample scan (reusable for CT and MRI)
         async function loadSampleScan(samplePath, button, buttonLabel) {
+            if (libraryAbort) {
+                libraryAbort.abort();
+                libraryAbort = null;
+            }
             button.disabled = true;
             button.textContent = 'Loading...';
             uploadProgress.style.display = 'flex';
@@ -3298,24 +3329,25 @@ Copyright (c) 2026 Divergent Health Technologies
         canvas.style.cursor = getCursorForTool(state.currentTool, false);
 
         // =====================================================================
-        // TEST MODE
-        // When ?test is in the URL, load test data from the server API
-        // instead of requiring File System Access API folder drop.
-        // This enables automated testing with Playwright/Puppeteer.
+        // API DATA MODES
+        // Test mode (?test) and local library mode (personal)
         // =====================================================================
 
-        /** Test mode flag - set when ?test URL parameter is present */
-        const isTestMode = new URLSearchParams(window.location.search).has('test');
+        const searchParams = new URLSearchParams(window.location.search);
+        const isTestMode = searchParams.has('test');
+        const noLib = searchParams.has('nolib');
+        let libraryAbort = null;
 
         /**
-         * Load test data from the server API
-         * @returns {Promise<Object>} Studies object matching the normal state.studies format
+         * Load studies from an API endpoint and normalize to state.studies shape.
+         * Supports both test-data array responses and library object responses.
+         *
+         * @param {string} apiBase
+         * @param {RequestInit} options
+         * @returns {Promise<{studies: Object, available: boolean, folder: string}>}
          */
-        async function loadTestData() {
-            const response = await fetch('/api/test-data/studies');
-            if (!response.ok) throw new Error('Failed to load test data');
-
-            const studiesArray = await response.json();
+        function normalizeStudiesPayload(payload, apiBase) {
+            const studiesArray = Array.isArray(payload) ? payload : (payload.studies || []);
             const studies = {};
 
             for (const study of studiesArray) {
@@ -3326,12 +3358,10 @@ Copyright (c) 2026 Divergent Health Technologies
                         seriesDescription: series.seriesDescription,
                         seriesNumber: series.seriesNumber,
                         modality: series.modality,
-                        // Create slice objects that use API URLs instead of fileHandles
                         slices: Array.from({ length: series.sliceCount }, (_, i) => ({
                             instanceNumber: i + 1,
                             sliceLocation: 0,
-                            // Store API info for test mode loading
-                            testMode: true,
+                            apiBase,
                             studyId: study.studyInstanceUid,
                             seriesId: series.seriesInstanceUid,
                             sliceIndex: i
@@ -3351,82 +3381,50 @@ Copyright (c) 2026 Divergent Health Technologies
                 };
             }
 
-            return studies;
-        }
-
-        /**
-         * Load a slice in test mode (fetches from API instead of fileHandle)
-         * This is called from loadSlice when the slice has testMode: true
-         */
-        async function loadTestSlice(slice) {
-            const url = `/api/test-data/dicom/${slice.studyId}/${slice.seriesId}/${slice.sliceIndex}`;
-            const response = await fetch(url);
-            if (!response.ok) throw new Error(`Failed to load test slice: ${response.status}`);
-
-            const arrayBuffer = await response.arrayBuffer();
-            return dicomParser.parseDicom(new Uint8Array(arrayBuffer));
-        }
-
-        // Patch loadSlice to handle test mode
-        const originalLoadSlice = loadSlice;
-        loadSlice = async function(index) {
-            if (!state.currentSeries) return;
-            const slices = state.currentSeries.slices;
-            if (index < 0 || index >= slices.length) return;
-
-            const slice = slices[index];
-
-            // If this is a test mode slice, fetch from API
-            if (slice.testMode) {
-                state.currentSliceIndex = index;
-                updateSliceInfo();
-                imageLoading.style.display = 'block';
-
-                try {
-                    let dataSet = state.sliceCache.get(index);
-
-                    if (!dataSet) {
-                        dataSet = await loadTestSlice(slice);
-                        state.sliceCache.set(index, dataSet);
-                    }
-
-                    // Pass W/L override if user has adjusted values
-                    const wlOverride = (state.windowLevel.center !== null && state.windowLevel.width !== null)
-                        ? state.windowLevel : null;
-                    const info = await renderDicom(dataSet, wlOverride);
-
-                    // Update W/L display in toolbar
-                    updateWLDisplay();
-
-                    if (info && !info.error && !info.isBlank) {
-                        let metadataHtml = `
-                            <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${slices.length}</div></div>
-                            <div class="metadata-item"><div class="label">Modality</div><div class="value">${escapeHtml(info.modality || '-')}</div></div>
-                            <div class="metadata-item"><div class="label">Size</div><div class="value">${info.cols} x ${info.rows}</div></div>
-                            <div class="metadata-item"><div class="label">Window</div><div class="value">C:${info.wc} W:${info.ww}</div></div>
-                        `;
-                        metadataContent.innerHTML = metadataHtml;
-                    }
-
-                    // Preload adjacent slices
-                    for (let i = index - 2; i <= index + 2; i++) {
-                        if (i >= 0 && i < slices.length && !state.sliceCache.has(i)) {
-                            loadTestSlice(slices[i]).then(ds => {
-                                state.sliceCache.set(i, ds);
-                            }).catch(() => {});
-                        }
-                    }
-                } catch (e) {
-                    console.error('Error loading test slice:', e);
-                }
-
-                imageLoading.style.display = 'none';
-                return;
+            if (Array.isArray(payload)) {
+                return { studies, available: true, folder: '' };
             }
 
-            // Normal mode - use original function
-            return originalLoadSlice.call(this, index);
-        };
+            return {
+                studies,
+                available: !!payload.available,
+                folder: payload.folder || ''
+            };
+        }
+
+        async function loadStudiesFromApi(apiBase, options = {}) {
+            const response = await fetch(`${apiBase}/studies`, options);
+            if (!response.ok) throw new Error(`Failed to load studies: ${response.status}`);
+            const payload = await response.json();
+            return normalizeStudiesPayload(payload, apiBase);
+        }
+
+        async function refreshLibrary() {
+            if (libraryAbort) {
+                libraryAbort.abort();
+                libraryAbort = null;
+            }
+            refreshLibraryBtn.disabled = true;
+            const previousText = refreshLibraryBtn.textContent;
+            refreshLibraryBtn.textContent = 'Refreshing...';
+            try {
+                const response = await fetch('/api/library/refresh', { method: 'POST' });
+                if (!response.ok) throw new Error(`Failed to refresh library: ${response.status}`);
+                const payload = await response.json();
+                const result = normalizeStudiesPayload(payload, '/api/library');
+                state.libraryAvailable = !!result.available;
+                if (result.folder) state.libraryFolder = result.folder;
+                state.studies = result.studies;
+                await displayStudies();
+            } catch (e) {
+                alert(`Failed to refresh library: ${e.message}`);
+            } finally {
+                refreshLibraryBtn.disabled = false;
+                refreshLibraryBtn.textContent = previousText;
+            }
+        }
+
+        refreshLibraryBtn.addEventListener('click', refreshLibrary);
 
         // Auto-load test data if in test mode
         if (isTestMode) {
@@ -3437,7 +3435,8 @@ Copyright (c) 2026 Divergent Health Technologies
                     progressText.textContent = 'Loading test data...';
                     progressDetail.textContent = '';
 
-                    state.studies = await loadTestData();
+                    const result = await loadStudiesFromApi('/api/test-data');
+                    state.studies = result.studies;
 
                     uploadProgress.style.display = 'none';
                     await displayStudies();
@@ -3475,6 +3474,23 @@ Copyright (c) 2026 Divergent Health Technologies
                     alert('Failed to load test data: ' + e.message);
                 }
             })();
+        } else if (CONFIG.features.libraryAutoLoad && !noLib) {
+            libraryAbort = new AbortController();
+            loadStudiesFromApi('/api/library', { signal: libraryAbort.signal })
+                .then(async result => {
+                    libraryAbort = null;
+                    state.libraryAvailable = !!result.available;
+                    if (result.folder) state.libraryFolder = result.folder;
+                    if (Object.keys(result.studies).length > 0) {
+                        state.studies = result.studies;
+                    }
+                    await displayStudies();
+                })
+                .catch(async e => {
+                    libraryAbort = null;
+                    if (e.name === 'AbortError') return;
+                    await displayStudies();
+                });
         } else {
             displayStudies();
         }

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -72,6 +72,10 @@ const CONFIG = {
             // Only works with Flask backend (localhost)
             testMode: mode === 'personal',
 
+            // Auto-load persistent local library from backend API
+            // Only in local/self-hosted personal mode
+            libraryAutoLoad: mode === 'personal',
+
             // Analytics (future feature)
             // Only on cloud platform
             analytics: mode === 'cloud',

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -1093,6 +1093,27 @@ test.describe('Test Suite 24: API Endpoint Health', () => {
         expect(response.status()).toBe(404);
     });
 
+    test('GET /api/test-data/dicom rejects path traversal in study ID', async ({ page }) => {
+        const response = await page.request.get(
+            'http://127.0.0.1:5001/api/test-data/dicom/..%2F..%2F..%2Fetc/passwd/0'
+        );
+        expect(response.status()).toBe(404);
+    });
+
+    test('GET /api/library/dicom rejects path traversal in study ID', async ({ page }) => {
+        const response = await page.request.get(
+            'http://127.0.0.1:5001/api/library/dicom/..%2F..%2F..%2Fetc/passwd/0'
+        );
+        expect(response.status()).toBe(404);
+    });
+
+    test('GET /api/library/dicom returns 404 for unknown study', async ({ page }) => {
+        const response = await page.request.get(
+            'http://127.0.0.1:5001/api/library/dicom/nonexistent-study-id/nonexistent-series-id/0'
+        );
+        expect(response.status()).toBe(404);
+    });
+
     test('GET / serves the main application HTML', async ({ page }) => {
         const response = await page.request.get('http://127.0.0.1:5001/');
         expect(response.status()).toBe(200);


### PR DESCRIPTION
## Summary

- Extract `DicomFolderSource` class from test-data code, reuse for both test-data and new `~/DICOMs` library
- Use raw DICOM UIDs instead of hashed IDs (fixes identity mismatch between library and drag-and-drop)
- New library API: `GET /api/library/studies`, `GET /api/library/dicom/...`, `POST /api/library/refresh`
- Eliminate `loadSlice` monkey-patch (~60 lines), integrate `apiBase` as third source type in original `loadSlice`
- Auto-load library in personal mode with `AbortController` race protection
- Capability-based Refresh Library button (shown when folder exists, not mode-based)
- `?nolib` query param for test determinism
- Path traversal guard on all DICOM-serving routes (`get_safe_slice_path`)
- Thread-safe scan coordination via `threading.Condition` (prevents concurrent scans)
- `launch.command` for macOS double-click launch with timeout and failure handling

## Test plan

- [x] 197 Playwright tests pass locally (197 passed, 32.9s)
- [ ] CI passes on this PR
- [ ] Manual: launch in personal mode, library auto-loads from `~/DICOMs`
- [ ] Manual: drag-and-drop still works as override
- [ ] Manual: Refresh Library button rescans and updates
- [ ] Manual: demo site (github.io) does not attempt library fetch

Generated with [Claude Code](https://claude.com/claude-code)