### PR TITLE
Split DICOM decode and render phases

### DIFF
--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -8,6 +8,7 @@
         isJpegLossless,
         isJpegBaseline,
         isJpeg2000,
+        getNumberOfFrames,
         getTransferSyntaxInfo,
         getModalityDefaults,
         calculateAutoWindowLevel,
@@ -18,19 +19,64 @@
         decodeJpegBaseline
     } = app.dicom;
 
-    function getUncompressedFramePixelData(dataSet, pixelDataElement, rows, cols, bitsAllocated, pixelRepresentation, frameIndex = 0) {
-        const samplesPerPixel = dataSet.uint16('x00280002') || 1;
-        const framePixelCount = rows * cols * samplesPerPixel;
-        const bytesPerSample = bitsAllocated > 8 ? 2 : 1;
-        const frameOffset = pixelDataElement.dataOffset + (frameIndex * framePixelCount * bytesPerSample);
+    function getPixelDataArrayType(bitsAllocated, pixelRepresentation) {
+        if (bitsAllocated <= 8) {
+            return pixelRepresentation === 1 ? Int8Array : Uint8Array;
+        }
+        if (bitsAllocated <= 16) {
+            return pixelRepresentation === 1 ? Int16Array : Uint16Array;
+        }
+        if (bitsAllocated <= 32) {
+            return pixelRepresentation === 1 ? Int32Array : Uint32Array;
+        }
+        throw new Error(`Unsupported Bits Allocated value: ${bitsAllocated}`);
+    }
 
-        if (bitsAllocated === 16) {
-            return pixelRepresentation === 1
-                ? new Int16Array(dataSet.byteArray.buffer, frameOffset, framePixelCount)
-                : new Uint16Array(dataSet.byteArray.buffer, frameOffset, framePixelCount);
+    function getUncompressedFramePixelData(
+        dataSet,
+        pixelDataElement,
+        rows,
+        cols,
+        bitsAllocated,
+        pixelRepresentation,
+        samplesPerPixel,
+        frameIndex = 0
+    ) {
+        if (bitsAllocated % 8 !== 0) {
+            throw new Error(`Native pixel data with Bits Allocated ${bitsAllocated} is not byte-aligned.`);
         }
 
-        return new Uint8Array(dataSet.byteArray.buffer, frameOffset, framePixelCount);
+        const framePixelCount = rows * cols * samplesPerPixel;
+        const bytesPerSample = Math.max(1, Math.ceil(bitsAllocated / 8));
+        const expectedFrameBytes = framePixelCount * bytesPerSample;
+        const numberOfFrames = getNumberOfFrames(dataSet);
+        const totalPixelBytes = Number.isFinite(pixelDataElement.length)
+            ? pixelDataElement.length
+            : (dataSet.byteArray.byteLength - pixelDataElement.dataOffset);
+
+        if (frameIndex < 0 || frameIndex >= numberOfFrames) {
+            throw new Error(`Frame index ${frameIndex} is outside the available native frames (${numberOfFrames}).`);
+        }
+
+        const evenlyDivisibleStride = numberOfFrames > 0 && totalPixelBytes % numberOfFrames === 0
+            ? totalPixelBytes / numberOfFrames
+            : null;
+        const frameStrideBytes = evenlyDivisibleStride && evenlyDivisibleStride >= expectedFrameBytes
+            ? evenlyDivisibleStride
+            : expectedFrameBytes;
+        const frameDataOffset = pixelDataElement.dataOffset + (frameIndex * frameStrideBytes);
+        const frameDataEnd = frameDataOffset + expectedFrameBytes;
+        const pixelDataEnd = pixelDataElement.dataOffset + totalPixelBytes;
+
+        if (frameDataEnd > pixelDataEnd) {
+            throw new Error('Native pixel data is shorter than the requested frame payload.');
+        }
+
+        const PixelArrayType = getPixelDataArrayType(bitsAllocated, pixelRepresentation);
+        const bufferOffset = dataSet.byteArray.byteOffset + frameDataOffset;
+
+        // Return a detached copy so future consumers can safely mutate decoded.pixelData.
+        return new PixelArrayType(dataSet.byteArray.buffer, bufferOffset, framePixelCount).slice();
     }
 
     // =====================================================================
@@ -82,6 +128,23 @@
         };
     }
 
