### PR TITLE
Move JPEG 2000 decode into a worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Tauri Desktop Shell (desktop/src-tauri/)
 | Uncompressed (Implicit/Explicit VR) | Supported | Native TypedArray |
 | JPEG Lossless | Supported | jpeg-lossless-decoder-js |
 | JPEG Baseline/Extended | Supported | Browser native |
-| JPEG 2000 | Supported | OpenJPEG WASM |
+| JPEG 2000 | Supported | OpenJPEG WASM (8/16/32-bit sample paths) |
 | RLE, JPEG-LS, MPEG | Not Supported | - |
 
 ## Current Work: 3D Volume Rendering

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -30,8 +30,8 @@
       "capabilities": [
         "main-capability"
       ],
-      "csp": "default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'",
-      "devCsp": "default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'"
+      "csp": "default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' 'wasm-unsafe-eval'",
+      "devCsp": "default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' 'wasm-unsafe-eval'"
     }
   },
   "bundle": {

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,9 +40,6 @@ Copyright (c) 2026 Divergent Health Technologies
     <!-- JPEG Lossless decoder for compressed DICOM images -->
     <script src="js/vendor/lossless.js"></script>
 
-    <!-- JPEG 2000 decoder (OpenJPEG compiled to WebAssembly) -->
-    <script src="js/openjpegwasm_decode.js"></script>
-
     <!-- Tauri runtime compatibility for plain-script desktop builds -->
     <script src="js/tauri-compat.js"></script>
 

--- a/docs/js/app/decode-worker.js
+++ b/docs/js/app/decode-worker.js
@@ -1,0 +1,127 @@
+const OPENJPEG_SCRIPT_URL = new URL('../openjpegwasm_decode.js', self.location.href).toString();
+let openjpegModulePromise = null;
+
+function resolveOpenJpegWorkerAssetUrl(fileName) {
+    return new URL(fileName, OPENJPEG_SCRIPT_URL).toString();
+}
+
+function loadOpenJpegWorkerScript() {
+    if (typeof OpenJPEGWASM === 'function') return;
+    importScripts(OPENJPEG_SCRIPT_URL);
+    if (typeof OpenJPEGWASM !== 'function') {
+        throw new Error('OpenJPEGWASM not found in the decode worker.');
+    }
+}
+
+async function initOpenJpegWorker() {
+    if (openjpegModulePromise) return openjpegModulePromise;
+
+    openjpegModulePromise = (async () => {
+        loadOpenJpegWorkerScript();
+        return OpenJPEGWASM({
+            locateFile: (path) => resolveOpenJpegWorkerAssetUrl(path)
+        });
+    })();
+
+    return openjpegModulePromise;
+}
+
+function createPixelArray(bitsPerSample, isSigned, sampleCount) {
+    if (bitsPerSample <= 8) {
+        return isSigned ? new Int8Array(sampleCount) : new Uint8Array(sampleCount);
+    }
+    if (bitsPerSample <= 16) {
+        return isSigned ? new Int16Array(sampleCount) : new Uint16Array(sampleCount);
+    }
+    if (bitsPerSample <= 32) {
+        return isSigned ? new Int32Array(sampleCount) : new Uint32Array(sampleCount);
+    }
+    throw new Error(`Unsupported JPEG 2000 bit depth: ${bitsPerSample}`);
+}
+
+function copyDecodedPixels(decoded, frameInfo, bitsAllocated, pixelRepresentation) {
+    const bitsPerSample = Number.isFinite(frameInfo?.bitsPerSample) && frameInfo.bitsPerSample > 0
+        ? frameInfo.bitsPerSample
+        : bitsAllocated;
+    const isSigned = typeof frameInfo?.isSigned === 'boolean'
+        ? frameInfo.isSigned
+        : pixelRepresentation === 1;
+    const bytesPerSample = Math.max(1, Math.ceil(bitsPerSample / 8));
+
+    if (![1, 2, 4].includes(bytesPerSample)) {
+        throw new Error(`Unsupported JPEG 2000 sample width: ${bytesPerSample} bytes`);
+    }
+
+    const sampleCount = decoded.byteLength / bytesPerSample;
+    if (!Number.isInteger(sampleCount)) {
+        throw new Error('Decoded JPEG 2000 buffer length is not aligned to the sample width.');
+    }
+
+    if (bytesPerSample === 1) {
+        return isSigned ? new Int8Array(decoded) : new Uint8Array(decoded);
+    }
+
+    const view = new DataView(decoded.buffer, decoded.byteOffset, decoded.byteLength);
+    const pixelData = createPixelArray(bitsPerSample, isSigned, sampleCount);
+
+    for (let i = 0; i < sampleCount; i++) {
+        const offset = i * bytesPerSample;
+        if (bytesPerSample === 2) {
+            pixelData[i] = isSigned ? view.getInt16(offset, true) : view.getUint16(offset, true);
+        } else {
+            pixelData[i] = isSigned ? view.getInt32(offset, true) : view.getUint32(offset, true);
+        }
+    }
+
+    return pixelData;
+}
+
+self.onmessage = async (event) => {
+    const payload = event?.data || {};
+    if (payload.type !== 'decode-j2k') return;
+
+    let decoder = null;
+
+    try {
+        const openjpeg = await initOpenJpegWorker();
+        decoder = new openjpeg.J2KDecoder();
+
+        const encodedBuffer = decoder.getEncodedBuffer(payload.frameData.length);
+        encodedBuffer.set(payload.frameData);
+        decoder.decode();
+
+        const decoded = decoder.getDecodedBuffer();
+        const frameInfo = decoder.getFrameInfo();
+
+        if (payload.expectedRows && frameInfo?.height && frameInfo.height !== payload.expectedRows) {
+            console.warn('JPEG 2000 worker decoded unexpected height:', frameInfo.height, payload.expectedRows);
+        }
+        if (payload.expectedCols && frameInfo?.width && frameInfo.width !== payload.expectedCols) {
+            console.warn('JPEG 2000 worker decoded unexpected width:', frameInfo.width, payload.expectedCols);
+        }
+
+        const pixelData = copyDecodedPixels(
+            decoded,
+            frameInfo,
+            payload.bitsAllocated,
+            payload.pixelRepresentation
+        );
+
+        self.postMessage(
+            {
+                type: 'decoded',
+                pixelData,
+                frameInfo
+            },
+            [pixelData.buffer]
+        );
+    } catch (error) {
+        self.postMessage({
+            type: 'error',
+            stage: 'decode',
+            message: String(error?.message || error || 'Unknown JPEG 2000 worker error')
+        });
+    } finally {
+        decoder?.delete();
+    }
+};

--- a/docs/js/app/decode-worker.js
+++ b/docs/js/app/decode-worker.js
@@ -23,7 +23,12 @@ async function initOpenJpegWorker() {
         });
     })();
 
