### PR TITLE
Add ADR framework and launch.command decision record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ After each test run, apply continuous improvement: analyze results, strengthen t
   - Why that solution was chosen (alternatives considered, tradeoffs)
   - Prevention control added (test, code guideline, or check to prevent recurrence)
 - **Update session log.** At the end of each session, append a summary to `docs/history/session-summaries.md` with date, session name, what was accomplished, and key decisions. This file is gitignored (private).
+- **Record major decisions as ADRs.** For new features, significant architecture choices, technology selections, or decisions likely to be revisited, write/update an ADR in `docs/decisions/`. Use ADR status updates as implementation progresses, and supersede with a new ADR when reversing a decision.
 
 ## Git Workflow Controls
 
@@ -353,6 +354,8 @@ Deployment mode is detected in `docs/js/config.js`:
 ---
 
 ## Past Decisions
+
+Canonical location for new decision records is `docs/decisions/` (Architecture Decision Records). This section is a historical snapshot.
 
 - Chose vanilla JS over React/Vue for simplicity and learning
 - Client-side processing to keep medical data in browser (privacy)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -41,6 +41,13 @@ Master index of all project documentation, organized by audience and purpose.
 | [3D Research](./planning/RESEARCH-3d-volume-rendering.md) | docs/planning/ | Benchmarking study of 3D rendering approaches |
 | [Measurement Tool Research](./planning/RESEARCH-measurement-tool.md) | docs/planning/ | Benchmarking of measurement tools (Horos, Ambra, Sectra) |
 
+### For Decisions
+
+| Document | Location | Description |
+|----------|----------|-------------|
+| [ADR Guide](./decisions/README.md) | docs/decisions/ | ADR conventions, template, and writing criteria |
+| [ADR 001: launch.command](./decisions/001-launch-command.md) | docs/decisions/ | Decision record for macOS double-click startup workflow |
+
 ---
 
 ## Document Locations
@@ -73,7 +80,8 @@ docs/
 ├── DEPLOY.md              # Deployment guide
 ├── TESTING.md             # Testing documentation
 ├── BUGS.md                # Bug tracking
-└── planning/              # Planning and research documents
+├── planning/              # Planning and research documents
+└── decisions/             # Architecture Decision Records (ADRs)
 ```
 
 ### docs/planning/ Directory
@@ -87,6 +95,16 @@ docs/planning/
 ├── RESEARCH-measurement-tool.md            # Measurement tool benchmarking
 ├── RESEARCH-measurement-tool-prompt.md     # Research methodology
 └── RESEARCH-measurement-tool-thinking.md   # Research analysis
+```
+
+### docs/decisions/ Directory
+
+Architecture Decision Records (ADRs) for significant decisions and rationale.
+
+```
+docs/decisions/
+├── README.md                               # ADR template and conventions
+└── 001-launch-command.md                   # Decision record for launch.command startup
 ```
 
 ---
@@ -114,6 +132,7 @@ Start here to understand the project before contributing:
 2. **[API.md](./API.md)** - Backend endpoints (if modifying server)
 3. **[TESTING.md](./TESTING.md)** - Test requirements for new features
 4. **Relevant RESEARCH-*.md** - Prior art and design decisions
+5. **Relevant ADR-*.md** - Canonical accepted decisions and tradeoffs
 
 ### For Understanding 3D Plans
 
@@ -169,6 +188,9 @@ Project structure map showing workspace layout, file organization, and current w
 **RESEARCH-*.md**
 Research documents capturing benchmarking and analysis before feature implementation. Includes competitive analysis, technology comparisons, and design rationale.
 
+**ADR-*.md (`docs/decisions/`)**
+Architecture Decision Records for significant choices. ADRs capture context, decision, alternatives, implementation details, and consequences in an append-only decision log.
+
 ---
 
 ## Keeping Documentation Updated