+    function buildDecodeError(errorMessage, errorDetails, extra = {}) {
+        return {
+            error: true,
+            errorMessage,
+            errorDetails,
+            ...extra
+        };
+    }
+
+    function renderDecodeError(errorInfo) {
+        state.pixelSpacing = null;
+        app.tools.updateCalibrationWarning();
+        displayError(errorInfo.errorMessage, errorInfo.errorDetails);
+        app.tools.drawMeasurements?.();
+        return errorInfo;
+    }
+
     async function decodeDicom(dataSet, frameIndex = 0) {
         // Extract image dimensions and pixel format from DICOM tags
         const rows = dataSet.uint16('x00280010');              // (0028,0010) Rows
@@ -124,10 +187,7 @@
             protocolName: getString(dataSet, 'x00181030'),         // (0018,1030) Protocol Name
             sequenceName: getString(dataSet, 'x00180024'),         // (0018,0024) Sequence Name
             scanningSequence: getString(dataSet, 'x00180020'),     // (0018,0020) Scanning Sequence
-            mrAcquisitionType: getString(dataSet, 'x00180023'),    // (0018,0023) MR Acquisition Type (2D/3D)
-            tr: getNumber(dataSet, 'x00180080', 0),
-            te: getNumber(dataSet, 'x00180081', 0),
-            fieldStrength: getNumber(dataSet, 'x00180087', 0)
+            mrAcquisitionType: getString(dataSet, 'x00180023')    // (0018,0023) MR Acquisition Type (2D/3D)
         };
 
         // Get transfer syntax to determine compression format
@@ -140,8 +200,11 @@
 
         if (!pixelDataElement) {
             console.error('No pixel data element found');
-            displayError('No pixel data found', 'The DICOM file may be corrupted or incomplete');
-            return { error: true };
+            return buildDecodeError(
+                'No pixel data found',
+                'The DICOM file may be corrupted or incomplete',
+                { transferSyntax, tsInfo: transferSyntaxInfo }
+            );
         }
 
         let pixelData;
@@ -163,39 +226,60 @@
                     frameIndex
                 );
                 if (!pixelData) {
-                    displayError('JPEG 2000 decode failed', transferSyntaxInfo.name);
-                    return { error: true, transferSyntax, tsInfo: transferSyntaxInfo };
+                    return buildDecodeError(
+                        'JPEG 2000 decode failed',
+                        transferSyntaxInfo.name,
+                        { transferSyntax, tsInfo: transferSyntaxInfo }
+                    );
                 }
             } else if (isJpegLossless(transferSyntax)) {
                 pixelData = decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated, frameIndex);
                 if (!pixelData) {
-                    displayError('JPEG Lossless decode failed', transferSyntaxInfo.name);
-                    return { error: true, transferSyntax, tsInfo: transferSyntaxInfo };
+                    return buildDecodeError(
+                        'JPEG Lossless decode failed',
+                        transferSyntaxInfo.name,
+                        { transferSyntax, tsInfo: transferSyntaxInfo }
+                    );
                 }
             } else if (isJpegBaseline(transferSyntax)) {
                 const result = await decodeJpegBaseline(dataSet, pixelDataElement, rows, cols, frameIndex);
                 if (!result) {
-                    displayError('JPEG decode failed', transferSyntaxInfo.name);
-                    return { error: true, transferSyntax, tsInfo: transferSyntaxInfo };
+                    return buildDecodeError(
+                        'JPEG decode failed',
+                        transferSyntaxInfo.name,
+                        { transferSyntax, tsInfo: transferSyntaxInfo }
+                    );
                 }
                 pixelData = result.pixels;
                 skipWindowLevel = result.isRgb; // Already 0-255 from JPEG decode
             } else {
                 // Unsupported compression format
-                displayError('Unsupported compression format', transferSyntaxInfo.name);
-                return { error: true, transferSyntax, tsInfo: transferSyntaxInfo };
+                return buildDecodeError(
+                    'Unsupported compression format',
+                    transferSyntaxInfo.name,
+                    { transferSyntax, tsInfo: transferSyntaxInfo }
+                );
             }
         } else {
-            // Uncompressed pixel data - create typed array view directly on buffer
-            pixelData = getUncompressedFramePixelData(
-                dataSet,
-                pixelDataElement,
-                rows,
-                cols,
-                bitsAllocated,
-                pixelRepresentation,
-                frameIndex
-            );
+            try {
+                pixelData = getUncompressedFramePixelData(
+                    dataSet,
+                    pixelDataElement,
+                    rows,
+                    cols,
+                    bitsAllocated,
+                    pixelRepresentation,
+                    samplesPerPixel,
+                    frameIndex
+                );
+            } catch (error) {
+                console.error('Native pixel data decode error:', error);
+                return buildDecodeError(
+                    'Native pixel data decode failed',
+                    String(error?.message || error || 'Unknown native decode error'),
+                    { transferSyntax, tsInfo: transferSyntaxInfo }
+                );
+            }
         }
 
         // Check for blank/uniform slices (common in MPR reconstructions as padding)
