### PR TITLE
Add sortable study table with a11y support

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -353,6 +353,19 @@ header .subtitle {
     letter-spacing: 0.5px;
 }
 
+.studies-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.studies-table th.sortable:hover {
+    color: #ccc;
+}
+
+.sort-arrow {
+    font-size: 0.7rem;
+}
+
 .studies-table tbody tr {
     cursor: pointer;
     transition: background-color 0.2s;

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,8 +95,8 @@ Copyright (c) 2026 Divergent Health Technologies
                 <thead>
                     <tr>
                         <th style="width: 30px;"></th>
-                        <th>Patient Name</th>
-                        <th>Study Date</th>
+                        <th class="sortable" data-sort="name" role="button" tabindex="0" aria-sort="none">Patient Name <span class="sort-arrow"></span></th>
+                        <th class="sortable" data-sort="date" role="button" tabindex="0" aria-sort="descending">Study Date <span class="sort-arrow"></span></th>
                         <th>Description</th>
                         <th>Modality</th>
                         <th>Series</th>
@@ -298,6 +298,7 @@ Copyright (c) 2026 Divergent Health Technologies
             libraryFolderResolved: '',
             libraryFolderSource: '',
             libraryConfigReachable: false,
+            studySort: { column: 'date', direction: 'desc' },
             // Viewing tools state
             currentTool: 'wl',
             viewTransform: { panX: 0, panY: 0, zoom: 1 },
@@ -321,6 +322,7 @@ Copyright (c) 2026 Divergent Health Technologies
         const viewerView = $('viewerView');
         const folderZone = $('folderZone');
         const studiesTable = $('studiesTable');
+        const studiesTableHead = document.querySelector('#studiesTable thead');
         const studiesBody = $('studiesBody');
         const emptyState = $('emptyState');
         const emptyStateHint = $('emptyStateHint');
@@ -1666,6 +1668,35 @@ Copyright (c) 2026 Divergent Health Technologies
             libraryFolderConfig.style.display = (state.libraryAvailable || state.libraryConfigReachable) ? 'block' : 'none';
 
             const studies = Object.values(state.studies);
+            const { column, direction } = state.studySort;
+            studies.sort((a, b) => {
+                let aVal;
+                let bVal;
+
+                if (column === 'name') {
+                    aVal = (a.patientName || '').trim().toLocaleLowerCase();
+                    bVal = (b.patientName || '').trim().toLocaleLowerCase();
+                } else {
+                    // Normalize to keep YYYYMMDD and YYYY-MM-DD comparable
+                    aVal = (a.studyDate || '').replace(/\D/g, '');
+                    bVal = (b.studyDate || '').replace(/\D/g, '');
+                }
+
+                // Missing values always sort to the bottom
+                if (!aVal && !bVal) {
+                    return (a.studyInstanceUid || '').localeCompare(b.studyInstanceUid || '');
+                }
+                if (!aVal) return 1;
+                if (!bVal) return -1;
+
+                const cmp = aVal.localeCompare(bVal);
+                if (cmp !== 0) {
+                    return direction === 'asc' ? cmp : -cmp;
+                }
+
+                // Tie-breaker for deterministic rendering order
+                return (a.studyInstanceUid || '').localeCompare(b.studyInstanceUid || '');
+            });
             if (!studies.length) {
                 emptyState.style.display = 'block';
                 studiesTable.style.display = 'none';
@@ -1987,6 +2018,35 @@ Copyright (c) 2026 Divergent Health Technologies
             Object.keys(state.studies).forEach(studyUid => {
                 attachReportEventHandlers(studyUid);
             });
+
+            // Update sort indicators and aria state
+            document.querySelectorAll('.sortable').forEach(th => {
+                const arrow = th.querySelector('.sort-arrow');
+                if (!arrow) return;
+
+                if (th.dataset.sort === state.studySort.column) {
+                    arrow.textContent = state.studySort.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+                    th.setAttribute('aria-sort', state.studySort.direction === 'asc' ? 'ascending' : 'descending');
+                } else {
+                    arrow.textContent = '';
+                    th.setAttribute('aria-sort', 'none');
+                }
+            });
+        }
+
+        function handleSortClick(e) {
+            const th = e.target.closest('.sortable');
+            if (!th) return;
+
+            const column = th.dataset.sort;
+            if (state.studySort.column === column) {
+                state.studySort.direction = state.studySort.direction === 'asc' ? 'desc' : 'asc';
+            } else {
+                state.studySort.column = column;
+                state.studySort.direction = column === 'date' ? 'desc' : 'asc';
+            }
+
+            displayStudies();
         }
 
         // =====================================================================
@@ -3066,6 +3126,14 @@ Copyright (c) 2026 Divergent Health Technologies
         // EVENT HANDLERS
         // Drag-and-drop, keyboard navigation, mouse wheel scrolling
         // =====================================================================
+
+        studiesTableHead.addEventListener('click', handleSortClick);
+        studiesTableHead.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleSortClick(e);
+            }
+        });
 
         // Drag-and-drop handlers for folder loading
         folderZone.addEventListener('dragover', e => { e.preventDefault(); folderZone.classList.add('dragover'); });

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -241,6 +241,113 @@ test.describe('Test Suite 15: Library View - Test Mode Studies Table', () => {
         expect(headerString).toContain('Series');
     });
 