@@ -189,13 +211,15 @@ Research documents capturing benchmarking and analysis before feature implementa
 | BUGS.md | Bug discovery and resolution |
 | SITEMAP.md | File structure changes |
 | INDEX.md | New documentation files |
+| docs/decisions/README.md and ADR-*.md | New significant decisions, status transitions, or superseding prior decisions |
 
 ### Documentation Requirements (from CLAUDE.md)
 
 - Keep SITEMAP.md accurate when project structure changes
 - Track bugs in BUGS.md with full context (symptoms, root cause, solution, prevention)
+- Record major decisions and rationale in ADRs under `docs/decisions/`
 - Document "why" not just "what" - future developers need context
 
 ---
 
-*Last updated: 2026-02-01*
+*Last updated: 2026-03-03*

--- a/docs/decisions/001-launch-command.md
+++ b/docs/decisions/001-launch-command.md
@@ -1,0 +1,70 @@
+# ADR 001: launch.command Startup for Personal macOS Use
+
+## Status
+Accepted (file exists in working tree, pending commit)
+
+## Context
+
+The user wanted the app to work "like Horos" -- put DICOMs in a folder once, double-click to launch, everything is there. The existing workflow required five steps: open a terminal, navigate to the project directory, activate a Python venv, run `python app.py`, and manually open `http://127.0.0.1:5001/` in a browser. Too much friction for a personal tool meant for daily use.
+
+This was one of three pillars of the Persistent Local DICOM Library feature (PR 1: backend library API, PR 2: frontend auto-load, PR 3: this launcher). The launcher eliminates startup friction while the library feature eliminates the need to re-import images each session.
+
+Related: Session 2026-02-24 ("Persistent Local DICOM Library -- Architecture and Planning").
+
+## Decision
+
+Use a macOS `.command` script as the startup entry point. The `.command` extension is a macOS convention: Terminal.app automatically opens and executes these files when double-clicked in Finder.
+
+The script launches Flask, detects the port from server output, waits for readiness, opens the browser, and cleans up on exit.
+
+## Alternatives Considered
+
+- **Plain `.sh` script** (initial proposal): Rejected after two independent reviewers flagged the same problem -- macOS opens `.sh` files in a text editor by default, not in Terminal. This was rated P2 in plan review. The `.command` extension is the standard fix.
+
+- **Automator `.app` wrapper**: Considered as an alternative to `.command`. Rejected as more complex to create and maintain for what is a developer convenience, not a product feature.
+
+- **Electron or Tauri desktop wrapper**: Briefly considered as part of the broader "like Horos" architecture discussion. Rejected as massive overkill -- the user's request was for something "extremely simple and dirty."
+
+- **Opening browser before server starts**: One counter-plan proposed `open "http://..." &` before `flask run`. Flagged because it would show a connection error briefly. This led to the wait-loop design where the browser only opens after the server confirms readiness.
+
+- **`flask run` instead of `python app.py`**: A counter-plan proposed this. Rejected because it requires `FLASK_APP` to be set, and the app calls `app.run()` directly.
+
+## Design Details
+
+The script (42 lines) includes several deliberate choices:
+
+- **Port detection via log parsing**: Rather than hardcoding port 5001, the script redirects Flask output to a temp file and parses the "Running on http://..." line with grep. This handles port conflicts gracefully.
+
+- **15-second timeout with health checks**: A wait loop checks every 0.5 seconds for the port, with `kill -0 $PID` verifying Flask is still alive before each check. If Flask dies, the script shows the log output for debugging and exits with code 1. Prevents hanging indefinitely.
+
+- **Venv activation with fallback**: `source venv/bin/activate 2>/dev/null || true` attempts the venv but doesn't fail if it's missing (the user might have packages installed globally).
+
+- **`cd "$(dirname "$0")`**: Changes to the script's own directory so it works regardless of where Finder launches it from (Finder's default working directory is `~`).
+
+- **Trap for cleanup**: `trap "kill $PID $TAIL_PID 2>/dev/null; rm -f $LOGFILE" EXIT` ensures the Flask server and log tail are killed and the temp file is removed when the Terminal window closes.
+
+- **Background log tailing**: After detecting the port, `tail -f "$LOGFILE" &` streams Flask output to the terminal so the user can see server activity.
+
+## Review Iterations
+
+The plan went through 5 major revisions with 2 external critique cycles:
+
+1. **V1**: Proposed `launch.sh`, ~15 lines, naive approach.
+2. **Critique 1**: Reviewer flagged `.sh` won't double-click on macOS -- needs `.command` or Automator.
+3. **V2**: Switched to `.command` extension.
+4. **Critique 2**: Second reviewer independently confirmed the `.sh` problem.
+5. **Counter-plans**: One proposed a 4-PR structure with auth-ready seams (rejected as over-engineered). Another proposed a cleaner version that was praised but needed adjustments: POST for refresh, `python app.py` not `flask run`, wait loop before opening browser.
+6. **Final plan**: ~10 lines with `curl` wait loop and trap.
+
+The actual implementation (42 lines by Codex) is more robust than the final plan specified, adding port detection from log parsing, process health checks, and background log tailing.
+
+## Consequences
+
+Positive:
+- Personal startup becomes a single double-click in Finder.
+- No changes to Flask architecture or dependencies.
+- Eliminates 5 manual steps from the daily workflow.
+
+Negative:
+- macOS-specific -- won't help on Linux or Windows.
+- Must stay aligned with Flask startup behavior (port selection, output format).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,63 @@
+# Architecture Decision Records (ADRs)
+
+This directory is the canonical record for significant architecture and implementation decisions in this repository.
+
+ADRs answer a recurring question: why was this approach chosen over alternatives?
+
+## When to Write an ADR
+
+Write an ADR for decisions that are likely to be revisited later, including:
+
+- New features with meaningful design tradeoffs
+- Significant architectural choices
+- Technology or dependency selections
+- Decisions where future contributors might ask: "Why did we do it this way?"
+
+ADRs are usually not needed for:
+
+- Routine bug fixes
+- Small refactors
+- Obvious low-impact changes
+
+## ADR Format
+
+This project uses Nygard's ADR structure with additional sections for implementation detail.
+
+```md
+# ADR NNN: Title
+
+## Status
+Proposed | Accepted | Implemented | Deprecated | Superseded by ADR-NNN
+
+## Context
+What problem or need triggered this decision.
+
+## Decision
+What we chose and why.
+
+## Alternatives Considered
+What we rejected and why.
+
+## Design Details
+Specific implementation choices and their rationale.
+
+## Consequences
+What follows from this decision, including both positive and negative effects.
+```
+
+## Conventions
+
+- Number ADRs sequentially: `001`, `002`, `003`, ...
+- File naming: `NNN-short-kebab-case.md`
+- Keep ADRs concise (typically 1-2 pages)
+- Reasoning is immutable: do not rewrite the `Context`, `Decision`, or `Alternatives Considered` sections in older ADRs
+- Status updates are allowed as implementation progresses (for example `Proposed` -> `Accepted` -> `Implemented`)
+- If a decision changes, create a new ADR that supersedes the old one
+- Add `Review Iterations` only when significant back-and-forth shaped the outcome
+
+## Workflow
+
+1. Create a new ADR with status `Proposed` or `Accepted`.
+2. Link related planning or research docs when relevant.
+3. Update status as implementation lands.
+4. If reversed, write a new ADR and mark the old one as superseded.