@@ -287,7 +371,7 @@
         // Calculate window/level range (min/max displayable values)
         const windowMin = windowCenter - windowWidth / 2;
         const windowMax = windowCenter + windowWidth / 2;
-        const windowRange = Math.max(windowMax - windowMin, 1);
+        const windowDivisor = Math.max(windowMax - windowMin, 1);
 
         // Apply rescale and window/level transform to each pixel
         for (let i = 0; i < decoded.pixelData.length; i++) {
@@ -301,7 +385,7 @@
                 let pixelValue = decoded.pixelData[i] * decoded.rescaleSlope + decoded.rescaleIntercept;
                 // Clamp to window range and scale to 0-255
                 pixelValue = Math.max(windowMin, Math.min(windowMax, pixelValue));
-                grayscaleValue = Math.round(((pixelValue - windowMin) / windowRange) * 255);
+                grayscaleValue = Math.round(((pixelValue - windowMin) / windowDivisor) * 255);
             }
             // Set RGBA values (grayscale = R=G=B, alpha=255)
             const pixelIndex = i * 4;
@@ -328,7 +412,12 @@
      */
     async function renderDicom(dataSet, wlOverride = null, frameIndex = 0) {
         const decoded = await decodeDicom(dataSet, frameIndex);
-        if (!decoded || decoded.error) return decoded || { error: true };
+        if (!decoded) {
+            return renderDecodeError(buildDecodeError('Image decode failed', 'Unknown decode error'));
+        }
+        if (decoded.error) {
+            return renderDecodeError(decoded);
+        }
         return renderPixels(decoded, wlOverride);
     }
 

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -69,20 +69,27 @@
         ctx.fillText('This format may require additional decoders', canvas.width / 2, 310);
     }
 
