### PR TITLE
Harden desktop DICOM scan and decode path

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -12,6 +12,59 @@ Known issues, bugs, and their resolution status.
 
 ## Resolved Bugs
 
+### BUG-004: Packaged Tauri app hid desktop library UI and included non-image DICOM objects
+
+| Field | Value |
+|-------|-------|
+| **Status** | Resolved |
+| **Priority** | High |
+| **Found** | 2026-03-08 |
+| **Resolved** | 2026-03-08 |
+| **Commit** | 7f330b1 |
+
+**How Encountered:**
+In the packaged macOS Tauri app, the saved desktop library controls were missing at startup until a sample study was loaded. After the library became visible, one real XR study from `/Users/gabriel/Desktop/radiology all discs` showed bogus series entries with `No pixel data found`, and a valid JPEG 2000 image series showed `JPEG 2000 decode failed`.
+
+**Root Cause:**
+This was a combination of three desktop-only issues:
+1. Packaged Tauri startup raced the plain-script frontend. The app could detect "desktop" before `window.__TAURI__` was ready, so desktop library initialization and native bridge setup were inconsistent.
+2. Desktop folder scans admitted any parseable DICOM object with a study UID, including Structured Reports and other non-image objects that have no renderable pixel data.
+3. JPEG 2000 decoding in packaged mode assumed a simple `js/<asset>` path for the WASM asset and manually read the first fragment instead of the full encapsulated frame, which was brittle for the packaged webview runtime.
+
+**Solution:**
+- Added a plain-script Tauri compatibility shim and startup readiness promise so packaged desktop mode waits for the runtime before initializing desktop-only features.
+- Rendered the saved desktop library configuration immediately on startup while the background rescan continues.
+- Tightened desktop scan admission to include only renderable image metadata (`study UID` + `pixel data` + non-zero `rows/cols`).
+- Updated JPEG 2000 loading to resolve the WASM asset relative to the decoder script and read the encapsulated image frame through `dicomParser.readEncapsulatedImageFrame(...)`.
+- Applied the same renderable-image filter to sample loading for consistency across sources.
+
+**Why This Solution:**
+Alternatives considered:
+- *Only hide bad series in the viewer* - Rejected; non-image objects should be filtered out at ingest so library counts and series lists stay correct.
+- *Hardcode another packaged asset path* - Rejected; brittle across local server, preview, and Tauri packaged origins.
+- *Treat the startup issue as cosmetic* - Rejected; it made desktop configuration look unavailable and obscured whether persisted library state had loaded.
+
+Chose a runtime-shim plus renderable-image admission model because it fixes the root contract mismatch between web and packaged desktop sources, instead of layering special cases on the viewer.
+
+**Prevention:**
+- Added Playwright coverage for packaged Tauri runtime detection and late-arriving `__TAURI_INTERNALS__`.
+- Added Playwright coverage ensuring saved desktop library config is visible before a slow startup scan completes.
+- Added a regression test for the renderable-image metadata helper so non-image DICOM objects stay excluded from library scans.
+- Kept the full Playwright suite as the shared regression guard, then rebuilt the packaged macOS bundle from the fixed tree.
+
+**Files Changed:**
+- `docs/index.html`
+- `docs/js/config.js`
+- `docs/js/tauri-compat.js`
+- `docs/js/app/main.js`
+- `docs/js/app/desktop-library.js`
+- `docs/js/app/dicom.js`
+- `docs/js/app/sources.js`
+- `tests/desktop-library.spec.js`
+- `tests/desktop-runtime-compat.spec.js`
+
+---
+
 ### BUG-003: Playwright tests fail when Flask server not running
 
 | Field | Value |
@@ -174,4 +227,4 @@ Series with 500+ slices may take several seconds to parse. This is expected give
 
 ---
 
-*Last updated: 2026-02-01*
+*Last updated: 2026-03-08*

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,6 +43,9 @@ Copyright (c) 2026 Divergent Health Technologies
     <!-- JPEG 2000 decoder (OpenJPEG compiled to WebAssembly) -->
     <script src="js/openjpegwasm_decode.js"></script>
 
+    <!-- Tauri runtime compatibility for plain-script desktop builds -->
+    <script src="js/tauri-compat.js"></script>
+
     <!-- Application configuration (deployment mode, feature flags) -->
     <script src="js/config.js"></script>
 

--- a/docs/js/app/desktop-library.js
+++ b/docs/js/app/desktop-library.js
@@ -53,6 +53,11 @@
             return app.sources.collectPathSources(folderPath);
         },
 