--- a/docs/planning/SITEMAP.md
+++ b/docs/planning/SITEMAP.md
@@ -44,6 +44,17 @@ Research, decisions, and reference materials for feature development.
 
 ---
 
+## Decisions (`dicom-viewer/docs/decisions/`)
+
+Architecture Decision Records (ADRs) for significant project decisions and rationale.
+
+| File | Description |
+|------|-------------|
+| `README.md` | ADR convention, template, and writing guidance |
+| `001-launch-command.md` | Decision record for macOS `launch.command` startup workflow |
+
+---
+
 ## DICOM Viewer Application (`dicom-viewer/`)
 
 ```
@@ -61,6 +72,7 @@ dicom-viewer/
 │   ├── sample/            # Demo CT scan
 │   ├── sample-mri/        # Demo MRI scan
 │   ├── planning/          # Research and feature planning
+│   ├── decisions/         # ADRs and architecture rationale
 │   ├── BUGS.md            # Bug tracking
 │   ├── DEPLOY.md          # Deployment guide
 │   ├── DEVELOPMENT_PHILOSOPHY.md  # Why we work this way
@@ -90,4 +102,4 @@ dicom-viewer/
 
 ---
 
-*Last updated: 2026-02-01*
+*Last updated: 2026-03-03*

--- a/docs/planning/update-sitemap.sh
+++ b/docs/planning/update-sitemap.sh
@@ -124,6 +124,38 @@ for file in *.md; do
     esac
 done
 
+# Decisions section
+cat >> "$SITEMAP" << 'DECISIONS'
+
+---
+
+## Decisions (`docs/decisions/`)
+
+Architecture Decision Records (ADRs) for significant project decisions and rationale.
+
+| File | Description |
+|------|-------------|
+DECISIONS
+
+if [[ -d "$PROJECT_ROOT/docs/decisions" ]]; then
+    cd "$PROJECT_ROOT/docs/decisions"
+    for file in *.md; do
+        [[ -e "$file" ]] || continue
+        case "$file" in
+            README.md)
+                echo "| \`README.md\` | ADR convention, template, and writing guidance |" >> "$SITEMAP"
+                ;;
+            [0-9][0-9][0-9]-*)
+                name="${file%.md}"
+                echo "| \`$file\` | ADR ${name:0:3} decision record |" >> "$SITEMAP"
+                ;;
+            *)
+                echo "| \`$file\` | |" >> "$SITEMAP"
+                ;;
+        esac
+    done
+fi
+
 # DICOM viewer section
 cat >> "$SITEMAP" << 'VIEWER'
 
@@ -139,7 +171,9 @@ dicom-viewer/
 │   ├── index.html         # Main SPA
 │   ├── css/               # Styles
 │   ├── js/                # JavaScript + WASM
-│   └── sample/            # Demo DICOM files
+│   ├── sample/            # Demo DICOM files
+│   ├── planning/          # Planning and research
+│   └── decisions/         # Architecture Decision Records (ADRs)
 ├── tests/                 # Playwright E2E tests
 ├── test-data/             # Test DICOM files
 └── uploads/               # Server upload destination


### PR DESCRIPTION
## Summary

- Introduces Architecture Decision Records (`docs/decisions/`) as the canonical location for significant project decisions
- ADR-001 documents the `launch.command` design: why `.command` over `.sh`, port detection, timeout, cleanup -- reconstructed from the original planning session transcript
- Updates INDEX.md, SITEMAP.md, update-sitemap.sh, and CLAUDE.md to integrate the new directory

## Context

Feature decisions were scattered across CLAUDE.md, PLAN-*.md, RESEARCH-*.md, and session summaries. ADRs give each decision a permanent, searchable document that lives with the code. ADR-001 sets the standard for depth -- capturing not just what was decided, but alternatives rejected, specific design rationale, and how the plan evolved through review.

## Test plan

- [ ] Verify `docs/decisions/README.md` contains template and conventions
- [ ] Verify `docs/decisions/001-launch-command.md` has full context, alternatives, and design details
- [ ] Verify `docs/INDEX.md` includes decisions directory
- [ ] Verify `docs/planning/SITEMAP.md` includes decisions directory
- [ ] Verify `docs/planning/update-sitemap.sh` generates decisions section (run `./update-sitemap.sh`)
- [ ] Verify `CLAUDE.md` references ADRs in Documentation Requirements and Past Decisions

Generated with [Claude Code](https://claude.com/claude-code)