-    /**
-     * Render a DICOM dataset to the canvas
-     * Handles decompression, window/level adjustment, and display
-     *
-     * @param {Object} dataSet - Parsed dicomParser dataset with pixel data
-     * @param {Object|null} wlOverride - Optional {center, width} to override DICOM values
-     * @returns {Promise<Object>} Rendering info {rows, cols, wc, ww, transferSyntax} or {error: true}
-     */
-    async function renderDicom(dataSet, wlOverride = null, frameIndex = 0) {
+    function buildRenderInfo(decoded, windowCenter, windowWidth, extra = {}) {
+        return {
+            rows: decoded.rows,
+            cols: decoded.cols,
+            wc: windowCenter,
+            ww: windowWidth,
+            transferSyntax: decoded.transferSyntax,
+            modality: decoded.modality,
+            mrMetadata: decoded.mrMetadata,
+            ...extra
+        };
+    }
+
+    async function decodeDicom(dataSet, frameIndex = 0) {
         // Extract image dimensions and pixel format from DICOM tags
         const rows = dataSet.uint16('x00280010');              // (0028,0010) Rows
         const cols = dataSet.uint16('x00280011');              // (0028,0011) Columns
         const bitsAllocated = dataSet.uint16('x00280100') || 16;  // (0028,0100) Bits Allocated
         const pixelRepresentation = dataSet.uint16('x00280103') || 0;  // (0028,0103) 0=unsigned, 1=signed
+        const samplesPerPixel = dataSet.uint16('x00280002') || 1;
+        const photometricInterpretation = getString(dataSet, 'x00280004');
 
         // Get modality for appropriate defaults
         const modality = getString(dataSet, 'x00080060');  // (0008,0060) Modality
@@ -107,8 +114,6 @@
 
         // Extract pixel spacing for measurement calibration
         const pixelSpacing = app.tools.extractPixelSpacing(dataSet);
-        state.pixelSpacing = pixelSpacing;
-        app.tools.updateCalibrationWarning();
 
         // Extract MRI-specific metadata
         const mrMetadata = {
@@ -120,6 +125,9 @@
             sequenceName: getString(dataSet, 'x00180024'),         // (0018,0024) Sequence Name
             scanningSequence: getString(dataSet, 'x00180020'),     // (0018,0020) Scanning Sequence
             mrAcquisitionType: getString(dataSet, 'x00180023'),    // (0018,0023) MR Acquisition Type (2D/3D)
+            tr: getNumber(dataSet, 'x00180080', 0),
+            te: getNumber(dataSet, 'x00180081', 0),
+            fieldStrength: getNumber(dataSet, 'x00180087', 0)
         };
 
         // Get transfer syntax to determine compression format
@@ -194,13 +202,23 @@
         // This must be done before window/level calculations
         if (isBlankSlice(pixelData, rescaleSlope, rescaleIntercept)) {
             console.log('Detected blank slice (all pixels same value)');
-            displayBlankSlice(rows, cols);
             return {
-                rows, cols,
-                wc: windowCenter, ww: windowWidth,
+                pixelData,
+                rows,
+                cols,
+                bitsAllocated,
+                pixelRepresentation,
+                samplesPerPixel,
+                photometricInterpretation,
+                windowCenter,
+                windowWidth,
+                rescaleSlope,
+                rescaleIntercept,
                 transferSyntax, modality,
                 mrMetadata,
-                isBlank: true
+                pixelSpacing,
+                isBlank: true,
+                skipWindowLevel
             };
         }
 
@@ -211,6 +229,40 @@
             windowCenter = autoWL.windowCenter;
             windowWidth = autoWL.windowWidth;
             console.log(`Auto window/level for ${modality}: C=${windowCenter} W=${windowWidth}`);
+        }
+
+        return {
+            pixelData,
+            rows,
+            cols,
+            bitsAllocated,
+            pixelRepresentation,
+            samplesPerPixel,
+            photometricInterpretation,
+            windowCenter,
+            windowWidth,
+            rescaleSlope,
+            rescaleIntercept,
+            modality,
+            transferSyntax,
+            mrMetadata,
+            pixelSpacing,
+            isBlank: false,
+            skipWindowLevel
+        };
+    }
+
+    function renderPixels(decoded, wlOverride = null) {
+        let windowCenter = decoded.windowCenter;
+        let windowWidth = decoded.windowWidth;
+
+        state.pixelSpacing = decoded.pixelSpacing || null;
+        app.tools.updateCalibrationWarning();
+
+        if (decoded.isBlank) {
+            displayBlankSlice(decoded.rows, decoded.cols);
+            app.tools.drawMeasurements?.();
+            return buildRenderInfo(decoded, windowCenter, windowWidth, { isBlank: true });
         }
 
         // Store base W/L values for reset (only on first render, not re-renders)
@@ -225,30 +277,31 @@
         }
 
         // Set canvas size to match image dimensions
-        canvas.width = cols;
-        canvas.height = rows;
+        canvas.width = decoded.cols;
+        canvas.height = decoded.rows;
 
         // Create image data buffer for canvas
-        const imageData = ctx.createImageData(cols, rows);
+        const imageData = ctx.createImageData(decoded.cols, decoded.rows);
         const outputPixels = imageData.data;
 
         // Calculate window/level range (min/max displayable values)
         const windowMin = windowCenter - windowWidth / 2;
         const windowMax = windowCenter + windowWidth / 2;
+        const windowRange = Math.max(windowMax - windowMin, 1);
 
         // Apply rescale and window/level transform to each pixel