+        loadStudies(folderPath, options = {}) {
+            this.getRuntime();
+            return app.sources.loadStudiesFromDesktopPaths([folderPath], options);
+        },
+
         markScanComplete(folderPath) {
             const config = this.getConfig();
             config.folder = folderPath || config.folder || null;

--- a/docs/js/app/desktop-library.js
+++ b/docs/js/app/desktop-library.js
@@ -4,6 +4,14 @@
     const DesktopLibrary = {
         CONFIG_KEY: 'dicom-viewer-library-config',
 
+        getRuntime() {
+            const tauri = window.__TAURI__;
+            if (!tauri?.dialog?.open || !tauri?.fs?.readDir || !tauri?.path?.join) {
+                throw new Error('Desktop runtime is not ready. Quit and reopen the app if this persists.');
+            }
+            return tauri;
+        },
+
         getConfig() {
             try {
                 const saved = localStorage.getItem(this.CONFIG_KEY);
@@ -41,6 +49,7 @@
         },
 
         scanFolder(folderPath) {
+            this.getRuntime();
             return app.sources.collectPathSources(folderPath);
         },
 
@@ -59,7 +68,8 @@
         },
 
         async pickAndSetFolder() {
-            const selected = await window.__TAURI__.dialog.open({
+            const tauri = this.getRuntime();
+            const selected = await tauri.dialog.open({
                 directory: true,
                 recursive: true,
                 title: 'Choose DICOM Library Folder'

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -103,6 +103,7 @@
             const rows = getMetadataNumber(dataSet, 'x00280010', 0);
             const cols = getMetadataNumber(dataSet, 'x00280011', 0);
             const pixelDataElement = dataSet.elements?.x7fe00010;
+            const numberOfFrames = getNumberOfFrames(dataSet);
             return {
                 patientName: getString(dataSet, 'x00100010'),
                 studyDate: getString(dataSet, 'x00080020'),
@@ -118,6 +119,7 @@
                 sopClassUid: getString(dataSet, 'x00080016'),
                 rows,
                 cols,
+                numberOfFrames,
                 hasPixelData: !!pixelDataElement && rows > 0 && cols > 0
             };
         } catch { return null; }
@@ -328,13 +330,13 @@
      * @param {number} bitsAllocated - Bits per pixel (8 or 16)
      * @returns {TypedArray|null} Decoded pixel data or null on failure
      */
-    function decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated) {
+    function decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated, frameIndex = 0) {
         try {
             let frameData;
 
             // Try using dicomParser's built-in function first
             if (pixelDataElement.fragments && pixelDataElement.fragments.length > 0) {
-                frameData = getEncapsulatedFrameData(dataSet, pixelDataElement, 0);
+                frameData = getEncapsulatedFrameData(dataSet, pixelDataElement, frameIndex);
             } else {
                 // Manually parse encapsulated pixel data
                 const byteArray = dataSet.byteArray;
@@ -456,7 +458,7 @@
      * @param {number} pixelRepresentation - 0=unsigned, 1=signed
      * @returns {Promise<TypedArray|null>} Decoded pixel data or null on failure
      */
-    async function decodeJpeg2000(dataSet, pixelDataElement, rows, cols, bitsAllocated, pixelRepresentation) {
+    async function decodeJpeg2000(dataSet, pixelDataElement, rows, cols, bitsAllocated, pixelRepresentation, frameIndex = 0) {
         try {
             console.log('Attempting JPEG 2000 decode for', rows, 'x', cols, 'image');
 
@@ -472,7 +474,7 @@
                 return null;
             }
 
-            const j2kData = getEncapsulatedFrameData(dataSet, jp2DataElement, 0);
+            const j2kData = getEncapsulatedFrameData(dataSet, jp2DataElement, frameIndex);
             console.log('JPEG 2000 data length:', j2kData.length, 'bytes');
 
             // Initialize and use OpenJPEG decoder
@@ -530,9 +532,9 @@
      * @param {number} cols - Image width
      * @returns {Promise<Object|null>} {pixels, isRgb} or null on failure
      */
-    async function decodeJpegBaseline(dataSet, pixelDataElement, rows, cols) {
+    async function decodeJpegBaseline(dataSet, pixelDataElement, rows, cols, frameIndex = 0) {
         try {
-            const frames = getEncapsulatedFrameData(dataSet, dataSet.elements.x7fe00010, 0);
+            const frames = getEncapsulatedFrameData(dataSet, dataSet.elements.x7fe00010, frameIndex);
 
             const blob = new Blob([frames], { type: 'image/jpeg' });
             const bitmap = await createImageBitmap(blob);
@@ -561,6 +563,7 @@
         parseDicomMetadata,
         toDicomByteArray,
         getMetadataNumber,
+        getNumberOfFrames,
         getEncapsulatedFrameData,
         isCompressed,
         isJpegLossless,

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -7,17 +7,36 @@
     // DICOM PARSING
     // =====================================================================
 
+    async function toDicomByteArray(input) {
+        if (input instanceof Uint8Array) {
+            return input;
+        }
+
+        if (input instanceof ArrayBuffer) {
+            return new Uint8Array(input);
+        }
+
+        if (input?.buffer instanceof ArrayBuffer && typeof input.byteLength === 'number') {
+            return new Uint8Array(input.buffer, input.byteOffset || 0, input.byteLength);
+        }
+
+        if (input?.arrayBuffer) {
+            return new Uint8Array(await input.arrayBuffer());
+        }
+
+        throw new Error('Unsupported DICOM metadata source');
+    }
+
     /**
      * Parse DICOM file metadata without loading pixel data (fast scan)
      * Used during folder import to organize files by study/series.
      *
-     * @param {File} file - File object from File System Access API
+     * @param {File|Blob|ArrayBuffer|Uint8Array} input - Source bytes or file-like object
      * @returns {Promise<Object|null>} Metadata object or null if not valid DICOM
      */
-    async function parseDicomMetadata(file) {
+    async function parseDicomMetadata(input) {
         try {
-            const arrayBuffer = await file.arrayBuffer();
-            const byteArray = new Uint8Array(arrayBuffer);
+            const byteArray = await toDicomByteArray(input);
             const dataSet = dicomParser.parseDicom(byteArray, { untilTag: 'x7fe00010' });
             const transferSyntax = getString(dataSet, 'x00020010');
             const rows = getNumber(dataSet, 'x00280010', 0);

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -559,6 +559,7 @@
 
     app.dicom = {
         parseDicomMetadata,
+        toDicomByteArray,
         getMetadataNumber,
         getEncapsulatedFrameData,
         isCompressed,

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -113,6 +113,7 @@
                 seriesInstanceUid: getString(dataSet, 'x0020000e'),
                 seriesNumber: getString(dataSet, 'x00200011'),
                 modality: getString(dataSet, 'x00080060'),
+                sopInstanceUid: getString(dataSet, 'x00080018'),
                 instanceNumber: getMetadataNumber(dataSet, 'x00200013', 0),
                 sliceLocation: getMetadataNumber(dataSet, 'x00201041', 0),
                 transferSyntax: transferSyntax,

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -64,6 +64,30 @@
         return fallback;
     }
 
+    function getNumberOfFrames(dataSet) {
+        const frameCount = getMetadataNumber(dataSet, 'x00280008', 1);
+        return Number.isFinite(frameCount) && frameCount > 0 ? frameCount : 1;
+    }
+
+    function getEncapsulatedFrameData(dataSet, pixelDataElement, frameIndex = 0) {
+        try {
+            return dicomParser.readEncapsulatedImageFrame(dataSet, pixelDataElement, frameIndex);
+        } catch (error) {
+            const frameCount = getNumberOfFrames(dataSet);
+            const message = String(error?.message || error || '');
+            const isEmptyBasicOffsetTable = message.includes('basicOffsetTable has zero entries');
+
+            if (!isEmptyBasicOffsetTable || frameCount > 1) {
+                throw error;
+            }
+
+            console.warn(
+                'Falling back to fragment-concatenated encapsulated frame decode for single-frame image with empty Basic Offset Table.'
+            );
+            return dicomParser.readEncapsulatedPixelData(dataSet, pixelDataElement, frameIndex);
+        }
+    }
+
     /**
      * Parse DICOM file metadata without loading pixel data (fast scan)
      * Used during folder import to organize files by study/series.
@@ -310,9 +334,7 @@
 
             // Try using dicomParser's built-in function first
             if (pixelDataElement.fragments && pixelDataElement.fragments.length > 0) {
-                frameData = dicomParser.readEncapsulatedPixelDataFromFragments(
-                    dataSet, pixelDataElement, 0
-                );
+                frameData = getEncapsulatedFrameData(dataSet, pixelDataElement, 0);
             } else {
                 // Manually parse encapsulated pixel data
                 const byteArray = dataSet.byteArray;
@@ -450,7 +472,7 @@
                 return null;
             }
 
-            const j2kData = dicomParser.readEncapsulatedImageFrame(dataSet, jp2DataElement, 0);
+            const j2kData = getEncapsulatedFrameData(dataSet, jp2DataElement, 0);
             console.log('JPEG 2000 data length:', j2kData.length, 'bytes');
 
             // Initialize and use OpenJPEG decoder
@@ -510,9 +532,7 @@
      */
     async function decodeJpegBaseline(dataSet, pixelDataElement, rows, cols) {
         try {
-            const frames = dicomParser.readEncapsulatedPixelDataFromFragments(
-                dataSet, dataSet.elements.x7fe00010, 0
-            );
+            const frames = getEncapsulatedFrameData(dataSet, dataSet.elements.x7fe00010, 0);
 
             const blob = new Blob([frames], { type: 'image/jpeg' });
             const bitmap = await createImageBitmap(blob);
@@ -540,6 +560,7 @@
     app.dicom = {
         parseDicomMetadata,
         getMetadataNumber,
+        getEncapsulatedFrameData,
         isCompressed,
         isJpegLossless,
         isJpegBaseline,

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -20,6 +20,9 @@
             const byteArray = new Uint8Array(arrayBuffer);
             const dataSet = dicomParser.parseDicom(byteArray, { untilTag: 'x7fe00010' });
             const transferSyntax = getString(dataSet, 'x00020010');
+            const rows = getNumber(dataSet, 'x00280010', 0);
+            const cols = getNumber(dataSet, 'x00280011', 0);
+            const pixelDataElement = dataSet.elements?.x7fe00010;
             return {
                 patientName: getString(dataSet, 'x00100010'),
                 studyDate: getString(dataSet, 'x00080020'),
@@ -32,8 +35,21 @@
                 instanceNumber: getNumber(dataSet, 'x00200013', 0),
                 sliceLocation: getNumber(dataSet, 'x00201041', 0),
                 transferSyntax: transferSyntax,
+                sopClassUid: getString(dataSet, 'x00080016'),
+                rows,
+                cols,
+                hasPixelData: !!pixelDataElement && rows > 0 && cols > 0
             };
         } catch { return null; }
+    }
+
+    function isRenderableImageMetadata(meta) {
+        return !!(
+            meta?.studyInstanceUid &&
+            meta?.hasPixelData &&
+            meta?.rows > 0 &&
+            meta?.cols > 0
+        );
     }
 
 
@@ -296,6 +312,31 @@
     /** Promise for OpenJPEG initialization (prevents multiple init) */
     let openjpegInitPromise = null;
 
+    function resolveOpenJpegAssetUrl(fileName, runtime = window) {
+        const scriptSrc = runtime?.document
+            ?.querySelector('script[src$="js/openjpegwasm_decode.js"], script[src*="openjpegwasm_decode.js"]')
+            ?.src;
+
+        if (scriptSrc) {
+            try {
+                return new URL(fileName, scriptSrc).toString();
+            } catch (e) {
+                console.warn('Failed to resolve OpenJPEG asset from script URL:', scriptSrc, e);
+            }
+        }
+
+        const href = runtime?.location?.href;
+        if (href) {
+            try {
+                return new URL(`js/${fileName}`, href).toString();
+            } catch (e) {
+                console.warn('Failed to resolve OpenJPEG asset from page URL:', href, e);
+            }
+        }
+
+        return `js/${fileName}`;
+    }
+
     /**
      * Initialize the OpenJPEG WebAssembly decoder
      * Lazily loaded on first JPEG 2000 image
@@ -311,7 +352,7 @@
                 // OpenJPEGWASM is loaded from the script tag
                 if (typeof OpenJPEGWASM === 'function') {
                     openjpegModule = await OpenJPEGWASM({
-                        locateFile: (path) => 'js/' + path
+                        locateFile: (path) => resolveOpenJpegAssetUrl(path)
                     });
                     console.log('OpenJPEG WASM initialized successfully');
                     return openjpegModule;
@@ -353,9 +394,7 @@
                 return null;
             }
 
-            // Get the first fragment (single frame)
-            const fragment = fragments[0];
-            const j2kData = new Uint8Array(dataSet.byteArray.buffer, fragment.position, fragment.length);
+            const j2kData = dicomParser.readEncapsulatedImageFrame(dataSet, jp2DataElement, 0);
             console.log('JPEG 2000 data length:', j2kData.length, 'bytes');
 
             // Initialize and use OpenJPEG decoder
@@ -455,6 +494,8 @@
         displayBlankSlice,
         decodeJpegLossless,
         decodeJpeg2000,
-        decodeJpegBaseline
+        decodeJpegBaseline,
+        isRenderableImageMetadata,
+        resolveOpenJpegAssetUrl
     };
 })();

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -27,6 +27,43 @@
         throw new Error('Unsupported DICOM metadata source');
     }
 
+    function getMetadataNumber(dataSet, tag, fallback = 0) {
+        const stringValue = getNumber(dataSet, tag, Number.NaN);
+        if (Number.isFinite(stringValue)) {
+            return stringValue;
+        }
+
+        try {
+            const uint16Value = dataSet.uint16?.(tag);
+            if (Number.isFinite(uint16Value)) {
+                return uint16Value;
+            }
+        } catch {}
+
+        try {
+            const int16Value = dataSet.int16?.(tag);
+            if (Number.isFinite(int16Value)) {
+                return int16Value;
+            }
+        } catch {}
+
+        try {
+            const uint32Value = dataSet.uint32?.(tag);
+            if (Number.isFinite(uint32Value)) {
+                return uint32Value;
+            }
+        } catch {}
+
+        try {
+            const int32Value = dataSet.int32?.(tag);
+            if (Number.isFinite(int32Value)) {
+                return int32Value;
+            }
+        } catch {}
+
+        return fallback;
+    }
+
     /**
      * Parse DICOM file metadata without loading pixel data (fast scan)
      * Used during folder import to organize files by study/series.
@@ -39,8 +76,8 @@
             const byteArray = await toDicomByteArray(input);
             const dataSet = dicomParser.parseDicom(byteArray, { untilTag: 'x7fe00010' });
             const transferSyntax = getString(dataSet, 'x00020010');
-            const rows = getNumber(dataSet, 'x00280010', 0);
-            const cols = getNumber(dataSet, 'x00280011', 0);
+            const rows = getMetadataNumber(dataSet, 'x00280010', 0);
+            const cols = getMetadataNumber(dataSet, 'x00280011', 0);
             const pixelDataElement = dataSet.elements?.x7fe00010;
             return {
                 patientName: getString(dataSet, 'x00100010'),
@@ -51,8 +88,8 @@
                 seriesInstanceUid: getString(dataSet, 'x0020000e'),
                 seriesNumber: getString(dataSet, 'x00200011'),
                 modality: getString(dataSet, 'x00080060'),
-                instanceNumber: getNumber(dataSet, 'x00200013', 0),
-                sliceLocation: getNumber(dataSet, 'x00201041', 0),
+                instanceNumber: getMetadataNumber(dataSet, 'x00200013', 0),
+                sliceLocation: getMetadataNumber(dataSet, 'x00201041', 0),
                 transferSyntax: transferSyntax,
                 sopClassUid: getString(dataSet, 'x00080016'),
                 rows,
@@ -502,6 +539,7 @@
 
     app.dicom = {
         parseDicomMetadata,
+        getMetadataNumber,
         isCompressed,
         isJpegLossless,
         isJpegBaseline,

--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -18,7 +18,7 @@
     } = app.dom;
     const { escapeHtml, formatDate } = app.utils;
     const { getTransferSyntaxInfo } = app.dicom;
-    const { normalizeStudiesPayload, processFilesFromSources } = app.sources;
+    const { normalizeStudiesPayload } = app.sources;
 
     const openPanels = {
         studyPanels: new Set(),
@@ -108,6 +108,23 @@
         }
     }
 
+    function updateDesktopScanMessage(stats, label = 'Scanning library folder...') {
+        if (!stats) {
+            setLibraryFolderMessage(label, 'info');
+            return;
+        }
+
+        if (!stats.discovered) {
+            setLibraryFolderMessage(label, 'info');
+            return;
+        }
+
+        setLibraryFolderMessage(
+            `${label} ${stats.processed}/${stats.discovered} files processed (${stats.valid} viewable DICOM).`,
+            'info'
+        );
+    }
+
     async function loadLibraryConfig() {
         if (config?.deploymentMode === 'desktop') {
             libraryFolderInput.readOnly = true;
@@ -149,8 +166,9 @@
 
                 libraryFolderInput.value = folder;
 
-                const files = await app.desktopLibrary.scanFolder(folder);
-                const studies = await processFilesFromSources(files);
+                const studies = await app.desktopLibrary.loadStudies(folder, {
+                    onProgress: stats => updateDesktopScanMessage(stats)
+                });
                 if (applyDesktopLibraryScan(folder, studies)) {
                     setLibraryFolderMessage('Library folder updated.', 'success');
                 }
@@ -214,8 +232,9 @@
                     throw new Error('Choose a library folder first.');
                 }
 
-                const files = await app.desktopLibrary.scanFolder(payload.folder);
-                const studies = await processFilesFromSources(files);
+                const studies = await app.desktopLibrary.loadStudies(payload.folder, {
+                    onProgress: stats => updateDesktopScanMessage(stats)
+                });
                 applyDesktopLibraryScan(payload.folder, studies);
                 await displayStudies();
                 return;
@@ -640,6 +659,7 @@
         refreshLibrary,
         saveLibraryFolderConfig,
         setLibraryFolderMessage,
-        setLibraryFolderStatus
+        setLibraryFolderStatus,
+        updateDesktopScanMessage
     };
 })();

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -29,7 +29,8 @@
         refreshLibrary,
         saveLibraryFolderConfig,
         setLibraryFolderMessage,
-        setLibraryFolderStatus
+        setLibraryFolderStatus,
+        updateDesktopScanMessage
     } = app.library;
     const {
         closeViewer,
@@ -207,8 +208,9 @@
                 throw new Error('Desktop runtime is not ready yet.');
             }
 
-            const files = await app.desktopLibrary.scanFolder(state.libraryFolder);
-            const studies = await app.sources.processFilesFromSources(files);
+            const studies = await app.desktopLibrary.loadStudies(state.libraryFolder, {
+                onProgress: stats => updateDesktopScanMessage(stats, 'Loading saved library folder...')
+            });
             applyDesktopLibraryScan(state.libraryFolder, studies);
         } catch (e) {
             app.desktopLibrary.markScanFailed(state.libraryFolder);

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -1,4 +1,4 @@
-(() => {
+(async () => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { state } = app;
     const config = window.CONFIG;
@@ -180,12 +180,31 @@
             });
     }
 
+    async function waitForDesktopRuntime() {
+        if (window.__TAURI__) return window.__TAURI__;
+
+        const ready = window.__DICOM_VIEWER_TAURI_READY__;
+        if (ready && typeof ready.then === 'function') {
+            return await ready;
+        }
+
+        return window.__TAURI__ || null;
+    }
+
     async function initializeDesktopLibrary() {
         try {
             await loadLibraryConfig();
             if (!state.libraryFolder) {
                 await displayStudies();
                 return;
+            }
+
+            setLibraryFolderMessage('Loading saved library folder...', 'info');
+            await displayStudies();
+
+            const runtime = await waitForDesktopRuntime();
+            if (!runtime?.fs || !runtime?.path) {
+                throw new Error('Desktop runtime is not ready yet.');
             }
 
             const files = await app.desktopLibrary.scanFolder(state.libraryFolder);
@@ -218,17 +237,23 @@
         });
     }
 
-    studiesTableHead.addEventListener('click', handleSortClick);
-    studiesTableHead.addEventListener('keydown', e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleSortClick(e);
+    async function initializeDesktopRuntimeBridge() {
+        const runtime = await waitForDesktopRuntime();
+        if (!runtime) {
+            console.warn('Desktop runtime APIs unavailable at startup; continuing without native bridge.');
+            return;
         }
-    });
 
-    if (config?.deploymentMode === 'desktop') {
         initializeDesktopMenuBridge();
-        window.__TAURI__.webview.getCurrentWebview().onDragDropEvent(event => {
+
+        const currentWebview = runtime.webview?.getCurrentWebview?.();
+        const registerDragDrop = currentWebview?.onDragDropEvent;
+        if (typeof registerDragDrop !== 'function') {
+            console.warn('Desktop drag-drop API unavailable at startup; continuing without native drag events.');
+            return;
+        }
+
+        await registerDragDrop.call(currentWebview, event => {
             const payload = event.payload;
             if (payload.type === 'enter' || payload.type === 'over') {
                 setDragActive(true);
@@ -240,6 +265,18 @@
         }).catch(err => {
             console.warn('Failed to register Tauri drag-drop handler:', err);
         });
+    }
+
+    studiesTableHead.addEventListener('click', handleSortClick);
+    studiesTableHead.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleSortClick(e);
+        }
+    });
+
+    if (config?.deploymentMode === 'desktop') {
+        initializeDesktopRuntimeBridge();
     } else {
         folderZone.addEventListener('dragover', e => {
             e.preventDefault();

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -18,6 +18,21 @@
         decodeJpegBaseline
     } = app.dicom;
 
+    function getUncompressedFramePixelData(dataSet, pixelDataElement, rows, cols, bitsAllocated, pixelRepresentation, frameIndex = 0) {
+        const samplesPerPixel = dataSet.uint16('x00280002') || 1;
+        const framePixelCount = rows * cols * samplesPerPixel;
+        const bytesPerSample = bitsAllocated > 8 ? 2 : 1;
+        const frameOffset = pixelDataElement.dataOffset + (frameIndex * framePixelCount * bytesPerSample);
+
+        if (bitsAllocated === 16) {
+            return pixelRepresentation === 1
+                ? new Int16Array(dataSet.byteArray.buffer, frameOffset, framePixelCount)
+                : new Uint16Array(dataSet.byteArray.buffer, frameOffset, framePixelCount);
+        }
+
+        return new Uint8Array(dataSet.byteArray.buffer, frameOffset, framePixelCount);
+    }
+
     // =====================================================================
     // RENDERING
     // Converts decoded pixel data to visible image on canvas
@@ -62,7 +77,7 @@
      * @param {Object|null} wlOverride - Optional {center, width} to override DICOM values
      * @returns {Promise<Object>} Rendering info {rows, cols, wc, ww, transferSyntax} or {error: true}
      */
-    async function renderDicom(dataSet, wlOverride = null) {
+    async function renderDicom(dataSet, wlOverride = null, frameIndex = 0) {
         // Extract image dimensions and pixel format from DICOM tags
         const rows = dataSet.uint16('x00280010');              // (0028,0010) Rows
         const cols = dataSet.uint16('x00280011');              // (0028,0011) Columns
@@ -130,19 +145,27 @@
         if (isCompressedData) {
             // Decode compressed pixel data using appropriate decoder
             if (isJpeg2000(transferSyntax)) {
-                pixelData = await decodeJpeg2000(dataSet, pixelDataElement, rows, cols, bitsAllocated, pixelRepresentation);
+                pixelData = await decodeJpeg2000(
+                    dataSet,
+                    pixelDataElement,
+                    rows,
+                    cols,
+                    bitsAllocated,
+                    pixelRepresentation,
+                    frameIndex
+                );
                 if (!pixelData) {
                     displayError('JPEG 2000 decode failed', transferSyntaxInfo.name);
                     return { error: true, transferSyntax, tsInfo: transferSyntaxInfo };
                 }
             } else if (isJpegLossless(transferSyntax)) {
-                pixelData = decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated);
+                pixelData = decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated, frameIndex);
                 if (!pixelData) {
                     displayError('JPEG Lossless decode failed', transferSyntaxInfo.name);
                     return { error: true, transferSyntax, tsInfo: transferSyntaxInfo };
                 }
             } else if (isJpegBaseline(transferSyntax)) {
-                const result = await decodeJpegBaseline(dataSet, pixelDataElement, rows, cols);
+                const result = await decodeJpegBaseline(dataSet, pixelDataElement, rows, cols, frameIndex);
                 if (!result) {
                     displayError('JPEG decode failed', transferSyntaxInfo.name);
                     return { error: true, transferSyntax, tsInfo: transferSyntaxInfo };
@@ -156,13 +179,15 @@
             }
         } else {
             // Uncompressed pixel data - create typed array view directly on buffer
-            if (bitsAllocated === 16) {
-                pixelData = pixelRepresentation === 1
-                    ? new Int16Array(dataSet.byteArray.buffer, pixelDataElement.dataOffset, pixelDataElement.length / 2)
-                    : new Uint16Array(dataSet.byteArray.buffer, pixelDataElement.dataOffset, pixelDataElement.length / 2);
-            } else {
-                pixelData = new Uint8Array(dataSet.byteArray.buffer, pixelDataElement.dataOffset, pixelDataElement.length);
-            }
+            pixelData = getUncompressedFramePixelData(
+                dataSet,
+                pixelDataElement,
+                rows,
+                cols,
+                bitsAllocated,
+                pixelRepresentation,
+                frameIndex
+            );
         }
 
         // Check for blank/uniform slices (common in MPR reconstructions as padding)

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -58,24 +58,50 @@
                 comments: []
             };
         }
-        studies[studyUid].series[seriesUid].slices.push({
+        studies[studyUid].series[seriesUid].slices.push(...expandFrameSlices(meta, source));
+    }
+
+    function expandFrameSlices(meta, source) {
+        const frameCount = Math.max(1, meta?.numberOfFrames || 1);
+        return Array.from({ length: frameCount }, (_, frameIndex) => ({
             source,
+            frameIndex,
             instanceNumber: meta.instanceNumber,
             sliceLocation: meta.sliceLocation
-        });
+        }));
     }
 
     function finalizeStudies(studies) {
         for (const study of Object.values(studies)) {
             let count = 0;
             for (const series of Object.values(study.series)) {
-                series.slices.sort((a, b) => a.instanceNumber - b.instanceNumber || a.sliceLocation - b.sliceLocation);
+                series.slices.sort((a, b) =>
+                    (a.instanceNumber ?? 0) - (b.instanceNumber ?? 0) ||
+                    (a.sliceLocation ?? 0) - (b.sliceLocation ?? 0) ||
+                    (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
+                );
                 count += series.slices.length;
             }
             study.seriesCount = Object.keys(study.series).length;
             study.imageCount = count;
         }
         return studies;
+    }
+
+    function getSliceCacheKey(slice, fallbackKey = null) {
+        const source = slice?.source;
+        switch (source?.kind) {
+            case 'path':
+                return `path:${source.path}`;
+            case 'api':
+                return `api:${source.apiBase}|${source.studyId}|${source.seriesId}|${source.sliceIndex}`;
+            case 'blob':
+                return source.blob || fallbackKey;
+            case 'handle':
+                return source.handle || fallbackKey;
+            default:
+                return fallbackKey ?? source ?? null;
+        }
     }
 
     async function joinPath(parent, child) {
@@ -613,50 +639,10 @@
 
                 if (!isRenderableImageMetadata(meta)) continue;
 
-                const studyUid = meta.studyInstanceUid;
-                const seriesUid = meta.seriesInstanceUid;
-
-                if (!studies[studyUid]) {
-                    studies[studyUid] = {
-                        ...meta,
-                        series: {},
-                        comments: []
-                    };
-                }
-
-                if (!studies[studyUid].series[seriesUid]) {
-                    studies[studyUid].series[seriesUid] = {
-                        seriesInstanceUid: seriesUid,
-                        seriesNumber: meta.seriesNumber,
-                        seriesDescription: meta.seriesDescription,
-                        modality: meta.modality,
-                        transferSyntax: meta.transferSyntax,
-                        slices: [],
-                        comments: []
-                    };
-                }
-
-                studies[studyUid].series[seriesUid].slices.push({
-                    instanceNumber: meta.instanceNumber,
-                    sliceLocation: meta.sliceLocation,
-                    source: { kind: 'blob', blob }
-                });
+                addSliceToStudies(studies, meta, { kind: 'blob', blob });
             }
 
-            for (const study of Object.values(studies)) {
-                let imageCount = 0;
-                for (const series of Object.values(study.series)) {
-                    series.slices.sort((a, b) =>
-                        (a.sliceLocation ?? a.instanceNumber ?? 0) -
-                        (b.sliceLocation ?? b.instanceNumber ?? 0)
-                    );
-                    imageCount += series.slices.length;
-                }
-                study.seriesCount = Object.keys(study.series).length;
-                study.imageCount = imageCount;
-            }
-
-            return studies;
+            return finalizeStudies(studies);
         } finally {
             hideProgressOverlay();
             button.textContent = buttonLabel;
@@ -676,6 +662,8 @@
         processFilesFromSources,
         readSliceBuffer,
         normalizeStudiesPayload,
-        loadStudiesFromApi
+        loadStudiesFromApi,
+        expandFrameSlices,
+        getSliceCacheKey
     };
 })();

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -4,8 +4,8 @@
     const { parseDicomMetadata, isRenderableImageMetadata } = app.dicom;
     const DESKTOP_MAX_SCAN_DEPTH = 20;
     const DEFAULT_SCAN_CONCURRENCY = 100;
-    const DESKTOP_PATH_SCAN_CONCURRENCY = 16;
-    const DESKTOP_PATH_BATCH_SIZE = 128;
+    const DESKTOP_PATH_SCAN_CONCURRENCY = 4;
+    const DESKTOP_PATH_BATCH_SIZE = 32;
     const DESKTOP_PATH_READ_ATTEMPTS = 3;
     const DESKTOP_PATH_READ_RETRY_DELAY_MS = 50;
     const SCAN_PROGRESS_UPDATE_INTERVAL = 200;
@@ -266,7 +266,7 @@
                         }
                     }
                 );
-                return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+                return bytes;
             }
             default:
                 throw new Error(`Unknown source kind: ${source?.kind}`);

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -3,6 +3,10 @@
     const { uploadProgress, progressFill, progressText, progressDetail } = app.dom;
     const { parseDicomMetadata, isRenderableImageMetadata } = app.dicom;
     const DESKTOP_MAX_SCAN_DEPTH = 20;
+    const DEFAULT_SCAN_CONCURRENCY = 100;
+    const DESKTOP_PATH_SCAN_CONCURRENCY = 16;
+    const DESKTOP_PATH_READ_ATTEMPTS = 3;
+    const DESKTOP_PATH_READ_RETRY_DELAY_MS = 50;
 
     function updateScanProgress(processed, total, valid) {
         if (processed % 200 !== 0 && processed !== total) return;
@@ -83,6 +87,44 @@
         return path.split(/[\\/]/).pop() || path;
     }
 
+    function wait(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function getScanConcurrency(files) {
+        return files.some(({ source }) => source?.kind === 'path')
+            ? DESKTOP_PATH_SCAN_CONCURRENCY
+            : DEFAULT_SCAN_CONCURRENCY;
+    }
+
+    async function withRetries(task, options = {}) {
+        const {
+            attempts = 1,
+            retryDelayMs = 0,
+            onRetry = null
+        } = options;
+
+        let lastError = null;
+        for (let attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                return await task();
+            } catch (error) {
+                lastError = error;
+                if (attempt >= attempts) break;
+
+                if (typeof onRetry === 'function') {
+                    onRetry(error, attempt + 1);
+                }
+
+                if (retryDelayMs > 0) {
+                    await wait(retryDelayMs * attempt);
+                }
+            }
+        }
+
+        throw lastError;
+    }
+
     async function getAllFileHandles(dirHandle) {
         const files = [];
         for await (const [name, handle] of dirHandle.entries()) {
@@ -109,9 +151,9 @@
         let processed = 0;
         let valid = 0;
 
-        const batchSize = 100;
-        for (let i = 0; i < files.length; i += batchSize) {
-            const batch = files.slice(i, i + batchSize);
+        const concurrency = getScanConcurrency(files);
+        for (let i = 0; i < files.length; i += concurrency) {
+            const batch = files.slice(i, i + concurrency);
             await Promise.all(batch.map(async ({ name, source }) => {
                 try {
                     const buffer = await readSliceBuffer({ source }, 'scan');
@@ -147,7 +189,19 @@
                 return resp.arrayBuffer();
             }
             case 'path': {
-                const bytes = await window.__TAURI__.fs.readFile(source.path);
+                const bytes = await withRetries(
+                    () => window.__TAURI__.fs.readFile(source.path),
+                    {
+                        attempts: DESKTOP_PATH_READ_ATTEMPTS,
+                        retryDelayMs: DESKTOP_PATH_READ_RETRY_DELAY_MS,
+                        onRetry: (error, nextAttempt) => {
+                            console.warn(
+                                `Retrying desktop file read (${nextAttempt}/${DESKTOP_PATH_READ_ATTEMPTS}) for ${source.path}:`,
+                                error
+                            );
+                        }
+                    }
+                );
                 return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
             }
             default:

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -1,7 +1,7 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { uploadProgress, progressFill, progressText, progressDetail } = app.dom;
-    const { parseDicomMetadata } = app.dicom;
+    const { parseDicomMetadata, isRenderableImageMetadata } = app.dicom;
     const DESKTOP_MAX_SCAN_DEPTH = 20;
 
     function updateScanProgress(processed, total, valid) {
@@ -10,7 +10,7 @@
         const pct = Math.round((processed / total) * 100);
         progressFill.style.width = pct + '%';
         progressText.textContent = `Scanning... ${pct}%`;
-        progressDetail.textContent = `${processed}/${total} files (${valid} DICOM)`;
+        progressDetail.textContent = `${processed}/${total} files (${valid} viewable DICOM)`;
     }
 
     function addSliceToStudies(studies, meta, source) {
@@ -116,7 +116,7 @@
                 try {
                     const buffer = await readSliceBuffer({ source }, 'scan');
                     const meta = await parseDicomMetadata(new Blob([buffer], { type: 'application/dicom' }));
-                    if (!meta?.studyInstanceUid) return;
+                    if (!isRenderableImageMetadata(meta)) return;
                     valid++;
                     addSliceToStudies(studies, meta, source);
                 } catch (e) {
@@ -395,7 +395,7 @@
                 progressFill.style.width = `${pct}%`;
                 progressDetail.textContent = `Processing ${processed}/${files.length}`;
 
-                if (!meta?.studyInstanceUid) continue;
+                if (!isRenderableImageMetadata(meta)) continue;
 
                 const studyUid = meta.studyInstanceUid;
                 const seriesUid = meta.seriesInstanceUid;
@@ -451,6 +451,7 @@
     app.sources = {
         collectPathSources,
         getAllFileHandles,
+        isRenderableImageMetadata,
         loadDroppedStudies,
         loadDroppedPaths,
         loadSampleStudies,

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -157,7 +157,7 @@
             await Promise.all(batch.map(async ({ name, source }) => {
                 try {
                     const buffer = await readSliceBuffer({ source }, 'scan');
-                    const meta = await parseDicomMetadata(new Blob([buffer], { type: 'application/dicom' }));
+                    const meta = await parseDicomMetadata(buffer);
                     if (!isRenderableImageMetadata(meta)) return;
                     valid++;
                     addSliceToStudies(studies, meta, source);

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -5,16 +5,33 @@
     const DESKTOP_MAX_SCAN_DEPTH = 20;
     const DEFAULT_SCAN_CONCURRENCY = 100;
     const DESKTOP_PATH_SCAN_CONCURRENCY = 16;
+    const DESKTOP_PATH_BATCH_SIZE = 128;
     const DESKTOP_PATH_READ_ATTEMPTS = 3;
     const DESKTOP_PATH_READ_RETRY_DELAY_MS = 50;
+    const SCAN_PROGRESS_UPDATE_INTERVAL = 200;
 
     function updateScanProgress(processed, total, valid) {
-        if (processed % 200 !== 0 && processed !== total) return;
+        if (processed % SCAN_PROGRESS_UPDATE_INTERVAL !== 0 && processed !== total) return;
 
         const pct = Math.round((processed / total) * 100);
+        progressFill.style.animation = 'none';
         progressFill.style.width = pct + '%';
         progressText.textContent = `Scanning... ${pct}%`;
         progressDetail.textContent = `${processed}/${total} files (${valid} viewable DICOM)`;
+    }
+
+    function showIndeterminateProgress(text, detail = '') {
+        uploadProgress.style.display = 'flex';
+        progressFill.style.width = '100%';
+        progressFill.style.animation = 'progress-pulse 1.5s ease-in-out infinite';
+        progressText.textContent = text;
+        progressDetail.textContent = detail;
+    }
+
+    function hideProgressOverlay() {
+        uploadProgress.style.display = 'none';
+        progressFill.style.width = '0%';
+        progressFill.style.animation = 'none';
     }
 
     function addSliceToStudies(studies, meta, source) {
@@ -125,6 +142,31 @@
         throw lastError;
     }
 
+    function safeEmitDesktopPathProgress(onProgress, stats, options = {}) {
+        if (typeof onProgress !== 'function') return;
+
+        const { force = false, currentPath = '', complete = false } = options;
+        const shouldEmit = force ||
+            stats.discovered === 0 ||
+            stats.discovered % SCAN_PROGRESS_UPDATE_INTERVAL === 0 ||
+            stats.processed % SCAN_PROGRESS_UPDATE_INTERVAL === 0 ||
+            stats.processed === stats.discovered;
+
+        if (!shouldEmit) return;
+
+        try {
+            onProgress({
+                discovered: stats.discovered,
+                processed: stats.processed,
+                valid: stats.valid,
+                currentPath,
+                complete
+            });
+        } catch (error) {
+            console.warn('Desktop path scan progress callback failed:', error);
+        }
+    }
+
     async function getAllFileHandles(dirHandle) {
         const files = [];
         for await (const [name, handle] of dirHandle.entries()) {
@@ -171,6 +213,28 @@
         }
 
         return finalizeStudies(studies);
+    }
+
+    async function processDesktopPathFileBatch(files, studies, stats, onProgress) {
+        for (let i = 0; i < files.length; i += DESKTOP_PATH_SCAN_CONCURRENCY) {
+            const batch = files.slice(i, i + DESKTOP_PATH_SCAN_CONCURRENCY);
+            await Promise.all(batch.map(async ({ name, source }) => {
+                try {
+                    const buffer = await readSliceBuffer({ source }, 'scan');
+                    const meta = await parseDicomMetadata(buffer);
+                    if (!isRenderableImageMetadata(meta)) return;
+                    stats.valid++;
+                    addSliceToStudies(studies, meta, source);
+                } catch (e) {
+                    console.warn(`Skipping unreadable DICOM file during scan: ${name}`, e);
+                } finally {
+                    stats.processed++;
+                    safeEmitDesktopPathProgress(onProgress, stats, { currentPath: source?.path || '' });
+                }
+            }));
+
+            await wait(0);
+        }
     }
 
     async function readSliceBuffer(slice, purpose = 'load') {
@@ -384,27 +448,125 @@
         return files;
     }
 
+    async function loadStudiesFromDesktopPaths(paths, options = {}) {
+        const fs = window.__TAURI__?.fs;
+        if (!fs?.readDir) {
+            throw new Error('Desktop file APIs unavailable');
+        }
+
+        const {
+            maxDepth = DESKTOP_MAX_SCAN_DEPTH,
+            onProgress = null
+        } = options;
+
+        const studies = {};
+        const pendingFiles = [];
+        const stats = { discovered: 0, processed: 0, valid: 0 };
+        const visited = new Set();
+        const stack = (Array.isArray(paths) ? paths : [paths])
+            .filter(Boolean)
+            .map(path => ({ path, depth: 0 }))
+            .reverse();
+
+        async function flushPendingFiles(force = false) {
+            while (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE || (force && pendingFiles.length > 0)) {
+                const batchSize = force ? pendingFiles.length : DESKTOP_PATH_BATCH_SIZE;
+                const batch = pendingFiles.splice(0, batchSize);
+                await processDesktopPathFileBatch(batch, studies, stats, onProgress);
+            }
+        }
+
+        safeEmitDesktopPathProgress(onProgress, stats, { force: true, complete: false });
+
+        while (stack.length) {
+            const current = stack.pop();
+            const normalizedPath = await normalizePath(current.path);
+
+            if (visited.has(normalizedPath)) {
+                console.warn('Skipping already-visited desktop scan path:', normalizedPath);
+                continue;
+            }
+            visited.add(normalizedPath);
+
+            let entries;
+            try {
+                entries = await fs.readDir(normalizedPath);
+            } catch (readError) {
+                const fileEntries = await resolveDesktopPathSource(fs, normalizedPath, readError);
+                for (const fileEntry of fileEntries) {
+                    pendingFiles.push(fileEntry);
+                    stats.discovered++;
+                    safeEmitDesktopPathProgress(onProgress, stats, { currentPath: fileEntry.source?.path || normalizedPath });
+                    if (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE) {
+                        await flushPendingFiles();
+                    }
+                }
+                continue;
+            }
+
+            for (const entry of entries) {
+                const entryPath = await joinPath(normalizedPath, entry.name);
+                if (entry.isSymlink) {
+                    console.warn('Skipping symlink during desktop scan:', entryPath);
+                    continue;
+                }
+
+                if (entry.isDirectory) {
+                    if (current.depth >= maxDepth) {
+                        console.warn('Skipping path beyond desktop scan depth limit:', entryPath);
+                        continue;
+                    }
+                    stack.push({
+                        path: entryPath,
+                        depth: current.depth + 1
+                    });
+                    continue;
+                }
+
+                if (!entry.isFile) continue;
+
+                pendingFiles.push({
+                    name: entry.name,
+                    source: { kind: 'path', path: entryPath }
+                });
+                stats.discovered++;
+                safeEmitDesktopPathProgress(onProgress, stats, { currentPath: entryPath });
+
+                if (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE) {
+                    await flushPendingFiles();
+                }
+            }
+
+            await wait(0);
+        }
+
+        await flushPendingFiles(true);
+        safeEmitDesktopPathProgress(onProgress, stats, { force: true, complete: true });
+        return finalizeStudies(studies);
+    }
+
     async function loadDroppedPaths(paths) {
-        uploadProgress.style.display = 'flex';
-        progressText.textContent = 'Reading folder...';
-        progressDetail.textContent = '';
-        progressFill.style.width = '0%';
+        let lastProgress = { discovered: 0, processed: 0, valid: 0 };
 
         try {
-            progressText.textContent = 'Finding files...';
-            const files = [];
-            for (const path of paths) {
-                files.push(...await collectPathSources(path));
-            }
-            progressDetail.textContent = `Found ${files.length} files`;
+            showIndeterminateProgress('Scanning desktop folder...', '0 files processed (0 viewable DICOM)');
+            const studies = await loadStudiesFromDesktopPaths(paths, {
+                onProgress: (stats) => {
+                    lastProgress = stats;
+                    showIndeterminateProgress(
+                        'Scanning desktop folder...',
+                        `${stats.processed}/${stats.discovered} files processed (${stats.valid} viewable DICOM)`
+                    );
+                }
+            });
 
-            if (!files.length) {
+            if (!lastProgress.discovered) {
                 throw new Error('No files found');
             }
 
-            return await processFilesFromSources(files);
+            return studies;
         } finally {
-            uploadProgress.style.display = 'none';
+            hideProgressOverlay();
         }
     }
 
@@ -496,7 +658,7 @@
 
             return studies;
         } finally {
-            uploadProgress.style.display = 'none';
+            hideProgressOverlay();
             button.textContent = buttonLabel;
             button.disabled = false;
         }
@@ -508,6 +670,7 @@
         isRenderableImageMetadata,
         loadDroppedStudies,
         loadDroppedPaths,
+        loadStudiesFromDesktopPaths,
         loadSampleStudies,
         processFiles,
         processFilesFromSources,

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -55,10 +55,21 @@
                 seriesNumber: meta.seriesNumber,
                 transferSyntax: meta.transferSyntax,
                 slices: [],
-                comments: []
+                comments: [],
+                seenSliceKeys: new Set()
             };
         }
-        studies[studyUid].series[seriesUid].slices.push(...expandFrameSlices(meta, source));
+        const series = studies[studyUid].series[seriesUid];
+        for (const slice of expandFrameSlices(meta, source)) {
+            const sliceKey = getSliceDedupKey(slice);
+            if (sliceKey && series.seenSliceKeys.has(sliceKey)) {
+                continue;
+            }
+            if (sliceKey) {
+                series.seenSliceKeys.add(sliceKey);
+            }
+            series.slices.push(slice);
+        }
     }
 
     function expandFrameSlices(meta, source) {
@@ -66,9 +77,17 @@
         return Array.from({ length: frameCount }, (_, frameIndex) => ({
             source,
             frameIndex,
+            sopInstanceUid: meta.sopInstanceUid || '',
             instanceNumber: meta.instanceNumber,
             sliceLocation: meta.sliceLocation
         }));
+    }
+
+    function getSliceDedupKey(slice) {
+        if (!slice?.sopInstanceUid) {
+            return null;
+        }
+        return `${slice.sopInstanceUid}|${slice.frameIndex || 0}`;
     }
 
     function finalizeStudies(studies) {
@@ -81,6 +100,7 @@
                     (a.frameIndex ?? 0) - (b.frameIndex ?? 0)
                 );
                 count += series.slices.length;
+                delete series.seenSliceKeys;
             }
             study.seriesCount = Object.keys(study.series).length;
             study.imageCount = count;
@@ -664,6 +684,7 @@
         normalizeStudiesPayload,
         loadStudiesFromApi,
         expandFrameSlices,
+        getSliceDedupKey,
         getSliceCacheKey
     };
 })();

--- a/docs/js/app/state.js
+++ b/docs/js/app/state.js
@@ -41,7 +41,7 @@
         }
     }
 
-    const SLICE_CACHE_MAX_ENTRIES = 100;
+    const SLICE_CACHE_MAX_ENTRIES = window.CONFIG?.deploymentMode === 'desktop' ? 24 : 100;
 
     /**
      * Global application state

--- a/docs/js/app/tools.js
+++ b/docs/js/app/tools.js
@@ -321,13 +321,17 @@
 
     async function reRenderCurrentSlice() {
         if (!state.currentSeries) return;
-        const dataSet = state.sliceCache.get(state.currentSliceIndex);
+        const slice = state.currentSeries.slices[state.currentSliceIndex];
+        if (!slice) return;
+
+        const cacheKey = app.sources?.getSliceCacheKey?.(slice, state.currentSliceIndex);
+        const dataSet = state.sliceCache.get(cacheKey);
         if (!dataSet) return;
 
         const wlOverride = (state.windowLevel.center !== null && state.windowLevel.width !== null)
             ? state.windowLevel
             : null;
-        await app.rendering.renderDicom(dataSet, wlOverride);
+        await app.rendering.renderDicom(dataSet, wlOverride, slice.frameIndex || 0);
     }
 
     function handleWLDrag(dx, dy) {

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -1,6 +1,7 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { state } = app;
+    const config = window.CONFIG;
     const {
         libraryView,
         viewerView,
@@ -15,6 +16,7 @@
         nextBtn
     } = app.dom;
     const { escapeHtml } = app.utils;
+    const { toDicomByteArray } = app.dicom;
     const { renderDicom } = app.rendering;
     const { readSliceBuffer } = app.sources;
     const {
@@ -22,6 +24,8 @@
         resetViewForNewSeries,
         updateWLDisplay
     } = app.tools;
+
+    const VIEWER_PRELOAD_RADIUS = config?.deploymentMode === 'desktop' ? 1 : 3;
 
     async function loadSlice(index) {
         if (!state.currentSeries) return;
@@ -38,7 +42,7 @@
 
             if (!dataSet) {
                 const buf = await readSliceBuffer(slice, 'load');
-                dataSet = dicomParser.parseDicom(new Uint8Array(buf));
+                dataSet = dicomParser.parseDicom(await toDicomByteArray(buf));
                 state.sliceCache.set(index, dataSet);
             }
 
@@ -98,11 +102,13 @@
                 `;
             }
 
-            for (let i = index - 3; i <= index + 3; i++) {
+            for (let i = index - VIEWER_PRELOAD_RADIUS; i <= index + VIEWER_PRELOAD_RADIUS; i++) {
                 if (i >= 0 && i < slices.length && !state.sliceCache.has(i)) {
                     const preloadSlice = slices[i];
                     readSliceBuffer(preloadSlice, 'preload').then(buf => {
-                        state.sliceCache.set(i, dicomParser.parseDicom(new Uint8Array(buf)));
+                        toDicomByteArray(buf).then(byteArray => {
+                            state.sliceCache.set(i, dicomParser.parseDicom(byteArray));
+                        }).catch(() => {});
                     }).catch(() => {});
                 }
             }

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -18,7 +18,7 @@
     const { escapeHtml } = app.utils;
     const { toDicomByteArray } = app.dicom;
     const { renderDicom } = app.rendering;
-    const { readSliceBuffer } = app.sources;
+    const { readSliceBuffer, getSliceCacheKey } = app.sources;
     const {
         drawMeasurements,
         resetViewForNewSeries,
@@ -38,18 +38,19 @@
 
         try {
             const slice = slices[index];
-            let dataSet = state.sliceCache.get(index);
+            const cacheKey = getSliceCacheKey(slice, index);
+            let dataSet = state.sliceCache.get(cacheKey);
 
             if (!dataSet) {
                 const buf = await readSliceBuffer(slice, 'load');
                 dataSet = dicomParser.parseDicom(await toDicomByteArray(buf));
-                state.sliceCache.set(index, dataSet);
+                state.sliceCache.set(cacheKey, dataSet);
             }
 
             const wlOverride = (state.windowLevel.center !== null && state.windowLevel.width !== null)
                 ? state.windowLevel
                 : null;
-            const info = await renderDicom(dataSet, wlOverride);
+            const info = await renderDicom(dataSet, wlOverride, slice.frameIndex || 0);
 
             updateWLDisplay();
 
@@ -103,11 +104,13 @@
             }
 
             for (let i = index - VIEWER_PRELOAD_RADIUS; i <= index + VIEWER_PRELOAD_RADIUS; i++) {
-                if (i >= 0 && i < slices.length && !state.sliceCache.has(i)) {
+                if (i >= 0 && i < slices.length) {
                     const preloadSlice = slices[i];
+                    const preloadCacheKey = getSliceCacheKey(preloadSlice, i);
+                    if (state.sliceCache.has(preloadCacheKey)) continue;
                     readSliceBuffer(preloadSlice, 'preload').then(buf => {
                         toDicomByteArray(buf).then(byteArray => {
-                            state.sliceCache.set(i, dicomParser.parseDicom(byteArray));
+                            state.sliceCache.set(preloadCacheKey, dicomParser.parseDicom(byteArray));
                         }).catch(() => {});
                     }).catch(() => {});
                 }

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -17,15 +17,29 @@
 
 const CONFIG = {
     /**
-     * Detect deployment mode based on hostname
+     * Detect deployment mode from a window-like runtime object.
+     * Accepts an override to keep the logic testable without mutating `window.location`.
+     * @param {Window|Object} runtime
      * @returns {'demo' | 'preview' | 'cloud' | 'desktop' | 'personal'}
      */
-    get deploymentMode() {
-        if (typeof window.__TAURI__ !== 'undefined') {
+    detectDeploymentMode(runtime = window) {
+        const location = runtime?.location || {};
+        const protocol = location.protocol || '';
+        const hostname = location.hostname || '';
+
+        if (typeof runtime?.__TAURI__ !== 'undefined') {
             return 'desktop';
         }
 
-        const hostname = window.location.hostname;
+        // Packaged Tauri apps load local assets from a Tauri localhost origin
+        // even before the convenience globals are available to page scripts.
+        if (protocol === 'tauri:' || hostname === 'tauri.localhost') {
+            return 'desktop';
+        }
+
+        if (runtime?.__TAURI_INTERNALS__?.metadata?.currentWindow) {
+            return 'desktop';
+        }
 
         // GitHub Pages - public demo
         if (hostname.endsWith('github.io')) {
@@ -44,6 +58,14 @@ const CONFIG = {
 
         // Local development or self-hosted
         return 'personal';
+    },
+
+    /**
+     * Detect deployment mode based on hostname
+     * @returns {'demo' | 'preview' | 'cloud' | 'desktop' | 'personal'}
+     */
+    get deploymentMode() {
+        return this.detectDeploymentMode(window);
     },
 
     /**

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -1,0 +1,231 @@
+(() => {
+    if (typeof window === 'undefined') return;
+
+    const APP_DATA_DIRECTORY = 14;
+    const DRAG_EVENTS = {
+        enter: 'tauri://drag-enter',
+        over: 'tauri://drag-over',
+        drop: 'tauri://drag-drop',
+        leave: 'tauri://drag-leave'
+    };
+    const MAX_ATTEMPTS = 200;
+    const RETRY_DELAY_MS = 25;
+
+    function getInternals() {
+        const internals = window.__TAURI_INTERNALS__;
+        return internals?.invoke ? internals : null;
+    }
+
+    function installCompatFromInternals(internals) {
+        if (window.__TAURI__ || !internals?.invoke) {
+            return window.__TAURI__ || null;
+        }
+
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = window.__TAURI_EVENT_PLUGIN_INTERNALS__ || {};
+
+        function invoke(cmd, args, options) {
+            return internals.invoke(cmd, args, options);
+        }
+
+        function transformCallback(callback, once = false) {
+            return internals.transformCallback(callback, once);
+        }
+
+        function unregisterListener(event, eventId) {
+            if (window.__TAURI_EVENT_PLUGIN_INTERNALS__?.unregisterListener) {
+                window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener(event, eventId);
+                return;
+            }
+            if (typeof internals.unregisterCallback === 'function') {
+                internals.unregisterCallback(eventId);
+            }
+        }
+
+        async function listen(event, handler, options = {}) {
+            const target = typeof options.target === 'string'
+                ? { kind: 'AnyLabel', label: options.target }
+                : (options.target || { kind: 'Any' });
+
+            const eventId = await invoke('plugin:event|listen', {
+                event,
+                target,
+                handler: transformCallback(handler)
+            });
+
+            return async () => {
+                unregisterListener(event, eventId);
+                await invoke('plugin:event|unlisten', { event, eventId });
+            };
+        }
+
+        function getCurrentWebviewLabel() {
+            return internals.metadata?.currentWebview?.label
+                || internals.metadata?.currentWindow?.label
+                || 'main';
+        }
+
+        function createCurrentWebview() {
+            const label = getCurrentWebviewLabel();
+            return {
+                async onDragDropEvent(handler) {
+                    const target = { kind: 'Webview', label };
+                    const unlistenEnter = await listen(DRAG_EVENTS.enter, (event) => {
+                        handler({
+                            ...event,
+                            payload: {
+                                type: 'enter',
+                                paths: event.payload?.paths,
+                                position: event.payload?.position
+                            }
+                        });
+                    }, { target });
+                    const unlistenOver = await listen(DRAG_EVENTS.over, (event) => {
+                        handler({
+                            ...event,
+                            payload: {
+                                type: 'over',
+                                position: event.payload?.position
+                            }
+                        });
+                    }, { target });
+                    const unlistenDrop = await listen(DRAG_EVENTS.drop, (event) => {
+                        handler({
+                            ...event,
+                            payload: {
+                                type: 'drop',
+                                paths: event.payload?.paths,
+                                position: event.payload?.position
+                            }
+                        });
+                    }, { target });
+                    const unlistenLeave = await listen(DRAG_EVENTS.leave, (event) => {
+                        handler({
+                            ...event,
+                            payload: { type: 'leave' }
+                        });
+                    }, { target });
+
+                    return async () => {
+                        await Promise.all([
+                            unlistenEnter(),
+                            unlistenOver(),
+                            unlistenDrop(),
+                            unlistenLeave()
+                        ]);
+                    };
+                }
+            };
+        }
+
+        async function readFile(path, options) {
+            const bytes = await invoke('plugin:fs|read_file', { path, options });
+            return bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : Uint8Array.from(bytes);
+        }
+
+        async function stat(path, options) {
+            const info = await invoke('plugin:fs|stat', { path, options });
+            return {
+                ...info,
+                mtime: info?.mtime !== null && info?.mtime !== undefined ? new Date(info.mtime) : null,
+                atime: info?.atime !== null && info?.atime !== undefined ? new Date(info.atime) : null,
+                birthtime: info?.birthtime !== null && info?.birthtime !== undefined ? new Date(info.birthtime) : null
+            };
+        }
+
+        async function writeFile(path, data, options) {
+            await invoke('plugin:fs|write_file', data, {
+                headers: {
+                    path: encodeURIComponent(path),
+                    options: JSON.stringify(options)
+                }
+            });
+        }
+
+        window.__TAURI__ = {
+            core: {
+                convertFileSrc(filePath, protocol) {
+                    return internals.convertFileSrc(filePath, protocol);
+                }
+            },
+            dialog: {
+                async open(options = {}) {
+                    if (typeof options === 'object') {
+                        Object.freeze(options);
+                    }
+                    return invoke('plugin:dialog|open', { options });
+                }
+            },
+            event: {
+                listen
+            },
+            fs: {
+                async exists(path, options) {
+                    return invoke('plugin:fs|exists', { path, options });
+                },
+                async mkdir(path, options) {
+                    return invoke('plugin:fs|mkdir', { path, options });
+                },
+                async readDir(path, options) {
+                    return invoke('plugin:fs|read_dir', { path, options });
+                },
+                readFile,
+                async remove(path, options) {
+                    return invoke('plugin:fs|remove', { path, options });
+                },
+                stat,
+                writeFile
+            },
+            path: {
+                async appDataDir() {
+                    return invoke('plugin:path|resolve_directory', {
+                        directory: APP_DATA_DIRECTORY
+                    });
+                },
+                async join(...paths) {
+                    return invoke('plugin:path|join', { paths });
+                },
+                async normalize(path) {
+                    return invoke('plugin:path|normalize', { path });
+                }
+            },
+            webview: {
+                getCurrentWebview: createCurrentWebview
+            }
+        };
+
+        return window.__TAURI__;
+    }
+
+    function resolveDesktopRuntime() {
+        if (window.__TAURI__) return window.__TAURI__;
+        return installCompatFromInternals(getInternals());
+    }
+
+    window.__DICOM_VIEWER_TAURI_READY__ = window.__DICOM_VIEWER_TAURI_READY__ || new Promise(resolve => {
+        let attempts = 0;
+
+        function finish(runtime) {
+            resolve(runtime || null);
+        }
+
+        function tick() {
+            const runtime = resolveDesktopRuntime();
+            if (runtime) {
+                finish(runtime);
+                return;
+            }
+
+            if (attempts >= MAX_ATTEMPTS) {
+                finish(null);
+                return;
+            }
+
+            attempts += 1;
+            setTimeout(tick, RETRY_DELAY_MS);
+        }
+
+        tick();
+    });
+
+    resolveDesktopRuntime();
+})();

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -146,6 +146,64 @@ async function installMockDesktop(page, options = {}) {
 }
 
 test.describe('Desktop library scanning', () => {
+    test('desktop path study scan starts processing before the full tree is materialized', async ({ page }) => {
+        const rootEntries = [];
+        const nestedEntries = [];
+        const fileBytes = {};
+
+        for (let index = 1; index <= 128; index++) {
+            const name = `root-${String(index).padStart(3, '0')}.dcm`;
+            rootEntries.push({ name, isDirectory: false, isFile: true, isSymlink: false });
+            fileBytes[`/library/${name}`] = [index];
+        }
+
+        for (let index = 1; index <= 2; index++) {
+            const name = `nested-${String(index).padStart(3, '0')}.dcm`;
+            nestedEntries.push({ name, isDirectory: false, isFile: true, isSymlink: false });
+            fileBytes[`/library/nested/${name}`] = [index];
+        }
+
+        rootEntries.push({ name: 'nested', isDirectory: true, isFile: false, isSymlink: false });
+
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': rootEntries,
+                '/library/nested': nestedEntries
+            },
+            fileBytes
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const summary = await page.evaluate(async () => {
+            const progress = [];
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library'], {
+                onProgress: (stats) => {
+                    progress.push({
+                        discovered: stats.discovered,
+                        processed: stats.processed,
+                        valid: stats.valid,
+                        complete: stats.complete
+                    });
+                }
+            });
+            return {
+                studyCount: Object.keys(studies).length,
+                progress
+            };
+        });
+
+        expect(summary.studyCount).toBe(0);
+        expect(summary.progress.some((entry) => entry.discovered === 128 && entry.processed === 128)).toBe(true);
+        expect(summary.progress.at(-1)).toMatchObject({
+            discovered: 130,
+            processed: 130,
+            valid: 0,
+            complete: true
+        });
+    });
+
     test('desktop path reads retry transient filesystem failures', async ({ page }) => {
         await installMockDesktop(page, {
             fileBytes: {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -260,6 +260,45 @@ test.describe('Desktop library scanning', () => {
         expect(result.missingDimensions).toBe(false);
     });
 
+    test('metadata scan helper reads numeric DICOM tags when string access is empty', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const dataSet = {
+                string(tag) {
+                    const values = {
+                        x00200013: '',
+                        x00201041: ''
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    const values = {
+                        x00280010: 512,
+                        x00280011: 512,
+                        x00200013: 7
+                    };
+                    return values[tag];
+                },
+                elements: {
+                    x7fe00010: {}
+                }
+            };
+
+            const { getMetadataNumber } = window.DicomViewerApp.dicom;
+            return {
+                rows: getMetadataNumber(dataSet, 'x00280010', 0),
+                cols: getMetadataNumber(dataSet, 'x00280011', 0),
+                instanceNumber: getMetadataNumber(dataSet, 'x00200013', 0)
+            };
+        });
+
+        expect(result.rows).toBe(512);
+        expect(result.cols).toBe(512);
+        expect(result.instanceNumber).toBe(7);
+    });
+
     test('saved desktop library config is visible before startup scan completes', async ({ page }) => {
         await installMockDesktop(page, {
             initialConfig: {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -220,10 +220,16 @@ test.describe('Desktop library scanning', () => {
             const buffer = await window.DicomViewerApp.sources.readSliceBuffer({
                 source: { kind: 'path', path: '/library/image.dcm' }
             }, 'scan');
-            return Array.from(new Uint8Array(buffer));
+            return {
+                isUint8Array: buffer instanceof Uint8Array,
+                bytes: Array.from(buffer)
+            };
         });
 
-        expect(bytes).toEqual([1, 2, 3, 4]);
+        expect(bytes).toEqual({
+            isUint8Array: true,
+            bytes: [1, 2, 3, 4]
+        });
     });
 
     test('renderable image metadata helper excludes non-image DICOM objects', async ({ page }) => {
@@ -297,6 +303,25 @@ test.describe('Desktop library scanning', () => {
         expect(result.rows).toBe(512);
         expect(result.cols).toBe(512);
         expect(result.instanceNumber).toBe(7);
+    });
+
+    test('byte-array helper preserves typed-array inputs without cloning', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const bytes = Uint8Array.from([9, 8, 7, 6]).subarray(1, 3);
+            const normalized = await window.DicomViewerApp.dicom.toDicomByteArray(bytes);
+            return {
+                sameReference: normalized === bytes,
+                bytes: Array.from(normalized)
+            };
+        });
+
+        expect(result).toEqual({
+            sameReference: true,
+            bytes: [8, 7]
+        });
     });
 
     test('encapsulated frame extraction falls back for single-frame files with an empty basic offset table', async ({ page }) => {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -324,6 +324,87 @@ test.describe('Desktop library scanning', () => {
         });
     });
 
+    test('multi-frame metadata expands into virtual slices that share a cache key', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const source = { kind: 'path', path: '/library/multi-frame.dcm' };
+            const slices = window.DicomViewerApp.sources.expandFrameSlices({
+                numberOfFrames: 4,
+                instanceNumber: 12,
+                sliceLocation: 34.5
+            }, source);
+
+            return {
+                count: slices.length,
+                frameIndexes: slices.map((slice) => slice.frameIndex),
+                sameSourceReference: slices.every((slice) => slice.source === source),
+                cacheKeys: slices.map((slice, index) =>
+                    window.DicomViewerApp.sources.getSliceCacheKey(slice, index)
+                )
+            };
+        });
+
+        expect(result.count).toBe(4);
+        expect(result.frameIndexes).toEqual([0, 1, 2, 3]);
+        expect(result.sameSourceReference).toBe(true);
+        expect(new Set(result.cacheKeys)).toEqual(new Set(['path:/library/multi-frame.dcm']));
+    });
+
+    test('renderDicom selects the requested frame from an uncompressed multi-frame dataset', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const frame0Pixels = Array.from({ length: 16 }, (_, index) => index * 100);
+            const frame1Pixels = Array.from({ length: 16 }, (_, index) => 4000 + (index * 100));
+            const buffer = new ArrayBuffer(32 * 2);
+            const pixels = new Uint16Array(buffer);
+            pixels.set([...frame0Pixels, ...frame1Pixels]);
+
+            const dataSet = {
+                byteArray: new Uint8Array(buffer),
+                elements: {
+                    x7fe00010: {
+                        dataOffset: 0,
+                        length: buffer.byteLength
+                    }
+                },
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'DX'
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    const values = {
+                        x00280010: 4,
+                        x00280011: 4,
+                        x00280100: 16,
+                        x00280103: 0,
+                        x00280002: 1
+                    };
+                    return values[tag];
+                }
+            };
+
+            await window.DicomViewerApp.rendering.renderDicom(dataSet, { center: 3500, width: 7000 }, 0);
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+            const frame0 = ctx.getImageData(0, 0, 1, 1).data[0];
+
+            await window.DicomViewerApp.rendering.renderDicom(dataSet, { center: 3500, width: 7000 }, 1);
+            const frame1 = ctx.getImageData(0, 0, 1, 1).data[0];
+
+            return { frame0, frame1 };
+        });
+
+        expect(result.frame0).toBe(0);
+        expect(result.frame1).toBeGreaterThan(result.frame0);
+    });
+
     test('encapsulated frame extraction falls back for single-frame files with an empty basic offset table', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -299,6 +299,41 @@ test.describe('Desktop library scanning', () => {
         expect(result.instanceNumber).toBe(7);
     });
 
+    test('encapsulated frame extraction falls back for single-frame files with an empty basic offset table', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const parser = globalThis.dicomParser || window.dicomParser || dicomParser;
+            const byteArray = Uint8Array.from([
+                0xfe, 0xff, 0x00, 0xe0, 0x00, 0x00, 0x00, 0x00,
+                0xfe, 0xff, 0x00, 0xe0, 0x03, 0x00, 0x00, 0x00,
+                0x07, 0x08, 0x09
+            ]);
+
+            const frame = window.DicomViewerApp.dicom.getEncapsulatedFrameData({
+                byteArrayParser: parser.littleEndianByteArrayParser,
+                byteArray,
+                string() {
+                    return '';
+                }
+            }, {
+                tag: 'x7fe00010',
+                dataOffset: 0,
+                encapsulatedPixelData: true,
+                hadUndefinedLength: true,
+                basicOffsetTable: [],
+                fragments: [{ offset: 0, position: 16, length: 3 }]
+            }, 0);
+
+            return {
+                frame: Array.from(frame)
+            };
+        });
+
+        expect(result.frame).toEqual([7, 8, 9]);
+    });
+
     test('saved desktop library config is visible before startup scan completes', async ({ page }) => {
         await installMockDesktop(page, {
             initialConfig: {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -332,6 +332,7 @@ test.describe('Desktop library scanning', () => {
             const source = { kind: 'path', path: '/library/multi-frame.dcm' };
             const slices = window.DicomViewerApp.sources.expandFrameSlices({
                 numberOfFrames: 4,
+                sopInstanceUid: '1.2.3.4',
                 instanceNumber: 12,
                 sliceLocation: 34.5
             }, source);
@@ -340,6 +341,7 @@ test.describe('Desktop library scanning', () => {
                 count: slices.length,
                 frameIndexes: slices.map((slice) => slice.frameIndex),
                 sameSourceReference: slices.every((slice) => slice.source === source),
+                dedupeKeys: slices.map((slice) => window.DicomViewerApp.sources.getSliceDedupKey(slice)),
                 cacheKeys: slices.map((slice, index) =>
                     window.DicomViewerApp.sources.getSliceCacheKey(slice, index)
                 )
@@ -349,7 +351,48 @@ test.describe('Desktop library scanning', () => {
         expect(result.count).toBe(4);
         expect(result.frameIndexes).toEqual([0, 1, 2, 3]);
         expect(result.sameSourceReference).toBe(true);
+        expect(result.dedupeKeys).toEqual([
+            '1.2.3.4|0',
+            '1.2.3.4|1',
+            '1.2.3.4|2',
+            '1.2.3.4|3'
+        ]);
         expect(new Set(result.cacheKeys)).toEqual(new Set(['path:/library/multi-frame.dcm']));
+    });
+
+    test('scan dedupes duplicate DICOM copies with the same SOP instance UID', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const summary = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const blob = await dicomResponse.blob();
+
+            const studies = await window.DicomViewerApp.sources.processFilesFromSources([
+                { name: 'first-copy.dcm', source: { kind: 'blob', blob } },
+                { name: 'second-copy.dcm', source: { kind: 'blob', blob } }
+            ]);
+
+            const loadedStudy = Object.values(studies)[0];
+            const loadedSeries = Object.values(loadedStudy.series)[0];
+            return {
+                studyCount: Object.keys(studies).length,
+                seriesCount: Object.keys(loadedStudy.series).length,
+                sliceCount: loadedSeries.slices.length
+            };
+        });
+
+        expect(summary).toEqual({
+            studyCount: 1,
+            seriesCount: 1,
+            sliceCount: 1
+        });
     });
 
     test('renderDicom selects the requested frame from an uncompressed multi-frame dataset', async ({ page }) => {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -76,6 +76,16 @@ async function installMockDesktop(page, options = {}) {
             stats[normalizePath(path)] = value;
         }
 
+        const fileBytes = {};
+        for (const [path, value] of Object.entries(options.fileBytes || {})) {
+            fileBytes[normalizePath(path)] = value;
+        }
+
+        const readFileFailures = {};
+        for (const [path, value] of Object.entries(options.readFileFailures || {})) {
+            readFileFailures[normalizePath(path)] = Number(value || 0);
+        }
+
         window.__TAURI__ = {
             dialog: {
                 async open() {
@@ -96,8 +106,15 @@ async function installMockDesktop(page, options = {}) {
                     }
                     return dirs[normalized];
                 },
-                async readFile() {
-                    return new Uint8Array([0]);
+                async readFile(path) {
+                    const normalized = normalizePath(path);
+                    const remainingFailures = readFileFailures[normalized] || 0;
+                    if (remainingFailures > 0) {
+                        readFileFailures[normalized] = remainingFailures - 1;
+                        throw new Error(`Transient read failure: ${normalized}`);
+                    }
+                    const bytes = fileBytes[normalized] || [0];
+                    return Uint8Array.from(bytes);
                 },
                 async stat(path) {
                     const normalized = normalizePath(path);
@@ -129,6 +146,28 @@ async function installMockDesktop(page, options = {}) {
 }
 
 test.describe('Desktop library scanning', () => {
+    test('desktop path reads retry transient filesystem failures', async ({ page }) => {
+        await installMockDesktop(page, {
+            fileBytes: {
+                '/library/image.dcm': [1, 2, 3, 4]
+            },
+            readFileFailures: {
+                '/library/image.dcm': 2
+            }
+        });
+
+        await page.goto(HOME_URL);
+
+        const bytes = await page.evaluate(async () => {
+            const buffer = await window.DicomViewerApp.sources.readSliceBuffer({
+                source: { kind: 'path', path: '/library/image.dcm' }
+            }, 'scan');
+            return Array.from(new Uint8Array(buffer));
+        });
+
+        expect(bytes).toEqual([1, 2, 3, 4]);
+    });
+
     test('renderable image metadata helper excludes non-image DICOM objects', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -3,6 +3,7 @@
 const { test, expect } = require('@playwright/test');
 
 const HOME_URL = 'http://127.0.0.1:5001/?nolib';
+const AUTOLOAD_URL = 'http://127.0.0.1:5001/';
 
 function normalizePath(input) {
     const text = String(input || '').replace(/\\/g, '/');
@@ -68,14 +69,24 @@ async function installMockDesktop(page, options = {}) {
             readDirErrors[normalizePath(path)] = message;
         }
 
+        const readDirDelayMs = Number(options.readDirDelayMs || 0);
+
         const stats = {};
         for (const [path, value] of Object.entries(options.stats || {})) {
             stats[normalizePath(path)] = value;
         }
 
         window.__TAURI__ = {
+            dialog: {
+                async open() {
+                    return null;
+                }
+            },
             fs: {
                 async readDir(path) {
+                    if (readDirDelayMs > 0) {
+                        await new Promise((resolve) => setTimeout(resolve, readDirDelayMs));
+                    }
                     const normalized = normalizePath(path);
                     if (Object.prototype.hasOwnProperty.call(readDirErrors, normalized)) {
                         throw new Error(readDirErrors[normalized]);
@@ -118,6 +129,58 @@ async function installMockDesktop(page, options = {}) {
 }
 
 test.describe('Desktop library scanning', () => {
+    test('renderable image metadata helper excludes non-image DICOM objects', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const { isRenderableImageMetadata } = window.DicomViewerApp.sources;
+            return {
+                image: isRenderableImageMetadata({
+                    studyInstanceUid: '1.2.3',
+                    hasPixelData: true,
+                    rows: 2991,
+                    cols: 1580
+                }),
+                structuredReport: isRenderableImageMetadata({
+                    studyInstanceUid: '1.2.3',
+                    hasPixelData: false,
+                    rows: 0,
+                    cols: 0,
+                    sopClassUid: '1.2.840.10008.5.1.4.1.1.88.22'
+                }),
+                missingDimensions: isRenderableImageMetadata({
+                    studyInstanceUid: '1.2.3',
+                    hasPixelData: true,
+                    rows: 0,
+                    cols: 1580
+                })
+            };
+        });
+
+        expect(result.image).toBe(true);
+        expect(result.structuredReport).toBe(false);
+        expect(result.missingDimensions).toBe(false);
+    });
+
+    test('saved desktop library config is visible before startup scan completes', async ({ page }) => {
+        await installMockDesktop(page, {
+            initialConfig: {
+                folder: '/slow-library',
+                lastScan: '2026-03-07T12:00:00.000Z'
+            },
+            dirs: {
+                '/slow-library': []
+            },
+            readDirDelayMs: 500
+        });
+
+        await page.goto(AUTOLOAD_URL);
+        await expect(page.locator('#libraryFolderConfig')).toBeVisible();
+        await expect(page.locator('#libraryFolderInput')).toHaveValue('/slow-library');
+        await expect(page.locator('#libraryFolderMessage')).toContainText('Loading saved library folder...');
+    });
+
     test('desktop auto-load does not mark empty folders as a successful scan', async ({ page }) => {
         await installMockDesktop(page, {
             dirs: {

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -1,0 +1,264 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+const { test, expect } = require('@playwright/test');
+
+const HOME_URL = 'http://127.0.0.1:5001/';
+
+async function installMockTauriInternals(page) {
+    await page.addInitScript(() => {
+        const listeners = new Map();
+        const callbacks = new Map();
+        let callbackId = 1;
+
+        function registerCallback(callback, once = false) {
+            const id = callbackId++;
+            callbacks.set(id, (payload) => {
+                if (once) {
+                    callbacks.delete(id);
+                }
+                return callback(payload);
+            });
+            return id;
+        }
+
+        function normalizePath(path) {
+            const text = String(path || '').replace(/\\/g, '/');
+            return text.replace(/\/+/g, '/');
+        }
+
+        window.__TAURI_INTERNALS__ = {
+            metadata: {
+                currentWindow: { label: 'main' },
+                currentWebview: { label: 'main', windowLabel: 'main' }
+            },
+            convertFileSrc(filePath, protocol = 'asset') {
+                return `${protocol}://localhost/${encodeURIComponent(filePath)}`;
+            },
+            transformCallback: registerCallback,
+            unregisterCallback(id) {
+                callbacks.delete(id);
+            },
+            async invoke(cmd, args, options) {
+                switch (cmd) {
+                    case 'plugin:dialog|open':
+                        return null;
+                    case 'plugin:event|listen':
+                        if (!listeners.has(args.event)) listeners.set(args.event, []);
+                        listeners.get(args.event).push(args.handler);
+                        return args.handler;
+                    case 'plugin:event|unlisten':
+                        return null;
+                    case 'plugin:fs|exists':
+                        return false;
+                    case 'plugin:fs|mkdir':
+                    case 'plugin:fs|remove':
+                        return null;
+                    case 'plugin:fs|read_dir':
+                        return [];
+                    case 'plugin:fs|read_file':
+                        return new Uint8Array([0]);
+                    case 'plugin:fs|stat':
+                        return {
+                            isFile: false,
+                            isDirectory: true,
+                            isSymlink: false,
+                            size: 0,
+                            mtime: null,
+                            atime: null,
+                            birthtime: null,
+                            readonly: false,
+                            fileAttributes: null,
+                            dev: null,
+                            ino: null,
+                            mode: null,
+                            nlink: null,
+                            uid: null,
+                            gid: null,
+                            rdev: null,
+                            blksize: null,
+                            blocks: null
+                        };
+                    case 'plugin:fs|write_file':
+                        return null;
+                    case 'plugin:path|resolve_directory':
+                        return '/mock/appdata';
+                    case 'plugin:path|join':
+                        return args.paths.map(normalizePath).join('/').replace(/\/+/g, '/');
+                    case 'plugin:path|normalize':
+                        return normalizePath(args.path);
+                    default:
+                        throw new Error(`Unhandled command: ${cmd}`);
+                }
+            }
+        };
+
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+            unregisterListener(_event, id) {
+                callbacks.delete(id);
+            }
+        };
+    });
+}
+
+test('desktop runtime shim enables desktop mode when only __TAURI_INTERNALS__ is present', async ({ page }) => {
+    await installMockTauriInternals(page);
+    await page.goto(HOME_URL);
+    await expect(page.locator('#libraryView')).toBeVisible();
+
+    const result = await page.evaluate(() => ({
+        deploymentMode: window.CONFIG.deploymentMode,
+        hasGlobalTauri: typeof window.__TAURI__ !== 'undefined',
+        hasDialogApi: typeof window.__TAURI__?.dialog?.open === 'function',
+        hasFsApi: typeof window.__TAURI__?.fs?.readDir === 'function',
+        libraryConfigVisible: getComputedStyle(document.getElementById('libraryFolderConfig')).display !== 'none'
+    }));
+
+    expect(result.deploymentMode).toBe('desktop');
+    expect(result.hasGlobalTauri).toBe(true);
+    expect(result.hasDialogApi).toBe(true);
+    expect(result.hasFsApi).toBe(true);
+    expect(result.libraryConfigVisible).toBe(true);
+});
+
+test('deployment mode detects packaged Tauri origins before globals are ready', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5001/?nolib');
+
+    const modes = await page.evaluate(() => ({
+        tauriScheme: window.CONFIG.detectDeploymentMode({
+            location: { protocol: 'tauri:', hostname: 'localhost' }
+        }),
+        tauriHost: window.CONFIG.detectDeploymentMode({
+            location: { protocol: 'https:', hostname: 'tauri.localhost' }
+        }),
+        personal: window.CONFIG.detectDeploymentMode({
+            location: { protocol: 'http:', hostname: '127.0.0.1' }
+        })
+    }));
+
+    expect(modes.tauriScheme).toBe('desktop');
+    expect(modes.tauriHost).toBe('desktop');
+    expect(modes.personal).toBe('personal');
+});
+
+test('tauri runtime shim installs when internals arrive after the script loads', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5001/?nolib');
+
+    await page.evaluate(() => {
+        const listeners = new Map();
+        const callbacks = new Map();
+        let callbackId = 1;
+
+        function registerCallback(callback, once = false) {
+            const id = callbackId++;
+            callbacks.set(id, payload => {
+                if (once) {
+                    callbacks.delete(id);
+                }
+                return callback(payload);
+            });
+            return id;
+        }
+
+        function normalizePath(path) {
+            const text = String(path || '').replace(/\\/g, '/');
+            return text.replace(/\/+/g, '/');
+        }
+
+        setTimeout(() => {
+            window.__TAURI_INTERNALS__ = {
+                metadata: {
+                    currentWindow: { label: 'main' },
+                    currentWebview: { label: 'main', windowLabel: 'main' }
+                },
+                convertFileSrc(filePath, protocol = 'asset') {
+                    return `${protocol}://localhost/${encodeURIComponent(filePath)}`;
+                },
+                transformCallback: registerCallback,
+                unregisterCallback(id) {
+                    callbacks.delete(id);
+                },
+                async invoke(cmd, args) {
+                    switch (cmd) {
+                        case 'plugin:dialog|open':
+                            return null;
+                        case 'plugin:event|listen':
+                            if (!listeners.has(args.event)) listeners.set(args.event, []);
+                            listeners.get(args.event).push(args.handler);
+                            return args.handler;
+                        case 'plugin:event|unlisten':
+                            return null;
+                        case 'plugin:fs|exists':
+                            return false;
+                        case 'plugin:fs|mkdir':
+                        case 'plugin:fs|remove':
+                            return null;
+                        case 'plugin:fs|read_dir':
+                            return [];
+                        case 'plugin:fs|read_file':
+                            return new Uint8Array([0]);
+                        case 'plugin:fs|stat':
+                            return {
+                                isFile: false,
+                                isDirectory: true,
+                                isSymlink: false,
+                                size: 0,
+                                mtime: null,
+                                atime: null,
+                                birthtime: null,
+                                readonly: false,
+                                fileAttributes: null,
+                                dev: null,
+                                ino: null,
+                                mode: null,
+                                nlink: null,
+                                uid: null,
+                                gid: null,
+                                rdev: null,
+                                blksize: null,
+                                blocks: null
+                            };
+                        case 'plugin:fs|write_file':
+                            return null;
+                        case 'plugin:path|resolve_directory':
+                            return '/mock/appdata';
+                        case 'plugin:path|join':
+                            return args.paths.map(normalizePath).join('/').replace(/\/+/g, '/');
+                        case 'plugin:path|normalize':
+                            return normalizePath(args.path);
+                        default:
+                            throw new Error(`Unhandled command: ${cmd}`);
+                    }
+                }
+            };
+
+            window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+                unregisterListener(_event, id) {
+                    callbacks.delete(id);
+                }
+            };
+        }, 50);
+    });
+
+    const result = await page.evaluate(async () => {
+        const runtime = await window.__DICOM_VIEWER_TAURI_READY__;
+        return {
+            hasReadyPromise: typeof window.__DICOM_VIEWER_TAURI_READY__?.then === 'function',
+            hasGlobalTauri: typeof window.__TAURI__ !== 'undefined',
+            hasDialogApi: typeof runtime?.dialog?.open === 'function',
+            hasFsApi: typeof runtime?.fs?.readDir === 'function'
+        };
+    });
+
+    expect(result.hasReadyPromise).toBe(true);
+    expect(result.hasGlobalTauri).toBe(true);
+    expect(result.hasDialogApi).toBe(true);
+    expect(result.hasFsApi).toBe(true);
+});
+
+test('OpenJPEG asset URL resolves relative to the decoder script', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5001/?nolib');
+
+    const result = await page.evaluate(() => window.DicomViewerApp.dicom.resolveOpenJpegAssetUrl('openjpegwasm_decode.wasm'));
+
+    expect(result).toMatch(/\/js\/openjpegwasm_decode\.wasm$/);
+});


### PR DESCRIPTION
## Summary
- stabilize large desktop library scans and reduce packaged webview memory pressure during path-based loading
- fix desktop metadata extraction, empty Basic Offset Table JPEG 2000 handling, and multi-frame DICOM slice expansion
- deduplicate duplicate study copies by SOP Instance UID plus frame index so repeated exports do not double counts
- add targeted desktop regressions for scan streaming, multi-frame expansion, frame-aware rendering, and duplicate-copy dedupe

## Validation
- npx playwright test
- npm run tauri build -- --bundles app

## Notes
- keeps the existing shared web app architecture and Playwright suite as the regression guard
- leaves unrelated local changes in docs/decisions/README.md and .claude/ untouched