### PR TITLE
Harden library config JSON parsing and info message color

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -301,7 +301,7 @@ header .subtitle {
 }
 
 .library-folder-message.info {
-    color: #8ea8d3;
+    color: #a8c4e0;
 }
 
 .library-folder-message.success {

--- a/docs/index.html
+++ b/docs/index.html
@@ -3467,7 +3467,9 @@ Copyright (c) 2026 Divergent Health Technologies
         async function loadLibraryConfig() {
             const response = await fetch('/api/library/config');
             if (!response.ok) throw new Error(`Failed to load library config: ${response.status}`);
-            const payload = await response.json();
+            const payload = await response.json().catch(() => {
+                throw new Error('Library config response was not valid JSON');
+            });
             applyLibraryConfigPayload(payload);
             return payload;
         }


### PR DESCRIPTION
## Summary
- Guard `response.json()` in `loadLibraryConfig()` against non-JSON 200 responses (e.g., proxy returning HTML on 502). Matches the existing `.catch(() => ({}))` pattern already used in `saveLibraryFolderConfig()`.
- Change `.library-folder-message.info` color from `#8ea8d3` to `#a8c4e0` so env-override confirmation messages are visually distinct from default muted text.

## Test plan
- [ ] Existing 197 Playwright tests pass (no behavioral change)
- [ ] Manual: verify env-override "Saved. Will take effect..." message is visually distinct

Generated with [Claude Code](https://claude.com/claude-code)