-        for (let i = 0; i < pixelData.length; i++) {
+        for (let i = 0; i < decoded.pixelData.length; i++) {
             let grayscaleValue;
-            if (skipWindowLevel) {
+            if (decoded.skipWindowLevel) {
                 // Already 0-255 (e.g., from JPEG baseline decode)
-                grayscaleValue = pixelData[i];
+                grayscaleValue = decoded.pixelData[i];
             } else {
                 // Apply rescale slope/intercept
                 // CT: converts to Hounsfield Units; MR: arbitrary signal intensity
-                let pixelValue = pixelData[i] * rescaleSlope + rescaleIntercept;
+                let pixelValue = decoded.pixelData[i] * decoded.rescaleSlope + decoded.rescaleIntercept;
                 // Clamp to window range and scale to 0-255
                 pixelValue = Math.max(windowMin, Math.min(windowMax, pixelValue));
-                grayscaleValue = Math.round(((pixelValue - windowMin) / (windowMax - windowMin)) * 255);
+                grayscaleValue = Math.round(((pixelValue - windowMin) / windowRange) * 255);
             }
             // Set RGBA values (grayscale = R=G=B, alpha=255)
             const pixelIndex = i * 4;
@@ -258,20 +311,32 @@
             outputPixels[pixelIndex + 3] = 255;             // A (opaque)
         }
 
-        // Draw to canvas
+        // Draw to canvas and keep the measurement overlay aligned with the new image size.
         ctx.putImageData(imageData, 0, 0);
+        app.tools.drawMeasurements?.();
 
-        return {
-            rows, cols,
-            wc: windowCenter, ww: windowWidth,
-            transferSyntax, modality,
-            mrMetadata
-        };
+        return buildRenderInfo(decoded, windowCenter, windowWidth);
+    }
+
+    /**
+     * Render a DICOM dataset to the canvas
+     * Handles decompression, window/level adjustment, and display
+     *
+     * @param {Object} dataSet - Parsed dicomParser dataset with pixel data
+     * @param {Object|null} wlOverride - Optional {center, width} to override DICOM values
+     * @returns {Promise<Object>} Rendering info {rows, cols, wc, ww, transferSyntax} or {error: true}
+     */
+    async function renderDicom(dataSet, wlOverride = null, frameIndex = 0) {
+        const decoded = await decodeDicom(dataSet, frameIndex);
+        if (!decoded || decoded.error) return decoded || { error: true };
+        return renderPixels(decoded, wlOverride);
     }
 
 
     app.rendering = {
         displayError,
+        decodeDicom,
+        renderPixels,
         renderDicom
     };
 })();

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -20,7 +20,6 @@
     const { renderDicom } = app.rendering;
     const { readSliceBuffer, getSliceCacheKey } = app.sources;
     const {
-        drawMeasurements,
         resetViewForNewSeries,
         updateWLDisplay
     } = app.tools;
@@ -120,7 +119,6 @@
         }
 
         imageLoading.style.display = 'none';
