### PR TITLE
Move set_folder() scan outside LIBRARY_CONFIG_LOCK

### DIFF
--- a/app.py
+++ b/app.py
@@ -750,13 +750,14 @@ def update_library_config():
         return jsonify(response)
 
     try:
-        with LIBRARY_CONFIG_LOCK:
-            refreshed = library_source.set_folder(folder_path)
-            library_folder_raw = folder_raw
-            library_folder_source = 'settings'
+        refreshed = library_source.set_folder(folder_path)
     except Exception:
         app.logger.exception("Failed to rescan updated library folder: %s", folder_path)
         return jsonify({'error': 'Failed to scan library folder'}), 500
+
+    with LIBRARY_CONFIG_LOCK:
+        library_folder_raw = folder_raw
+        library_folder_source = 'settings'
 
     return jsonify({
         **_build_library_config_payload(),


### PR DESCRIPTION
## Summary
- `set_folder()` can run for seconds/minutes on large DICOM libraries. Holding `LIBRARY_CONFIG_LOCK` across the entire scan blocked all concurrent library API requests (`GET /api/library/studies`, `POST /api/library/refresh`, `GET /api/library/config`).
- Now the scan runs without the lock. The lock is acquired only for the two global assignments (`library_folder_raw`, `library_folder_source`) afterward.

## Test plan
- [ ] Existing Playwright tests pass (no behavioral change -- single-threaded test client)
- [ ] Manual: change library folder to a large directory, verify other API requests aren't blocked during scan

-- claude

Generated with [Claude Code](https://claude.com/claude-code)