-    return openjpegModulePromise;
+    try {
+        return await openjpegModulePromise;
+    } catch (error) {
+        openjpegModulePromise = null;
+        throw error;
+    }
 }
 
 function createPixelArray(bitsPerSample, isSigned, sampleCount) {
@@ -46,6 +51,7 @@ function copyDecodedPixels(decoded, frameInfo, bitsAllocated, pixelRepresentatio
     const isSigned = typeof frameInfo?.isSigned === 'boolean'
         ? frameInfo.isSigned
         : pixelRepresentation === 1;
+    // Some parametric maps and NM SUV studies use 32-bit samples; keep them intact.
     const bytesPerSample = Math.max(1, Math.ceil(bitsPerSample / 8));
 
     if (![1, 2, 4].includes(bytesPerSample)) {
@@ -110,6 +116,7 @@ self.onmessage = async (event) => {
         self.postMessage(
             {
                 type: 'decoded',
+                requestId: payload.requestId,
                 pixelData,
                 frameInfo
             },
@@ -118,6 +125,7 @@ self.onmessage = async (event) => {
     } catch (error) {
         self.postMessage({
             type: 'error',
+            requestId: payload.requestId,
             stage: 'decode',
             message: String(error?.message || error || 'Unknown JPEG 2000 worker error')
         });

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -388,10 +388,7 @@
     // JPEG 2000 Decoding (OpenJPEG WebAssembly)
     // ---------------------------------------------------------------------
 
-    /** Cached OpenJPEG WASM module instance */
-    let openjpegModule = null;
-    /** Promise for OpenJPEG initialization (prevents multiple init) */
-    let openjpegInitPromise = null;
+    const JPEG2000_DECODE_TIMEOUT_MS = 10000;
 
     function resolveOpenJpegAssetUrl(fileName, runtime = window) {
         const scriptSrc = runtime?.document
@@ -418,34 +415,96 @@
         return `js/${fileName}`;
     }
 
-    /**
-     * Initialize the OpenJPEG WebAssembly decoder
-     * Lazily loaded on first JPEG 2000 image
-     * @returns {Promise<Object>} Initialized OpenJPEG module
-     */
-    async function initOpenJPEG() {
-        if (openjpegModule) return openjpegModule;
-        if (openjpegInitPromise) return openjpegInitPromise;
-
-        openjpegInitPromise = (async () => {
+    function resolveJpeg2000WorkerUrl(runtime = window) {
+        const href = runtime?.location?.href;
+        if (href) {
             try {
-                console.log('Initializing OpenJPEG WASM...');
-                // OpenJPEGWASM is loaded from the script tag
-                if (typeof OpenJPEGWASM === 'function') {
-                    openjpegModule = await OpenJPEGWASM({
-                        locateFile: (path) => resolveOpenJpegAssetUrl(path)
-                    });
-                    console.log('OpenJPEG WASM initialized successfully');
-                    return openjpegModule;
-                }
-                throw new Error('OpenJPEGWASM not found');
+                return new URL('js/app/decode-worker.js', href).toString();
             } catch (e) {
-                console.error('Failed to initialize OpenJPEG:', e);
-                throw e;
+                console.warn('Failed to resolve JPEG 2000 worker URL from page URL:', href, e);
             }
-        })();
+        }
 
-        return openjpegInitPromise;
+        return 'js/app/decode-worker.js';
+    }
+
+    function decodeJ2KInWorker(frameData, bitsAllocated, pixelRepresentation, expectedRows, expectedCols) {
+        return new Promise((resolve, reject) => {
+            if (typeof Worker !== 'function') {
+                reject(new Error('Web Workers are not available for JPEG 2000 decode.'));
+                return;
+            }
+
+            const worker = new Worker(resolveJpeg2000WorkerUrl());
+            let settled = false;
+
+            function finish(callback, value) {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
+                worker.terminate();
+                callback(value);
+            }
+
+            const timeoutId = setTimeout(() => {
+                finish(reject, new Error(`JPEG 2000 decode timeout (${JPEG2000_DECODE_TIMEOUT_MS / 1000}s)`));
+            }, JPEG2000_DECODE_TIMEOUT_MS);
+
+            worker.onmessage = (event) => {
+                const payload = event?.data || {};
+                if (payload.type === 'error') {
+                    finish(reject, new Error(payload.message || 'JPEG 2000 worker decode failed'));
+                    return;
+                }
+                if (payload.type !== 'decoded' || !payload.pixelData) {
+                    finish(reject, new Error('JPEG 2000 worker returned an invalid response.'));
+                    return;
+                }
+
+                if (payload.frameInfo?.width && expectedCols && payload.frameInfo.width !== expectedCols) {
+                    console.warn(
+                        'JPEG 2000 worker width mismatch:',
+                        payload.frameInfo.width,
+                        'expected',
+                        expectedCols
+                    );
+                }
+                if (payload.frameInfo?.height && expectedRows && payload.frameInfo.height !== expectedRows) {
+                    console.warn(
+                        'JPEG 2000 worker height mismatch:',
+                        payload.frameInfo.height,
+                        'expected',
+                        expectedRows
+                    );
+                }
+
+                finish(resolve, payload.pixelData);
+            };
+
+            worker.onerror = (event) => {
+                finish(reject, event?.error || new Error(event?.message || 'JPEG 2000 worker error'));
+            };
+
+            // getEncapsulatedFrameData() returns a view into the parsed dataset buffer.
+            // Transfer a copy so we do not detach the cached dicomParser dataset bytes.
+            const frameDataCopy = new Uint8Array(frameData);
+
+            try {
+                worker.postMessage(
+                    {
+                        type: 'decode-j2k',
+                        frameData: frameDataCopy,
+                        bitsAllocated,
+                        pixelRepresentation,
+                        expectedRows,
+                        expectedCols
+                    },
+                    [frameDataCopy.buffer]
+                );
+            } catch (error) {
+                finish(reject, error);
+            }
+        });
     }
 
     /**
@@ -478,44 +537,13 @@
             const j2kData = getEncapsulatedFrameData(dataSet, jp2DataElement, frameIndex);
             console.log('JPEG 2000 data length:', j2kData.length, 'bytes');
 
-            // Initialize and use OpenJPEG decoder
-            const oj = await initOpenJPEG();
-
-            // Use the J2KDecoder class from the WASM module
-            const decoder = new oj.J2KDecoder();
-            const encodedBuffer = decoder.getEncodedBuffer(j2kData.length);
-            encodedBuffer.set(j2kData);
-
-            decoder.decode();
-
-            const decoded = decoder.getDecodedBuffer();
-            const frameInfo = decoder.getFrameInfo();
-
-            console.log('JPEG 2000 decoded:', frameInfo.width, 'x', frameInfo.height,
-                        'components:', frameInfo.componentCount, 'bpp:', frameInfo.bitsPerSample);
-
-            // Copy decoded data to a new array before cleanup
-            let pixelData;
-            if (frameInfo.bitsPerSample > 8) {
-                if (frameInfo.isSigned) {
-                    pixelData = new Int16Array(decoded.length / 2);
-                    const view = new DataView(decoded.buffer, decoded.byteOffset, decoded.byteLength);
-                    for (let i = 0; i < pixelData.length; i++) {
-                        pixelData[i] = view.getInt16(i * 2, true);
-                    }
-                } else {
-                    pixelData = new Uint16Array(decoded.length / 2);
-                    const view = new DataView(decoded.buffer, decoded.byteOffset, decoded.byteLength);
-                    for (let i = 0; i < pixelData.length; i++) {
-                        pixelData[i] = view.getUint16(i * 2, true);
-                    }
-                }
-            } else {
-                pixelData = new Uint8Array(decoded);
-            }
-
-            decoder.delete();
-            return pixelData;
+            return await decodeJ2KInWorker(
+                j2kData,
+                bitsAllocated,
+                pixelRepresentation,
+                rows,
+                cols
+            );
 
         } catch (e) {
             console.error('JPEG 2000 decode error:', e);
@@ -577,8 +605,10 @@
         displayBlankSlice,
         decodeJpegLossless,
         decodeJpeg2000,
+        decodeJ2KInWorker,
         decodeJpegBaseline,
         isRenderableImageMetadata,
-        resolveOpenJpegAssetUrl
+        resolveOpenJpegAssetUrl,
+        resolveJpeg2000WorkerUrl
     };
 })();

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -389,20 +389,15 @@
     // ---------------------------------------------------------------------
 
     const JPEG2000_DECODE_TIMEOUT_MS = 10000;
+    let nextJpeg2000RequestId = 1;
+    const jpeg2000WorkerState = {
+        worker: null,
+        workerUrl: null,
+        activeRequest: null,
+        queue: []
+    };
 
     function resolveOpenJpegAssetUrl(fileName, runtime = window) {
-        const scriptSrc = runtime?.document
-            ?.querySelector('script[src$="js/openjpegwasm_decode.js"], script[src*="openjpegwasm_decode.js"]')
-            ?.src;
-
-        if (scriptSrc) {
-            try {
-                return new URL(fileName, scriptSrc).toString();
-            } catch (e) {
-                console.warn('Failed to resolve OpenJPEG asset from script URL:', scriptSrc, e);
-            }
-        }
-
         const href = runtime?.location?.href;
         if (href) {
             try {
@@ -428,82 +423,173 @@
         return 'js/app/decode-worker.js';
     }
 
-    function decodeJ2KInWorker(frameData, bitsAllocated, pixelRepresentation, expectedRows, expectedCols) {
-        return new Promise((resolve, reject) => {
-            if (typeof Worker !== 'function') {
-                reject(new Error('Web Workers are not available for JPEG 2000 decode.'));
+    function disposeJpeg2000Worker() {
+        if (!jpeg2000WorkerState.worker) return;
+        try {
+            jpeg2000WorkerState.worker.terminate();
+        } catch {}
+        jpeg2000WorkerState.worker = null;
+        jpeg2000WorkerState.workerUrl = null;
+    }
+
+    function formatJpeg2000WorkerError(event, workerUrl) {
+        const eventMessage = event?.error?.message || event?.message || 'JPEG 2000 worker error';
+        return new Error(`${eventMessage} (${workerUrl})`);
+    }
+
+    function pumpJpeg2000WorkerQueue() {
+        if (jpeg2000WorkerState.activeRequest || !jpeg2000WorkerState.queue.length) {
+            return;
+        }
+
+        if (typeof Worker === 'undefined') {
+            const error = new Error('Web Workers are not available for JPEG 2000 decode.');
+            while (jpeg2000WorkerState.queue.length) {
+                jpeg2000WorkerState.queue.shift().reject(error);
+            }
+            return;
+        }
+
+        if (!jpeg2000WorkerState.worker) {
+            jpeg2000WorkerState.workerUrl = resolveJpeg2000WorkerUrl();
+            try {
+                jpeg2000WorkerState.worker = new Worker(jpeg2000WorkerState.workerUrl);
+            } catch (error) {
+                jpeg2000WorkerState.worker = null;
+                while (jpeg2000WorkerState.queue.length) {
+                    jpeg2000WorkerState.queue.shift().reject(error);
+                }
                 return;
             }
 
-            const worker = new Worker(resolveJpeg2000WorkerUrl());
-            let settled = false;
-
-            function finish(callback, value) {
-                if (settled) return;
-                settled = true;
-                clearTimeout(timeoutId);
-                worker.terminate();
-                callback(value);
-            }
-
-            const timeoutId = setTimeout(() => {
-                finish(reject, new Error(`JPEG 2000 decode timeout (${JPEG2000_DECODE_TIMEOUT_MS / 1000}s)`));
-            }, JPEG2000_DECODE_TIMEOUT_MS);
-
-            worker.onmessage = (event) => {
+            jpeg2000WorkerState.worker.onmessage = (event) => {
                 const payload = event?.data || {};
+                const activeRequest = jpeg2000WorkerState.activeRequest;
+                if (!activeRequest) {
+                    return;
+                }
+                if (payload.requestId !== activeRequest.requestId) {
+                    clearTimeout(activeRequest.timeoutId);
+                    jpeg2000WorkerState.activeRequest = null;
+                    disposeJpeg2000Worker();
+                    activeRequest.reject(new Error('JPEG 2000 worker returned an unexpected response.'));
+                    pumpJpeg2000WorkerQueue();
+                    return;
+                }
                 if (payload.type === 'error') {
-                    finish(reject, new Error(payload.message || 'JPEG 2000 worker decode failed'));
+                    clearTimeout(activeRequest.timeoutId);
+                    jpeg2000WorkerState.activeRequest = null;
+                    activeRequest.reject(new Error(payload.message || 'JPEG 2000 worker decode failed'));
+                    pumpJpeg2000WorkerQueue();
                     return;
                 }
                 if (payload.type !== 'decoded' || !payload.pixelData) {
-                    finish(reject, new Error('JPEG 2000 worker returned an invalid response.'));
+                    clearTimeout(activeRequest.timeoutId);
+                    jpeg2000WorkerState.activeRequest = null;
+                    disposeJpeg2000Worker();
+                    activeRequest.reject(new Error('JPEG 2000 worker returned an invalid response.'));
+                    pumpJpeg2000WorkerQueue();
                     return;
                 }
 
-                if (payload.frameInfo?.width && expectedCols && payload.frameInfo.width !== expectedCols) {
+                if (payload.frameInfo?.width && activeRequest.expectedCols && payload.frameInfo.width !== activeRequest.expectedCols) {
                     console.warn(
                         'JPEG 2000 worker width mismatch:',
                         payload.frameInfo.width,
                         'expected',
-                        expectedCols
+                        activeRequest.expectedCols
                     );
                 }
-                if (payload.frameInfo?.height && expectedRows && payload.frameInfo.height !== expectedRows) {
+                if (payload.frameInfo?.height && activeRequest.expectedRows && payload.frameInfo.height !== activeRequest.expectedRows) {
                     console.warn(
                         'JPEG 2000 worker height mismatch:',
                         payload.frameInfo.height,
                         'expected',
-                        expectedRows
+                        activeRequest.expectedRows
                     );
                 }
 
-                finish(resolve, payload.pixelData);
+                clearTimeout(activeRequest.timeoutId);
+                jpeg2000WorkerState.activeRequest = null;
+                activeRequest.resolve(payload.pixelData);
+                pumpJpeg2000WorkerQueue();
             };
 
-            worker.onerror = (event) => {
-                finish(reject, event?.error || new Error(event?.message || 'JPEG 2000 worker error'));
+            jpeg2000WorkerState.worker.onerror = (event) => {
+                const activeRequest = jpeg2000WorkerState.activeRequest;
+                if (activeRequest) {
+                    clearTimeout(activeRequest.timeoutId);
+                    jpeg2000WorkerState.activeRequest = null;
+                }
+
+                const error = formatJpeg2000WorkerError(event, jpeg2000WorkerState.workerUrl);
+                disposeJpeg2000Worker();
+                activeRequest?.reject(error);
+                pumpJpeg2000WorkerQueue();
             };
+        }
+
+        const request = jpeg2000WorkerState.queue.shift();
+        jpeg2000WorkerState.activeRequest = request;
+        request.timeoutId = setTimeout(() => {
+            if (jpeg2000WorkerState.activeRequest?.requestId !== request.requestId) {
+                return;
+            }
+            jpeg2000WorkerState.activeRequest = null;
+            disposeJpeg2000Worker();
+            request.reject(
+                new Error(
+                    `JPEG 2000 decode timeout (${JPEG2000_DECODE_TIMEOUT_MS / 1000}s, ${request.frameByteLength} bytes)`
+                )
+            );
+            pumpJpeg2000WorkerQueue();
+        }, JPEG2000_DECODE_TIMEOUT_MS);
+
+        try {
+            jpeg2000WorkerState.worker.postMessage(
+                {
+                    type: 'decode-j2k',
+                    requestId: request.requestId,
+                    frameData: request.frameData,
+                    bitsAllocated: request.bitsAllocated,
+                    pixelRepresentation: request.pixelRepresentation,
+                    expectedRows: request.expectedRows,
+                    expectedCols: request.expectedCols
+                },
+                [request.frameData.buffer]
+            );
+        } catch (error) {
+            clearTimeout(request.timeoutId);
+            jpeg2000WorkerState.activeRequest = null;
+            disposeJpeg2000Worker();
+            request.reject(error);
+            pumpJpeg2000WorkerQueue();
+        }
+    }
+
+    function decodeJ2KInWorker(frameData, bitsAllocated, pixelRepresentation, expectedRows, expectedCols) {
+        return new Promise((resolve, reject) => {
+            if (typeof Worker === 'undefined') {
+                reject(new Error('Web Workers are not available for JPEG 2000 decode.'));
+                return;
+            }
 
             // getEncapsulatedFrameData() returns a view into the parsed dataset buffer.
             // Transfer a copy so we do not detach the cached dicomParser dataset bytes.
             const frameDataCopy = new Uint8Array(frameData);
-
-            try {
-                worker.postMessage(
-                    {
-                        type: 'decode-j2k',
-                        frameData: frameDataCopy,
-                        bitsAllocated,
-                        pixelRepresentation,
-                        expectedRows,
-                        expectedCols
-                    },
-                    [frameDataCopy.buffer]
-                );
-            } catch (error) {
-                finish(reject, error);
-            }
+            jpeg2000WorkerState.queue.push({
+                requestId: nextJpeg2000RequestId++,
+                frameData: frameDataCopy,
+                frameByteLength: frameDataCopy.byteLength,
+                bitsAllocated,
+                pixelRepresentation,
+                expectedRows,
+                expectedCols,
+                resolve,
+                reject,
+                timeoutId: null
+            });
+            pumpJpeg2000WorkerQueue();
         });
     }
 

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -1,6 +1,8 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
 
 const HOME_URL = 'http://127.0.0.1:5001/';
 
@@ -261,4 +263,12 @@ test('OpenJPEG asset URL resolves when the decoder bundle is worker-loaded', asy
     const result = await page.evaluate(() => window.DicomViewerApp.dicom.resolveOpenJpegAssetUrl('openjpegwasm_decode.wasm'));
 
     expect(result).toMatch(/\/js\/openjpegwasm_decode\.wasm$/);
+});
+
+test('desktop CSP allows the JPEG 2000 worker to load OpenJPEG WASM', async () => {
+    const tauriConfigPath = path.join(__dirname, '..', 'desktop', 'src-tauri', 'tauri.conf.json');
+    const tauriConfig = JSON.parse(fs.readFileSync(tauriConfigPath, 'utf8'));
+
+    expect(tauriConfig.app.security.csp).toContain("worker-src 'self' 'wasm-unsafe-eval'");
+    expect(tauriConfig.app.security.devCsp).toContain("worker-src 'self' 'wasm-unsafe-eval'");
 });

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -255,7 +255,7 @@ test('tauri runtime shim installs when internals arrive after the script loads',
     expect(result.hasFsApi).toBe(true);
 });
 
-test('OpenJPEG asset URL resolves relative to the decoder script', async ({ page }) => {
+test('OpenJPEG asset URL resolves when the decoder bundle is worker-loaded', async ({ page }) => {
     await page.goto('http://127.0.0.1:5001/?nolib');
 
     const result = await page.evaluate(() => window.DicomViewerApp.dicom.resolveOpenJpegAssetUrl('openjpegwasm_decode.wasm'));

--- a/tests/jpeg2000-worker.spec.js
+++ b/tests/jpeg2000-worker.spec.js
@@ -1,8 +1,12 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
 
 const HOME_URL = 'http://127.0.0.1:5001/?nolib';
+const MR2_J2K_PATH = path.join(__dirname, '..', 'test-data', 'mri-samples', 'MR2_J2KI.dcm');
+const MR2_UNCOMPRESSED_PATH = path.join(__dirname, '..', 'test-data', 'mri-samples', 'MR2_UNCI.dcm');
 
 test('JPEG 2000 worker URL resolves relative to the app root and the decoder is no longer eagerly loaded', async ({ page }) => {
     await page.goto(HOME_URL);
@@ -16,24 +20,29 @@ test('JPEG 2000 worker URL resolves relative to the app root and the decoder is 
     expect(result.hasDecoderScriptTag).toBe(false);
 });
 
-test('decodeJ2KInWorker posts a copied frame buffer to the worker and resolves decoded pixels', async ({ page }) => {
+test('decodeJ2KInWorker reuses a persistent worker and posts copied frame buffers', async ({ page }) => {
     await page.goto(HOME_URL);
 
     const result = await page.evaluate(async () => {
         const originalWorker = window.Worker;
-        const sourceFrame = new Uint8Array([1, 2, 3, 4]);
+        const firstSourceFrame = new Uint8Array([1, 2, 3, 4]);
+        const secondSourceFrame = new Uint8Array([5, 6, 7, 8]);
         const calls = [];
+        let workerCount = 0;
+        let terminatedCount = 0;
 
         class FakeWorker {
             constructor(url) {
                 this.url = url;
-                this.terminated = false;
+                workerCount += 1;
             }
 
             postMessage(payload, transferList) {
+                const workerCallNumber = calls.length + 1;
                 calls.push({
+                    requestId: payload.requestId,
                     url: this.url,
-                    copiedBuffer: payload.frameData.buffer !== sourceFrame.buffer,
+                    copiedBuffer: payload.frameData.buffer !== (workerCallNumber === 1 ? firstSourceFrame.buffer : secondSourceFrame.buffer),
                     transferCount: transferList.length,
                     transferByteLength: transferList[0]?.byteLength || 0
                 });
@@ -42,7 +51,13 @@ test('decodeJ2KInWorker posts a copied frame buffer to the worker and resolves d
                     this.onmessage?.({
                         data: {
                             type: 'decoded',
-                            pixelData: new Uint16Array([11, 22, 33, 44]),
+                            requestId: payload.requestId,
+                            pixelData: new Uint16Array([
+                                workerCallNumber,
+                                workerCallNumber + 10,
+                                workerCallNumber + 20,
+                                workerCallNumber + 30
+                            ]),
                             frameInfo: { width: 2, height: 2 }
                         }
                     });
@@ -50,36 +65,48 @@ test('decodeJ2KInWorker posts a copied frame buffer to the worker and resolves d
             }
 
             terminate() {
-                this.terminated = true;
-                if (calls.length) {
-                    calls[calls.length - 1].terminated = true;
-                }
+                terminatedCount += 1;
             }
         }
 
         window.Worker = FakeWorker;
 
         try {
-            const pixelData = await window.DicomViewerApp.dicom.decodeJ2KInWorker(sourceFrame, 16, 0, 2, 2);
+            const firstPixelData = await window.DicomViewerApp.dicom.decodeJ2KInWorker(firstSourceFrame, 16, 0, 2, 2);
+            const secondPixelData = await window.DicomViewerApp.dicom.decodeJ2KInWorker(secondSourceFrame, 16, 0, 2, 2);
             return {
-                workerCall: calls[0],
-                pixelDataType: pixelData.constructor.name,
-                pixelValues: Array.from(pixelData),
-                sourceFrame: Array.from(sourceFrame)
+                workerCount,
+                terminatedCount,
+                workerCalls: calls,
+                firstPixelDataType: firstPixelData.constructor.name,
+                secondPixelDataType: secondPixelData.constructor.name,
+                firstPixelValues: Array.from(firstPixelData),
+                secondPixelValues: Array.from(secondPixelData),
+                firstSourceFrame: Array.from(firstSourceFrame),
+                secondSourceFrame: Array.from(secondSourceFrame)
             };
         } finally {
             window.Worker = originalWorker;
         }
     });
 
-    expect(result.workerCall.url).toMatch(/\/js\/app\/decode-worker\.js$/);
-    expect(result.workerCall.copiedBuffer).toBe(true);
-    expect(result.workerCall.transferCount).toBe(1);
-    expect(result.workerCall.transferByteLength).toBe(4);
-    expect(result.workerCall.terminated).toBe(true);
-    expect(result.pixelDataType).toBe('Uint16Array');
-    expect(result.pixelValues).toEqual([11, 22, 33, 44]);
-    expect(result.sourceFrame).toEqual([1, 2, 3, 4]);
+    expect(result.workerCount).toBe(1);
+    expect(result.terminatedCount).toBe(0);
+    expect(result.workerCalls).toHaveLength(2);
+    expect(result.workerCalls[0].url).toMatch(/\/js\/app\/decode-worker\.js$/);
+    expect(result.workerCalls[0].requestId).not.toBe(result.workerCalls[1].requestId);
+    expect(result.workerCalls[0].copiedBuffer).toBe(true);
+    expect(result.workerCalls[1].copiedBuffer).toBe(true);
+    expect(result.workerCalls[0].transferCount).toBe(1);
+    expect(result.workerCalls[1].transferCount).toBe(1);
+    expect(result.workerCalls[0].transferByteLength).toBe(4);
+    expect(result.workerCalls[1].transferByteLength).toBe(4);
+    expect(result.firstPixelDataType).toBe('Uint16Array');
+    expect(result.secondPixelDataType).toBe('Uint16Array');
+    expect(result.firstPixelValues).toEqual([1, 11, 21, 31]);
+    expect(result.secondPixelValues).toEqual([2, 12, 22, 32]);
+    expect(result.firstSourceFrame).toEqual([1, 2, 3, 4]);
+    expect(result.secondSourceFrame).toEqual([5, 6, 7, 8]);
 });
 
 test('decodeJ2KInWorker times out and terminates a hanging worker', async ({ page }) => {
@@ -117,5 +144,147 @@ test('decodeJ2KInWorker times out and terminates a hanging worker', async ({ pag
     });
 
     expect(result.errorMessage).toContain('JPEG 2000 decode timeout');
+    expect(result.errorMessage).toContain('3 bytes');
     expect(result.terminated).toBe(true);
+});
+
+test('decodeJ2KInWorker includes the worker URL when the worker fails to load', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const originalWorker = window.Worker;
+        let terminated = false;
+
+        class BrokenWorker {
+            constructor() {
+                queueMicrotask(() => {
+                    this.onerror?.({ message: 'Script error.' });
+                });
+            }
+
+            postMessage() {}
+
+            terminate() {
+                terminated = true;
+            }
+        }
+
+        window.Worker = BrokenWorker;
+
+        try {
+            let errorMessage = null;
+            try {
+                await window.DicomViewerApp.dicom.decodeJ2KInWorker(new Uint8Array([1]), 16, 0, 1, 1);
+            } catch (error) {
+                errorMessage = String(error?.message || error);
+            }
+
+            return { errorMessage, terminated };
+        } finally {
+            window.Worker = originalWorker;
+        }
+    });
+
+    expect(result.errorMessage).toContain('Script error.');
+    expect(result.errorMessage).toContain('/js/app/decode-worker.js');
+    expect(result.terminated).toBe(true);
+});
+
+test('decodeJpeg2000 decodes a real JPEG 2000 DICOM to the same pixels as its uncompressed companion', async ({ page }) => {
+    const jpeg2000Bytes = Array.from(fs.readFileSync(MR2_J2K_PATH));
+    const uncompressedBytes = Array.from(fs.readFileSync(MR2_UNCOMPRESSED_PATH));
+
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async ({ jpeg2000Bytes, uncompressedBytes }) => {
+        function toUint8Array(bytes) {
+            return new Uint8Array(bytes);
+        }
+
+        function readUncompressedPixels(dataSet, sampleCount) {
+            const pixelElement = dataSet.elements.x7fe00010;
+            const view = new DataView(
+                dataSet.byteArray.buffer,
+                dataSet.byteArray.byteOffset + pixelElement.dataOffset,
+                sampleCount * 2
+            );
+            const pixels = new Uint16Array(sampleCount);
+            for (let i = 0; i < sampleCount; i++) {
+                pixels[i] = view.getUint16(i * 2, true);
+            }
+            return pixels;
+        }
+
+        const jpeg2000DataSet = dicomParser.parseDicom(toUint8Array(jpeg2000Bytes));
+        const uncompressedDataSet = dicomParser.parseDicom(toUint8Array(uncompressedBytes));
+        const rows = jpeg2000DataSet.uint16('x00280010');
+        const cols = jpeg2000DataSet.uint16('x00280011');
+        const sampleCount = rows * cols;
+        const bitsAllocated = jpeg2000DataSet.uint16('x00280100');
+        const pixelRepresentation = jpeg2000DataSet.uint16('x00280103');
+
+        const decodedPixels = await window.DicomViewerApp.dicom.decodeJpeg2000(
+            jpeg2000DataSet,
+            jpeg2000DataSet.elements.x7fe00010,
+            rows,
+            cols,
+            bitsAllocated,
+            pixelRepresentation
+        );
+        if (!decodedPixels) {
+            let workerErrorMessage = null;
+            try {
+                const frameData = window.DicomViewerApp.dicom.getEncapsulatedFrameData(
+                    jpeg2000DataSet,
+                    jpeg2000DataSet.elements.x7fe00010,
+                    0
+                );
+                await window.DicomViewerApp.dicom.decodeJ2KInWorker(
+                    frameData,
+                    bitsAllocated,
+                    pixelRepresentation,
+                    rows,
+                    cols
+                );
+            } catch (error) {
+                workerErrorMessage = String(error?.message || error);
+            }
+
+            return {
+                decodedType: null,
+                sampleCount,
+                allEqual: false,
+                firstEightDecoded: [],
+                firstEightNative: [],
+                checksumDecoded: null,
+                checksumNative: null,
+                workerErrorMessage
+            };
+        }
+
+        const nativePixels = readUncompressedPixels(uncompressedDataSet, sampleCount);
+
+        let allEqual = decodedPixels.length === nativePixels.length;
+        for (let i = 0; allEqual && i < decodedPixels.length; i++) {
+            if (decodedPixels[i] !== nativePixels[i]) {
+                allEqual = false;
+            }
+        }
+
+        return {
+            decodedType: decodedPixels.constructor.name,
+            sampleCount,
+            allEqual,
+            firstEightDecoded: Array.from(decodedPixels.slice(0, 8)),
+            firstEightNative: Array.from(nativePixels.slice(0, 8)),
+            checksumDecoded: decodedPixels.reduce((sum, value) => sum + value, 0),
+            checksumNative: nativePixels.reduce((sum, value) => sum + value, 0)
+        };
+    }, { jpeg2000Bytes, uncompressedBytes });
+    expect(result.decodedType).toBe('Uint16Array');
+    expect(result.sampleCount).toBe(1024 * 1024);
+    expect(result.allEqual).toBe(true);
+    expect(result.firstEightDecoded).toEqual(result.firstEightNative);
+    expect(result.checksumDecoded).toBe(result.checksumNative);
+    expect(result.workerErrorMessage || null).toBeNull();
 });

--- a/tests/jpeg2000-worker.spec.js
+++ b/tests/jpeg2000-worker.spec.js
@@ -1,0 +1,121 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+const { test, expect } = require('@playwright/test');
+
+const HOME_URL = 'http://127.0.0.1:5001/?nolib';
+
+test('JPEG 2000 worker URL resolves relative to the app root and the decoder is no longer eagerly loaded', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(() => ({
+        workerUrl: window.DicomViewerApp.dicom.resolveJpeg2000WorkerUrl(),
+        hasDecoderScriptTag: !!document.querySelector('script[src$="js/openjpegwasm_decode.js"], script[src*="openjpegwasm_decode.js"]')
+    }));
+
+    expect(result.workerUrl).toMatch(/\/js\/app\/decode-worker\.js$/);
+    expect(result.hasDecoderScriptTag).toBe(false);
+});
+
+test('decodeJ2KInWorker posts a copied frame buffer to the worker and resolves decoded pixels', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const originalWorker = window.Worker;
+        const sourceFrame = new Uint8Array([1, 2, 3, 4]);
+        const calls = [];
+
+        class FakeWorker {
+            constructor(url) {
+                this.url = url;
+                this.terminated = false;
+            }
+
+            postMessage(payload, transferList) {
+                calls.push({
+                    url: this.url,
+                    copiedBuffer: payload.frameData.buffer !== sourceFrame.buffer,
+                    transferCount: transferList.length,
+                    transferByteLength: transferList[0]?.byteLength || 0
+                });
+
+                queueMicrotask(() => {
+                    this.onmessage?.({
+                        data: {
+                            type: 'decoded',
+                            pixelData: new Uint16Array([11, 22, 33, 44]),
+                            frameInfo: { width: 2, height: 2 }
+                        }
+                    });
+                });
+            }
+
+            terminate() {
+                this.terminated = true;
+                if (calls.length) {
+                    calls[calls.length - 1].terminated = true;
+                }
+            }
+        }
+
+        window.Worker = FakeWorker;
+
+        try {
+            const pixelData = await window.DicomViewerApp.dicom.decodeJ2KInWorker(sourceFrame, 16, 0, 2, 2);
+            return {
+                workerCall: calls[0],
+                pixelDataType: pixelData.constructor.name,
+                pixelValues: Array.from(pixelData),
+                sourceFrame: Array.from(sourceFrame)
+            };
+        } finally {
+            window.Worker = originalWorker;
+        }
+    });
+
+    expect(result.workerCall.url).toMatch(/\/js\/app\/decode-worker\.js$/);
+    expect(result.workerCall.copiedBuffer).toBe(true);
+    expect(result.workerCall.transferCount).toBe(1);
+    expect(result.workerCall.transferByteLength).toBe(4);
+    expect(result.workerCall.terminated).toBe(true);
+    expect(result.pixelDataType).toBe('Uint16Array');
+    expect(result.pixelValues).toEqual([11, 22, 33, 44]);
+    expect(result.sourceFrame).toEqual([1, 2, 3, 4]);
+});
+
+test('decodeJ2KInWorker times out and terminates a hanging worker', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const originalWorker = window.Worker;
+        const originalSetTimeout = window.setTimeout;
+        let terminated = false;
+
+        class HangingWorker {
+            postMessage() {}
+
+            terminate() {
+                terminated = true;
+            }
+        }
+
+        window.Worker = HangingWorker;
+        window.setTimeout = (callback, _ms, ...args) => originalSetTimeout(callback, 0, ...args);
+
+        try {
+            let errorMessage = null;
+            try {
+                await window.DicomViewerApp.dicom.decodeJ2KInWorker(new Uint8Array([9, 8, 7]), 16, 0, 1, 1);
+            } catch (error) {
+                errorMessage = String(error?.message || error);
+            }
+
+            return { errorMessage, terminated };
+        } finally {
+            window.Worker = originalWorker;
+            window.setTimeout = originalSetTimeout;
+        }
+    });
+
+    expect(result.errorMessage).toContain('JPEG 2000 decode timeout');
+    expect(result.terminated).toBe(true);
+});


### PR DESCRIPTION
## Summary
- move JPEG 2000 decode off the main thread via a dedicated worker with termination-based timeout handling
- load the OpenJPEG WASM bundle inside the worker and stop eagerly loading the decoder script in index.html
- add focused coverage for worker URL resolution, copied frame transfer, and hanging-worker timeouts

## Validation
- npx playwright test tests/jpeg2000-worker.spec.js tests/desktop-runtime-compat.spec.js
- npx playwright test