+    test('Sortable headers toggle order and keep missing values at bottom', async ({ page }) => {
+        await page.route('**/api/test-data/studies', async route => {
+            const response = await route.fetch();
+            const originalStudies = await response.json();
+            expect(Array.isArray(originalStudies)).toBe(true);
+            expect(originalStudies.length).toBeGreaterThan(0);
+
+            const baseStudy = originalStudies[0];
+            const fallbackSeries = [{
+                seriesInstanceUid: 'sort-seed-series',
+                seriesDescription: 'Synthetic',
+                modality: 'CT',
+                sliceCount: 1
+            }];
+            const baseSeries = Array.isArray(baseStudy.series) && baseStudy.series.length > 0
+                ? baseStudy.series
+                : fallbackSeries;
+            const baseSeriesCount = baseStudy.seriesCount ?? baseSeries.length;
+            const baseImageCount = baseStudy.imageCount ?? baseSeries.reduce((sum, series) => {
+                return sum + (series.sliceCount || 1);
+            }, 0);
+
+            const customStudies = [
+                {
+                    ...baseStudy,
+                    patientName: 'Mason, Zed',
+                    studyDate: '20240210',
+                    studyInstanceUid: baseStudy.studyInstanceUid,
+                    series: baseSeries,
+                    seriesCount: baseSeriesCount,
+                    imageCount: baseImageCount
+                },
+                {
+                    studyInstanceUid: 'sort-test-uid-a',
+                    patientName: 'Adams, Amy',
+                    studyDate: '20210102',
+                    studyDescription: 'Synthetic A',
+                    modality: 'CT',
+                    seriesCount: 1,
+                    imageCount: 1,
+                    series: fallbackSeries
+                },
+                {
+                    studyInstanceUid: 'sort-test-uid-b',
+                    patientName: '',
+                    studyDate: '20230303',
+                    studyDescription: 'Synthetic B',
+                    modality: 'CT',
+                    seriesCount: 1,
+                    imageCount: 1,
+                    series: fallbackSeries
+                },
+                {
+                    studyInstanceUid: 'sort-test-uid-c',
+                    patientName: 'Brown, Bob',
+                    studyDate: '',
+                    studyDescription: 'Synthetic C',
+                    modality: 'CT',
+                    seriesCount: 1,
+                    imageCount: 1,
+                    series: fallbackSeries
+                }
+            ];
+
+            await route.fulfill({ response, json: customStudies });
+        });
+
+        await page.goto(TEST_URL);
+        await waitForViewerReady(page);
+        await page.click(BACK_BUTTON_SELECTOR);
+        await expect(page.locator(STUDIES_TABLE_SELECTOR)).toBeVisible();
+
+        const nameHeader = page.locator('#studiesTable th.sortable[data-sort="name"]');
+        const dateHeader = page.locator('#studiesTable th.sortable[data-sort="date"]');
+
+        const getColumnTexts = async (columnIndex) => {
+            const cells = page.locator(`${STUDIES_BODY_SELECTOR} .study-row td:nth-child(${columnIndex})`);
+            const values = await cells.allInnerTexts();
+            return values.map(v => v.trim());
+        };
+
+        // Default sort: date descending
+        await expect(dateHeader).toHaveAttribute('aria-sort', 'descending');
+        await expect(nameHeader).toHaveAttribute('aria-sort', 'none');
+        const defaultDates = await getColumnTexts(3);
+        expect(defaultDates).toEqual(['2024-02-10', '2023-03-03', '2021-01-02', '-']);
+
+        // Toggle date -> ascending (missing still at bottom)
+        await dateHeader.click();
+        await expect(dateHeader).toHaveAttribute('aria-sort', 'ascending');
+        const ascDates = await getColumnTexts(3);
+        expect(ascDates).toEqual(['2021-01-02', '2023-03-03', '2024-02-10', '-']);
+
+        // Switch to name -> ascending
+        await nameHeader.click();
+        await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+        await expect(dateHeader).toHaveAttribute('aria-sort', 'none');
+        const ascNames = await getColumnTexts(2);
+        expect(ascNames).toEqual(['Adams, Amy', 'Brown, Bob', 'Mason, Zed', '-']);
+
+        // Toggle name -> descending (missing still at bottom)
+        await nameHeader.click();
+        await expect(nameHeader).toHaveAttribute('aria-sort', 'descending');
+        const descNames = await getColumnTexts(2);
+        expect(descNames).toEqual(['Mason, Zed', 'Brown, Bob', 'Adams, Amy', '-']);
+    });
+
     test('Studies table has at least one study row', async ({ page }) => {
         await setupLibraryFromTestMode(page);
 


### PR DESCRIPTION
## Summary
- Clickable Patient Name and Study Date column headers to sort the study table
- Default sort: newest studies first (date descending)
- Missing values always sort to bottom regardless of direction
- Date normalization (strips non-digits) for mixed YYYYMMDD/YYYY-MM-DD formats
- Deterministic tie-breaker via StudyInstanceUID
- Keyboard accessible: `role="button"`, `tabindex="0"`, Enter/Space handlers, `aria-sort` updates
- Sort arrow indicators on active column

## Test plan
- [ ] Existing Playwright tests pass
- [ ] New test: sort toggle + missing-values-to-bottom verification
- [ ] Manual: click headers to sort, verify arrow and order change

-- claude

Generated with [Claude Code](https://claude.com/claude-code)