### PR TITLE
Add code review tracking document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,12 +235,13 @@ After each test run, apply continuous improvement: analyze results, strengthen t
 ## Documentation Requirements
 
 - **Keep SITEMAP.md accurate.** Update `docs/planning/SITEMAP.md` whenever project structure changes (new files, moved files, renamed folders). It's the reference for understanding the project.
-- **Track bugs in BUGS.md.** Document in `docs/planning/BUGS.md` with full context:
+- **Track bugs in BUGS.md.** Document in `docs/BUGS.md` with full context:
   - How the bug was encountered (symptoms, reproduction steps)
   - Root cause analysis (why it happened)
   - Solution implemented (what was changed)
   - Why that solution was chosen (alternatives considered, tradeoffs)
   - Prevention control added (test, code guideline, or check to prevent recurrence)
+- **Track code review findings in CODE_REVIEWS.md.** Document findings from PR reviews in `docs/CODE_REVIEWS.md`, organized by PR with severity grouping (Critical/Important/Suggestions). Update finding status as issues are resolved. Promote unresolved findings to BUGS.md if they survive past merge.
 - **Update session log.** At the end of each session, append a summary to `docs/history/session-summaries.md` with date, session name, what was accomplished, and key decisions. This file is gitignored (private).
 - **Record major decisions as ADRs.** For new features, significant architecture choices, technology selections, or decisions likely to be revisited, write/update an ADR in `docs/decisions/`. Use ADR status updates as implementation progresses, and supersede with a new ADR when reversing a decision.
 

--- a/docs/CODE_REVIEWS.md
+++ b/docs/CODE_REVIEWS.md
@@ -1,0 +1,66 @@
+# Code Reviews
+
+PR review findings and their resolution status.
+
+**Scoping**: This file tracks what was found and recommended during PR reviews (pre-merge quality gate). For bugs found in the running codebase, see [BUGS.md](BUGS.md). When a finding outlives its PR, it gets promoted to BUGS.md with a `Promoted (BUG-XXX)` status here.
+
+---
+
+## PR #16: Add Tauri desktop app shell and persistence (2026-03-08)
+
+Branch: `codex/tauri-desktop-app` | Score: 6/10
+
+### Critical
+
+| ID | Finding | File(s) | Status |
+|----|---------|---------|--------|
+| 16-1 | Unbounded recursive traversal in `collectPathSources` -- no depth limit or cycle detection, stack overflow on symlink loops | sources.js:225-247 | Open |
+| 16-2 | `DesktopBackend.deleteReport` removes localStorage before file delete -- orphaned files on failure | api.js:306-334 | Open |
+
+### Important
+
+| ID | Finding | File(s) | Status |
+|----|---------|---------|--------|
+| 16-3 | `fs:default` capability broader than needed, no read-scope restriction on DICOM library paths | capabilities/default.json | Open |
+| 16-4 | `deleteReport` rollback partial -- `saveStore` already called before file delete attempt | notes-reports.js:369-385 | Open |
+| 16-5 | `markScanComplete` called even on empty scan results | main.js:181-198 | Open |
+| 16-6 | Silent failure when Tauri APIs unavailable in desktop path | api.js:523-541 | Open |
+| 16-7 | Cargo.toml author email field contains URL, not email | Cargo.toml:5 | Open |
+| 16-8 | ADR 003 status not updated to reflect implementation progress | 003-tauri-desktop-shell-with-shared-web-core.md | Open |
+
+### Suggestions
+
+| ID | Finding | File(s) | Status |
+|----|---------|---------|--------|
+| 16-9 | `joinPath` heuristic fragile, should use Tauri `path.join` | sources.js:59-62 | Open |
+| 16-10 | `desktop-smoke` CI job has no artifact upload on failure | pr-validate.yml | Open |
+| 16-11 | No registry of localStorage keys across modules | desktop-library.js:5 | Open |
+| 16-12 | Redundant state mutations before `applyLibraryConfigPayload` | library.js:128-130 | Open |
+| 16-13 | `processFilesFromSources` -- one corrupt file aborts entire batch | sources.js:88-110 | Open |
+
+---
+
+## PR #15: Frontend extraction refactor (2026-03-08)
+
+Branch: `codex/frontend-extraction-refactor-pr` | Score: 7/10
+
+### Important
+
+| ID | Finding | File(s) | Status |
+|----|---------|---------|--------|
+| 15-1 | Inconsistent indentation in dicom.js and rendering.js -- function bodies at column 0 inside IIFE | dicom.js:7-445, rendering.js:21-245 | Open |
+| 15-2 | `NotesAPI` referenced as bare global in library.js, bypasses `app` namespace | library.js:443,456 | Open |
+| 15-3 | Dead `state` import in dicom.js | dicom.js:3 | Open |
+| 15-4 | `section.content` raw HTML injection in help-viewer.js without comment explaining why it is safe | help-viewer.js:47 | Open |
+
+### Suggestions
+
+| ID | Finding | File(s) | Status |
+|----|---------|---------|--------|
+| 15-5 | `processFiles` does not initialize `comments: []`, inconsistent with `loadSampleStudies` | sources.js:47 vs 229 | Open |
+| 15-6 | CONFIG access pattern inconsistent -- guard vs. no guard across modules | main.js:317 vs notes-reports.js | Open |
+| 15-7 | dom.js acquires canvas contexts at module load time, fragile if scripts move | dom.js:46-47 | Open |
+
+---
+
+*Last updated: 2026-03-09*

--- a/docs/planning/SITEMAP.md
+++ b/docs/planning/SITEMAP.md
@@ -25,6 +25,7 @@ claude 0/                          # Workspace/inbox - drop files here for Claud
 | File | Description |
 |------|-------------|
 | `BUGS.md` | Bug tracking and known issues |
+| `CODE_REVIEWS.md` | PR review findings and resolution tracking |
 | `DEPLOY.md` | Deployment guide: local dev, GitHub Pages, CI/CD workflow |
 | `DEVELOPMENT_PHILOSOPHY.md` | Learning guide: why branches, CI/CD, preview environments, code review exist |
 | `TESTING.md` | Testing documentation and Playwright setup |


### PR DESCRIPTION
## Summary

- Create `docs/CODE_REVIEWS.md` to track PR review findings with severity levels and resolution status
- Populate with all findings from PR #15 (frontend extraction, 7/10) and PR #16 (Tauri desktop app, 6/10)
- Add promotion path: unresolved findings that survive past merge get promoted to BUGS.md
- Update CLAUDE.md documentation requirements and SITEMAP.md

## Design

CODE_REVIEWS.md and BUGS.md have non-overlapping scopes:
- **CODE_REVIEWS.md** -- what was found and recommended (pre-merge quality gate)
- **BUGS.md** -- what was fixed and how (post-merge bugs in the running codebase)

Findings are organized by PR, grouped by severity (Critical/Important/Suggestions), with IDs like `16-1`, `15-3` for easy reference.

## Test plan

- [ ] Verify CODE_REVIEWS.md renders correctly on GitHub
- [ ] Confirm all 20 findings across both PRs are present (13 from PR #16, 7 from PR #15)
- [ ] Check SITEMAP.md and CLAUDE.md updates are accurate

Generated with [Claude Code](https://claude.com/claude-code)