-        drawMeasurements();
     }
 
     function updateSliceInfo() {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -448,6 +448,59 @@ test.describe('Desktop library scanning', () => {
         expect(result.frame1).toBeGreaterThan(result.frame0);
     });
 
+    test('decodeDicom selects the requested frame from a 32-bit uncompressed multi-frame dataset', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const frame0Pixels = [10, 20, 30, 40];
+            const frame1Pixels = [100000, 100100, 100200, 100300];
+            const buffer = new ArrayBuffer(8 * 4);
+            const pixels = new Uint32Array(buffer);
+            pixels.set([...frame0Pixels, ...frame1Pixels]);
+
+            const dataSet = {
+                byteArray: new Uint8Array(buffer),
+                elements: {
+                    x7fe00010: {
+                        dataOffset: 0,
+                        length: buffer.byteLength
+                    }
+                },
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'CT',
+                        x00280004: 'MONOCHROME2',
+                        x00281050: '128',
+                        x00281051: '256'
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    const values = {
+                        x00280010: 2,
+                        x00280011: 2,
+                        x00280100: 32,
+                        x00280103: 0,
+                        x00280002: 1,
+                        x00280008: 2
+                    };
+                    return values[tag];
+                }
+            };
+
+            const decoded = await window.DicomViewerApp.rendering.decodeDicom(dataSet, 1);
+            return {
+                pixelDataType: decoded.pixelData.constructor.name,
+                pixelValues: Array.from(decoded.pixelData)
+            };
+        });
+
+        expect(result.pixelDataType).toBe('Uint32Array');
+        expect(result.pixelValues).toEqual([100000, 100100, 100200, 100300]);
+    });
+
     test('decodeDicom returns the normalized intermediate contract for uncompressed CT data', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
@@ -534,15 +587,109 @@ test.describe('Desktop library scanning', () => {
         });
         expect(result.mrMetadataKeys).toEqual(expect.arrayContaining([
             'echoTime',
-            'fieldStrength',
             'flipAngle',
             'magneticFieldStrength',
+            'mrAcquisitionType',
             'protocolName',
             'repetitionTime',
+            'scanningSequence',
             'sequenceName',
-            'te',
-            'tr'
         ]));
+    });
+
+    test('decodeDicom does not write to the canvas when it returns an error', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+            canvas.width = 2;
+            canvas.height = 2;
+            ctx.fillStyle = 'rgb(12, 34, 56)';
+            ctx.fillRect(0, 0, 2, 2);
+            const before = Array.from(ctx.getImageData(0, 0, 2, 2).data);
+
+            const info = await window.DicomViewerApp.rendering.decodeDicom({
+                elements: {},
+                string() {
+                    return '';
+                },
+                uint16() {
+                    return 0;
+                }
+            }, 0);
+
+            return {
+                info,
+                after: Array.from(ctx.getImageData(0, 0, 2, 2).data),
+                canvasSize: { width: canvas.width, height: canvas.height },
+                before
+            };
+        });
+
+        expect(result.info).toMatchObject({
+            error: true,
+            errorMessage: 'No pixel data found'
+        });
+        expect(result.canvasSize).toEqual({ width: 2, height: 2 });
+        expect(result.after).toEqual(result.before);
+    });
+
+    test('decodeDicom returns a detached copy of uncompressed pixel data', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const buffer = new ArrayBuffer(4 * 2);
+            const backingPixels = new Uint16Array(buffer);
+            backingPixels.set([100, 200, 300, 400]);
+
+            const dataSet = {
+                byteArray: new Uint8Array(buffer),
+                elements: {
+                    x7fe00010: {
+                        dataOffset: 0,
+                        length: buffer.byteLength
+                    }
+                },
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'CT',
+                        x00280004: 'MONOCHROME2',
+                        x00281050: '40',
+                        x00281051: '400'
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    const values = {
+                        x00280010: 2,
+                        x00280011: 2,
+                        x00280100: 16,
+                        x00280103: 0,
+                        x00280002: 1,
+                        x00280008: 1
+                    };
+                    return values[tag];
+                }
+            };
+
+            const decoded = await window.DicomViewerApp.rendering.decodeDicom(dataSet, 0);
+            const sharesBuffer = decoded.pixelData.buffer === buffer;
+            decoded.pixelData[0] = 9999;
+
+            return {
+                sharesBuffer,
+                backingFirstValue: backingPixels[0],
+                decodedFirstValue: decoded.pixelData[0]
+            };
+        });
+
+        expect(result.sharesBuffer).toBe(false);
+        expect(result.backingFirstValue).toBe(100);
+        expect(result.decodedFirstValue).toBe(9999);
     });
 
     test('renderPixels renders a hand-constructed decode contract to the canvas', async ({ page }) => {
@@ -576,10 +723,7 @@ test.describe('Desktop library scanning', () => {
                     protocolName: '',
                     sequenceName: '',
                     scanningSequence: '',
-                    mrAcquisitionType: '',
-                    tr: 0,
-                    te: 0,
-                    fieldStrength: 0
+                    mrAcquisitionType: ''
                 },
                 pixelSpacing: { row: 0.5, col: 0.25 },
                 isBlank: false,

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -448,6 +448,253 @@ test.describe('Desktop library scanning', () => {
         expect(result.frame1).toBeGreaterThan(result.frame0);
     });
 
+    test('decodeDicom returns the normalized intermediate contract for uncompressed CT data', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const buffer = new ArrayBuffer(16 * 2);
+            const pixels = new Uint16Array(buffer);
+            pixels.set(Array.from({ length: 16 }, (_, index) => 1000 + (index * 10)));
+
+            const dataSet = {
+                byteArray: new Uint8Array(buffer),
+                elements: {
+                    x7fe00010: {
+                        dataOffset: 0,
+                        length: buffer.byteLength
+                    }
+                },
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'CT',
+                        x00280004: 'MONOCHROME2',
+                        x00280030: '0.7\\0.8',
+                        x00281050: '40',
+                        x00281051: '400',
+                        x00281052: '-1024',
+                        x00281053: '2'
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    const values = {
+                        x00280010: 4,
+                        x00280011: 4,
+                        x00280100: 16,
+                        x00280103: 0,
+                        x00280002: 1
+                    };
+                    return values[tag];
+                }
+            };
+
+            const decoded = await window.DicomViewerApp.rendering.decodeDicom(dataSet, 0);
+            return {
+                rows: decoded.rows,
+                cols: decoded.cols,
+                bitsAllocated: decoded.bitsAllocated,
+                pixelRepresentation: decoded.pixelRepresentation,
+                samplesPerPixel: decoded.samplesPerPixel,
+                photometricInterpretation: decoded.photometricInterpretation,
+                windowCenter: decoded.windowCenter,
+                windowWidth: decoded.windowWidth,
+                rescaleSlope: decoded.rescaleSlope,
+                rescaleIntercept: decoded.rescaleIntercept,
+                modality: decoded.modality,
+                transferSyntax: decoded.transferSyntax,
+                pixelDataType: decoded.pixelData.constructor.name,
+                pixelDataLength: decoded.pixelData.length,
+                pixelSpacing: decoded.pixelSpacing,
+                isBlank: decoded.isBlank,
+                skipWindowLevel: decoded.skipWindowLevel,
+                mrMetadataKeys: Object.keys(decoded.mrMetadata).sort()
+            };
+        });
+
+        expect(result).toMatchObject({
+            rows: 4,
+            cols: 4,
+            bitsAllocated: 16,
+            pixelRepresentation: 0,
+            samplesPerPixel: 1,
+            photometricInterpretation: 'MONOCHROME2',
+            windowCenter: 40,
+            windowWidth: 400,
+            rescaleSlope: 2,
+            rescaleIntercept: -1024,
+            modality: 'CT',
+            transferSyntax: '1.2.840.10008.1.2.1',
+            pixelDataType: 'Uint16Array',
+            pixelDataLength: 16,
+            pixelSpacing: { row: 0.7, col: 0.8 },
+            isBlank: false,
+            skipWindowLevel: false
+        });
+        expect(result.mrMetadataKeys).toEqual(expect.arrayContaining([
+            'echoTime',
+            'fieldStrength',
+            'flipAngle',
+            'magneticFieldStrength',
+            'protocolName',
+            'repetitionTime',
+            'sequenceName',
+            'te',
+            'tr'
+        ]));
+    });
+
+    test('renderPixels renders a hand-constructed decode contract to the canvas', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const { state, rendering } = window.DicomViewerApp;
+            state.baseWindowLevel = { center: null, width: null };
+            state.pixelSpacing = null;
+
+            const info = rendering.renderPixels({
+                pixelData: new Uint16Array([0, 1000, 2000, 3000]),
+                rows: 2,
+                cols: 2,
+                bitsAllocated: 16,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 1500,
+                windowWidth: 3000,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                modality: 'CT',
+                transferSyntax: '1.2.840.10008.1.2.1',
+                mrMetadata: {
+                    repetitionTime: 0,
+                    echoTime: 0,
+                    flipAngle: 0,
+                    magneticFieldStrength: 0,
+                    protocolName: '',
+                    sequenceName: '',
+                    scanningSequence: '',
+                    mrAcquisitionType: '',
+                    tr: 0,
+                    te: 0,
+                    fieldStrength: 0
+                },
+                pixelSpacing: { row: 0.5, col: 0.25 },
+                isBlank: false,
+                skipWindowLevel: false
+            });
+
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+            const imageData = Array.from(ctx.getImageData(0, 0, 2, 2).data);
+
+            return {
+                info,
+                canvasSize: { width: canvas.width, height: canvas.height },
+                firstChannel: imageData.filter((_, index) => index % 4 === 0),
+                alphaChannel: imageData.filter((_, index) => index % 4 === 3),
+                baseWindowLevel: state.baseWindowLevel,
+                pixelSpacing: state.pixelSpacing
+            };
+        });
+
+        expect(result.info).toMatchObject({
+            rows: 2,
+            cols: 2,
+            wc: 1500,
+            ww: 3000,
+            transferSyntax: '1.2.840.10008.1.2.1',
+            modality: 'CT'
+        });
+        expect(result.canvasSize).toEqual({ width: 2, height: 2 });
+        expect(result.firstChannel).toEqual([0, 85, 170, 255]);
+        expect(result.alphaChannel).toEqual([255, 255, 255, 255]);
+        expect(result.baseWindowLevel).toEqual({ center: 1500, width: 3000 });
+        expect(result.pixelSpacing).toEqual({ row: 0.5, col: 0.25 });
+    });
+
+    test('renderDicom matches decodeDicom plus renderPixels for a known slice', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            function createDataSet() {
+                const buffer = new ArrayBuffer(16 * 2);
+                const pixels = new Uint16Array(buffer);
+                pixels.set(Array.from({ length: 16 }, (_, index) => index * 256));
+
+                return {
+                    byteArray: new Uint8Array(buffer),
+                    elements: {
+                        x7fe00010: {
+                            dataOffset: 0,
+                            length: buffer.byteLength
+                        }
+                    },
+                    string(tag) {
+                        const values = {
+                            x00020010: '1.2.840.10008.1.2.1',
+                            x00080060: 'CT',
+                            x00280004: 'MONOCHROME2',
+                            x00280030: '0.9\\0.9',
+                            x00281050: '128',
+                            x00281051: '256',
+                            x00281052: '0',
+                            x00281053: '1'
+                        };
+                        return values[tag] || '';
+                    },
+                    uint16(tag) {
+                        const values = {
+                            x00280010: 4,
+                            x00280011: 4,
+                            x00280100: 16,
+                            x00280103: 0,
+                            x00280002: 1
+                        };
+                        return values[tag];
+                    }
+                };
+            }
+
+            const { rendering, state } = window.DicomViewerApp;
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+            const override = { center: 1024, width: 2048 };
+
+            state.baseWindowLevel = { center: null, width: null };
+            state.pixelSpacing = null;
+            const decoded = await rendering.decodeDicom(createDataSet(), 0);
+            const splitInfo = rendering.renderPixels(decoded, override);
+            const splitPixels = Array.from(ctx.getImageData(0, 0, 4, 4).data);
+            const splitBaseWindowLevel = { ...state.baseWindowLevel };
+            const splitPixelSpacing = state.pixelSpacing ? { ...state.pixelSpacing } : null;
+
+            state.baseWindowLevel = { center: null, width: null };
+            state.pixelSpacing = null;
+            const wrapperInfo = await rendering.renderDicom(createDataSet(), override, 0);
+            const wrapperPixels = Array.from(ctx.getImageData(0, 0, 4, 4).data);
+
+            return {
+                splitInfo,
+                wrapperInfo,
+                splitPixels,
+                wrapperPixels,
+                splitBaseWindowLevel,
+                wrapperBaseWindowLevel: state.baseWindowLevel,
+                splitPixelSpacing,
+                wrapperPixelSpacing: state.pixelSpacing
+            };
+        });
+
+        expect(result.wrapperInfo).toEqual(result.splitInfo);
+        expect(result.wrapperPixels).toEqual(result.splitPixels);
+        expect(result.wrapperBaseWindowLevel).toEqual(result.splitBaseWindowLevel);
+        expect(result.wrapperPixelSpacing).toEqual(result.splitPixelSpacing);
+    });
+
     test('encapsulated frame extraction falls back for single-frame files with an empty basic offset table', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);


### PR DESCRIPTION
## Summary
- split the rendering pipeline into decodeDicom() and renderPixels() while keeping renderDicom() as the compatibility wrapper
- move calibration and overlay synchronization into the render phase so native-style decoded payloads can render without a dicomParser dataset
- add contract coverage for the decode intermediate, direct renderPixels() rendering, and wrapper parity

## Validation
- npx playwright test tests/desktop-library.spec.js
- npx playwright test