### PR TITLE
Add native desktop decode frame commands

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -176,6 +176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteordered"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf2cd9424f5ff404aba1959c835cbc448ee8b689b870a9981c76c0fd46280e6"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +409,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,14 +539,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "dicom-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f6e9f0a581bffa2630b1bd381d8114b09b3f66d1ed76ab924104ad153e0c59"
+dependencies = [
+ "chrono",
+ "either",
+ "itertools",
+ "num-traits",
+ "safe-transmute",
+ "smallvec",
+ "snafu",
+]
+
+[[package]]
+name = "dicom-dictionary-std"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057250ea38d2e716cfde2f0c211f07c53be307c98b2bc6bf0e4f330f8e506968"
+dependencies = [
+ "dicom-core",
+ "once_cell",
+]
+
+[[package]]
+name = "dicom-encoding"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6076f4ef3627291ab2b5beecd2fde1df7f8e0219b8d1fe4ec45a773416409f13"
+dependencies = [
+ "byteordered",
+ "dicom-core",
+ "dicom-dictionary-std",
+ "encoding",
+ "snafu",
+]
+
+[[package]]
+name = "dicom-object"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e550fd9def08c12b64e0410e83cb491821767d62e59b74d8b960c12ebd51490"
+dependencies = [
+ "byteordered",
+ "dicom-core",
+ "dicom-dictionary-std",
+ "dicom-encoding",
+ "dicom-parser",
+ "dicom-transfer-syntax-registry",
+ "itertools",
+ "smallvec",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
+name = "dicom-parser"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73d8c380a0655e819adf06263b2144d0ac55120aa3a66f2f6848b15e3de93e8"
+dependencies = [
+ "dicom-core",
+ "dicom-dictionary-std",
+ "dicom-encoding",
+ "smallvec",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
+name = "dicom-pixeldata"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4400743debbc4a5433e4c581fe492b50c2e2a2adb0cbf1f1f246ef8d2037b8"
+dependencies = [
+ "byteorder",
+ "dicom-core",
+ "dicom-dictionary-std",
+ "dicom-encoding",
+ "dicom-object",
+ "dicom-transfer-syntax-registry",
+ "num-traits",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
+name = "dicom-transfer-syntax-registry"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b680acd7f349598f94f3291266196ed687150af5ff57691184a493e5cfce090d"
+dependencies = [
+ "byteordered",
+ "dicom-core",
+ "dicom-encoding",
+ "jpeg-decoder",
+ "jpeg-encoder",
+ "jpeg2k",
+ "jxl-oxide",
+ "lazy_static",
+ "tracing",
+]
+
+[[package]]
 name = "dicom-viewer-desktop"
 version = "0.1.0"
 dependencies = [
+ "dicom-core",
+ "dicom-dictionary-std",
+ "dicom-object",
+ "dicom-pixeldata",
+ "dicom-transfer-syntax-registry",
+ "serde",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-persisted-scope",
+ "tokio",
 ]
 
 [[package]]
@@ -635,6 +774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +798,70 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "equivalent"
@@ -1485,6 +1694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1754,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "jpeg-encoder"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b454d911ac55068f53495488d8ccd0646eaa540c033a28ee15b07838afafb01f"
+
+[[package]]
+name = "jpeg2k"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2982db6b9f254c9df44d89bcfdc758924d538f576d9649f5b10008150f2a60"
+dependencies = [
+ "anyhow",
+ "log",
+ "openjpeg-sys",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1813,163 @@ dependencies = [
 ]
 
 [[package]]
+name = "jxl-bitstream"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "116184a8c915e99b08c7a4abca038b05863980bbf9e433dc2883363853c99afe"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-coding"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7ffdab0c48e989f23a8bd6113d88bd243ae45c7871e90cfdcb6997eacbfb2"
+dependencies = [
+ "jxl-bitstream",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-color"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4806c94be9e37c82e571684ad673af0a2e4049a74942c407034da6a087c4de7b"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-frame"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1649956cb002031108e1fa44e0e483a770e2e95f4544137788c32265db0b8c71"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-grid"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5739f02add3d5c00320140bec6f5a80fac4baa630f88fe4c6a55a0d719718ce3"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-image"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de3283303bb66b1742538f1a6947313596242598d6ddf325f301c2fbf01abd3"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-color",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-modular"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3f2fd5a3346deda8169f6b26aa6c955c32bd275377b527415ef2e5f362e00ad"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-oxide"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a42a404a09f4704e60ad102eb995ac074cad467df48631c1a1269b97eef3c5"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-oxide-common",
+ "jxl-render",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-oxide-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efb65a6ef812eae1083e5d2d1a4358bd74cf7e08d112f6e939a40003a6a9920"
+dependencies = [
+ "jxl-bitstream",
+]
+
+[[package]]
+name = "jxl-render"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b7162076893570cdeaced01086893df132ff8b2eaf22d63ed3b066d9b88739"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-threadpool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9c78eaf899cce165e266300f9963d8d376d4ed95cf4d12dd7066f05542cd88"
+dependencies = [
+ "rayon",
+ "rayon-core",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-vardct"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "737b4a65897907c644329c8a54e042cefdec2989e482698eea150d463e475fe5"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1991,12 @@ dependencies = [
  "indexmap 2.13.0",
  "selectors",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1973,6 +2381,16 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openjpeg-sys"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92682cb92e7b01e2c020cf8ec12f3374558924bb24621df1112d8a7c93d419ef"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "option-ext"
@@ -2438,6 +2856,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,6 +3016,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "safe-transmute"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
 name = "same-file"
@@ -2877,6 +3321,27 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "socket2"
@@ -3658,7 +4123,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -11,7 +11,14 @@ rust-version = "1.77.2"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+dicom-core = "0.9"
+dicom-dictionary-std = "0.9"
+dicom-object = "0.9"
+dicom-pixeldata = { version = "0.9", default-features = false }
+dicom-transfer-syntax-registry = { version = "0.9", features = ["openjpeg-sys"] }
+serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-persisted-scope = "2"
+tokio = { version = "1", features = ["sync", "time"] }

--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -13,9 +13,11 @@ use dicom_dictionary_std::tags;
 use dicom_object::{open_file, DefaultDicomObject};
 use dicom_pixeldata::{DecodedPixelData, PixelDecoder};
 use serde::Serialize;
-use tauri::{ipc::Response, State};
+use tauri::{ipc::Response, AppHandle, Runtime, State};
+use tauri_plugin_fs::FsExt;
 
 const DECODE_TIMEOUT_SECS: u64 = 30;
+const MAX_DECODE_STORE_ENTRIES: usize = 8;
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -35,49 +37,108 @@ pub struct DecodeFrameMetadata {
     pub pixel_data_length: usize,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct DecodedFrameMetadata {
+    rows: u16,
+    cols: u16,
+    bits_allocated: u16,
+    pixel_representation: u16,
+    samples_per_pixel: u16,
+    planar_configuration: u16,
+    photometric_interpretation: String,
+    window_center: Option<f64>,
+    window_width: Option<f64>,
+    rescale_slope: Option<f64>,
+    rescale_intercept: Option<f64>,
+    pixel_data_length: usize,
+}
+
+impl DecodedFrameMetadata {
+    fn into_response(self, decode_id: String) -> DecodeFrameMetadata {
+        DecodeFrameMetadata {
+            decode_id,
+            rows: self.rows,
+            cols: self.cols,
+            bits_allocated: self.bits_allocated,
+            pixel_representation: self.pixel_representation,
+            samples_per_pixel: self.samples_per_pixel,
+            planar_configuration: self.planar_configuration,
+            photometric_interpretation: self.photometric_interpretation,
+            window_center: self.window_center,
+            window_width: self.window_width,
+            rescale_slope: self.rescale_slope,
+            rescale_intercept: self.rescale_intercept,
+            pixel_data_length: self.pixel_data_length,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct DecodedFrame {
-    metadata: DecodeFrameMetadata,
+    metadata: DecodedFrameMetadata,
     pixel_bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+struct DecodeStoreEntries {
+    order: VecDeque<String>,
+    pixels_by_id: HashMap<String, Vec<u8>>,
 }
 
 #[derive(Default)]
 pub struct DecodeStore {
     next_id: AtomicU64,
-    entries: Mutex<HashMap<String, Vec<u8>>>,
+    entries: Mutex<DecodeStoreEntries>,
 }
 
 impl DecodeStore {
     fn insert(&self, pixel_bytes: Vec<u8>) -> String {
+        // Uniqueness only depends on atomicity here; we do not need cross-thread ordering.
         let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
         let decode_id = format!("decode-{id}");
-        self.entries
-            .lock()
-            .expect("decode store poisoned")
-            .insert(decode_id.clone(), pixel_bytes);
+        let mut entries = self.entries.lock().expect("decode store poisoned");
+        entries.pixels_by_id.insert(decode_id.clone(), pixel_bytes);
+        entries.order.push_back(decode_id.clone());
+
+        while entries.order.len() > MAX_DECODE_STORE_ENTRIES {
+            if let Some(stale_decode_id) = entries.order.pop_front() {
+                entries.pixels_by_id.remove(&stale_decode_id);
+            }
+        }
+
         decode_id
     }
 
     fn take(&self, decode_id: &str) -> Option<Vec<u8>> {
+        let mut entries = self.entries.lock().expect("decode store poisoned");
+        let pixel_bytes = entries.pixels_by_id.remove(decode_id)?;
+        if let Some(index) = entries.order.iter().position(|id| id == decode_id) {
+            entries.order.remove(index);
+        }
+        Some(pixel_bytes)
+    }
+
+    #[cfg(test)]
+    fn pending_count(&self) -> usize {
         self.entries
             .lock()
             .expect("decode store poisoned")
-            .remove(decode_id)
+            .pixels_by_id
+            .len()
     }
 }
 
 #[tauri::command]
-pub async fn decode_frame(
+pub async fn decode_frame<R: Runtime>(
+    app: AppHandle<R>,
     path: String,
     frame_index: u32,
     store: State<'_, DecodeStore>,
 ) -> Result<DecodeFrameMetadata, String> {
-    let decode_result = run_decode_with_timeout(path, frame_index).await?;
+    let scoped_path = validate_decode_path(&app, &path)?;
+    let decode_result = run_decode_with_timeout(scoped_path, frame_index).await?;
     let decode_id = store.insert(decode_result.pixel_bytes);
-    Ok(DecodeFrameMetadata {
-        decode_id,
-        ..decode_result.metadata
-    })
+    Ok(decode_result.metadata.into_response(decode_id))
 }
 
 #[tauri::command]
@@ -91,23 +152,46 @@ pub fn take_decoded_frame(
     Ok(Response::new(pixel_bytes))
 }
 
-async fn run_decode_with_timeout(path: String, frame_index: u32) -> Result<DecodedFrame, String> {
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(decode_frame_impl(&path, frame_index));
-    });
+async fn run_decode_with_timeout(path: PathBuf, frame_index: u32) -> Result<DecodedFrame, String> {
+    let decode_task = tokio::task::spawn_blocking(move || decode_frame_impl(&path, frame_index));
 
-    match tokio::time::timeout(Duration::from_secs(DECODE_TIMEOUT_SECS), rx).await {
+    match tokio::time::timeout(Duration::from_secs(DECODE_TIMEOUT_SECS), decode_task).await {
         Ok(Ok(result)) => result,
-        Ok(Err(_)) => Err("Native decode worker ended before producing a result.".into()),
+        Ok(Err(error)) => Err(format!(
+            "Native decode worker ended before producing a result: {error}"
+        )),
         Err(_) => Err(format!(
-            "Native decode timed out after {DECODE_TIMEOUT_SECS}s. The decode thread may still be running."
+            "Native decode timed out after {DECODE_TIMEOUT_SECS}s while waiting on the bounded blocking pool."
         )),
     }
 }
 
-fn decode_frame_impl(path: &str, frame_index: u32) -> Result<DecodedFrame, String> {
-    let object = open_file(path).map_err(|e| format!("Failed to open DICOM file {path}: {e}"))?;
+fn validate_decode_path<R: Runtime>(app: &AppHandle<R>, path: &str) -> Result<PathBuf, String> {
+    let requested_path = PathBuf::from(path);
+    if requested_path.as_os_str().is_empty() {
+        return Err("Decode path is empty.".into());
+    }
+    if !requested_path.is_absolute() {
+        return Err(format!("Decode path must be absolute: {path}"));
+    }
+
+    let canonical_path = requested_path
+        .canonicalize()
+        .map_err(|e| format!("Failed to open DICOM file {path}: {e}"))?;
+
+    if !app.fs_scope().is_allowed(&canonical_path) {
+        return Err(format!(
+            "Decode path is outside the allowed desktop file scope: {}",
+            canonical_path.display()
+        ));
+    }
+
+    Ok(canonical_path)
+}
+
+fn decode_frame_impl(path: &Path, frame_index: u32) -> Result<DecodedFrame, String> {
+    let object = open_file(path)
+        .map_err(|e| format!("Failed to open DICOM file {}: {e}", path.display()))?;
 
     let rows = required_u16(&object, tags::ROWS, "Rows")?;
     let cols = required_u16(&object, tags::COLUMNS, "Columns")?;
@@ -131,8 +215,7 @@ fn decode_frame_impl(path: &str, frame_index: u32) -> Result<DecodedFrame, Strin
     let pixel_bytes = decoded_pixels_to_bytes(decoded);
 
     Ok(DecodedFrame {
-        metadata: DecodeFrameMetadata {
-            decode_id: String::new(),
+        metadata: DecodedFrameMetadata {
             rows,
             cols,
             bits_allocated,
@@ -214,10 +297,26 @@ mod tests {
     }
 
     #[test]
+    fn decode_store_evicts_oldest_entries_when_capacity_is_exceeded() {
+        let store = DecodeStore::default();
+        let mut decode_ids = Vec::new();
+
+        for value in 0..=MAX_DECODE_STORE_ENTRIES {
+            decode_ids.push(store.insert(vec![value as u8]));
+        }
+
+        assert_eq!(store.pending_count(), MAX_DECODE_STORE_ENTRIES);
+        assert_eq!(store.take(&decode_ids[0]), None);
+        assert_eq!(
+            store.take(decode_ids.last().unwrap()),
+            Some(vec![MAX_DECODE_STORE_ENTRIES as u8])
+        );
+    }
+
+    #[test]
     fn decode_frame_impl_decodes_real_jpeg2000_fixture() {
         let fixture = fixture_path("test-data/mri-samples/MR2_J2KI.dcm");
-        let decoded =
-            decode_frame_impl(fixture.to_str().unwrap(), 0).expect("fixture should decode");
+        let decoded = decode_frame_impl(&fixture, 0).expect("fixture should decode");
 
         assert_eq!(decoded.metadata.rows, 1024);
         assert_eq!(decoded.metadata.cols, 1024);

--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -1,0 +1,234 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex,
+    },
+    time::Duration,
+};
+
+use dicom_core::Tag;
+use dicom_dictionary_std::tags;
+use dicom_object::{open_file, DefaultDicomObject};
+use dicom_pixeldata::{DecodedPixelData, PixelDecoder};
+use serde::Serialize;
+use tauri::{ipc::Response, State};
+
+const DECODE_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeFrameMetadata {
+    pub decode_id: String,
+    pub rows: u16,
+    pub cols: u16,
+    pub bits_allocated: u16,
+    pub pixel_representation: u16,
+    pub samples_per_pixel: u16,
+    pub planar_configuration: u16,
+    pub photometric_interpretation: String,
+    pub window_center: Option<f64>,
+    pub window_width: Option<f64>,
+    pub rescale_slope: Option<f64>,
+    pub rescale_intercept: Option<f64>,
+    pub pixel_data_length: usize,
+}
+
+#[derive(Debug)]
+struct DecodedFrame {
+    metadata: DecodeFrameMetadata,
+    pixel_bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+pub struct DecodeStore {
+    next_id: AtomicU64,
+    entries: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+impl DecodeStore {
+    fn insert(&self, pixel_bytes: Vec<u8>) -> String {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
+        let decode_id = format!("decode-{id}");
+        self.entries
+            .lock()
+            .expect("decode store poisoned")
+            .insert(decode_id.clone(), pixel_bytes);
+        decode_id
+    }
+
+    fn take(&self, decode_id: &str) -> Option<Vec<u8>> {
+        self.entries
+            .lock()
+            .expect("decode store poisoned")
+            .remove(decode_id)
+    }
+}
+
+#[tauri::command]
+pub async fn decode_frame(
+    path: String,
+    frame_index: u32,
+    store: State<'_, DecodeStore>,
+) -> Result<DecodeFrameMetadata, String> {
+    let decode_result = run_decode_with_timeout(path, frame_index).await?;
+    let decode_id = store.insert(decode_result.pixel_bytes);
+    Ok(DecodeFrameMetadata {
+        decode_id,
+        ..decode_result.metadata
+    })
+}
+
+#[tauri::command]
+pub fn take_decoded_frame(
+    decode_id: String,
+    store: State<'_, DecodeStore>,
+) -> Result<Response, String> {
+    let pixel_bytes = store
+        .take(&decode_id)
+        .ok_or_else(|| format!("Decoded frame not found: {decode_id}"))?;
+    Ok(Response::new(pixel_bytes))
+}
+
+async fn run_decode_with_timeout(path: String, frame_index: u32) -> Result<DecodedFrame, String> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(decode_frame_impl(&path, frame_index));
+    });
+
+    match tokio::time::timeout(Duration::from_secs(DECODE_TIMEOUT_SECS), rx).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => Err("Native decode worker ended before producing a result.".into()),
+        Err(_) => Err(format!(
+            "Native decode timed out after {DECODE_TIMEOUT_SECS}s. The decode thread may still be running."
+        )),
+    }
+}
+
+fn decode_frame_impl(path: &str, frame_index: u32) -> Result<DecodedFrame, String> {
+    let object = open_file(path).map_err(|e| format!("Failed to open DICOM file {path}: {e}"))?;
+
+    let rows = required_u16(&object, tags::ROWS, "Rows")?;
+    let cols = required_u16(&object, tags::COLUMNS, "Columns")?;
+    let bits_allocated = required_u16(&object, tags::BITS_ALLOCATED, "Bits Allocated")?;
+    let pixel_representation = get_u16(&object, tags::PIXEL_REPRESENTATION).unwrap_or_default();
+    let samples_per_pixel = get_u16(&object, tags::SAMPLES_PER_PIXEL).unwrap_or(1);
+    let planar_configuration = get_u16(&object, tags::PLANAR_CONFIGURATION).unwrap_or(0);
+    let photometric_interpretation =
+        get_text(&object, tags::PHOTOMETRIC_INTERPRETATION).unwrap_or_else(|| "MONOCHROME2".into());
+    let frame_count = get_u32(&object, tags::NUMBER_OF_FRAMES).unwrap_or(1);
+
+    if frame_index >= frame_count {
+        return Err(format!(
+            "Requested frame {frame_index} but dataset only has {frame_count} frame(s)."
+        ));
+    }
+
+    let decoded = object
+        .decode_pixel_data_frame(frame_index)
+        .map_err(|e| format!("Failed to decode frame {frame_index}: {e}"))?;
+    let pixel_bytes = decoded_pixels_to_bytes(decoded);
+
+    Ok(DecodedFrame {
+        metadata: DecodeFrameMetadata {
+            decode_id: String::new(),
+            rows,
+            cols,
+            bits_allocated,
+            pixel_representation,
+            samples_per_pixel,
+            planar_configuration,
+            photometric_interpretation,
+            window_center: get_first_f64(&object, tags::WINDOW_CENTER),
+            window_width: get_first_f64(&object, tags::WINDOW_WIDTH),
+            rescale_slope: get_first_f64(&object, tags::RESCALE_SLOPE),
+            rescale_intercept: get_first_f64(&object, tags::RESCALE_INTERCEPT),
+            pixel_data_length: pixel_bytes.len(),
+        },
+        pixel_bytes,
+    })
+}
+
+fn decoded_pixels_to_bytes(decoded: DecodedPixelData<'_>) -> Vec<u8> {
+    decoded.data().to_vec()
+}
+
+fn get_text(object: &DefaultDicomObject, tag: Tag) -> Option<String> {
+    object
+        .element_opt(tag)
+        .ok()
+        .flatten()
+        .and_then(|element| element.to_str().ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn get_u16(object: &DefaultDicomObject, tag: Tag) -> Option<u16> {
+    object
+        .element_opt(tag)
+        .ok()
+        .flatten()
+        .and_then(|element| element.to_int::<u16>().ok())
+}
+
+fn get_u32(object: &DefaultDicomObject, tag: Tag) -> Option<u32> {
+    object
+        .element_opt(tag)
+        .ok()
+        .flatten()
+        .and_then(|element| element.to_int::<u32>().ok())
+}
+
+fn required_u16(object: &DefaultDicomObject, tag: Tag, label: &str) -> Result<u16, String> {
+    get_u16(object, tag).ok_or_else(|| format!("Missing or invalid DICOM field: {label}"))
+}
+
+fn get_first_f64(object: &DefaultDicomObject, tag: Tag) -> Option<f64> {
+    object
+        .element_opt(tag)
+        .ok()
+        .flatten()
+        .and_then(|element| element.to_multi_float64().ok())
+        .and_then(|values| values.into_iter().next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_path(relative: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join(relative)
+    }
+
+    #[test]
+    fn decode_store_take_removes_entries() {
+        let store = DecodeStore::default();
+        let decode_id = store.insert(vec![1, 2, 3, 4]);
+
+        assert_eq!(store.take(&decode_id), Some(vec![1, 2, 3, 4]));
+        assert_eq!(store.take(&decode_id), None);
+    }
+
+    #[test]
+    fn decode_frame_impl_decodes_real_jpeg2000_fixture() {
+        let fixture = fixture_path("test-data/mri-samples/MR2_J2KI.dcm");
+        let decoded =
+            decode_frame_impl(fixture.to_str().unwrap(), 0).expect("fixture should decode");
+
+        assert_eq!(decoded.metadata.rows, 1024);
+        assert_eq!(decoded.metadata.cols, 1024);
+        assert_eq!(decoded.metadata.bits_allocated, 16);
+        assert_eq!(decoded.metadata.pixel_representation, 0);
+        assert_eq!(decoded.metadata.samples_per_pixel, 1);
+        assert_eq!(decoded.metadata.photometric_interpretation, "MONOCHROME2");
+        assert_eq!(decoded.metadata.pixel_data_length, 1024 * 1024 * 2);
+        assert_eq!(
+            decoded.pixel_bytes.len(),
+            decoded.metadata.pixel_data_length
+        );
+    }
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod decode;
+
 use tauri::{
     menu::{AboutMetadata, Menu, MenuItemBuilder, SubmenuBuilder},
     AppHandle, Emitter, Manager, Runtime,
@@ -17,7 +19,11 @@ fn build_menu<R: Runtime, M: Manager<R>>(manager: &M) -> tauri::Result<Menu<R>> 
         name: Some(package_info.name.clone()),
         version: Some(package_info.version.to_string()),
         copyright: config.bundle.copyright.clone(),
-        authors: config.bundle.publisher.clone().map(|publisher| vec![publisher]),
+        authors: config
+            .bundle
+            .publisher
+            .clone()
+            .map(|publisher| vec![publisher]),
         ..Default::default()
     };
 
@@ -70,6 +76,7 @@ fn emit_menu_event<R: Runtime>(app: &AppHandle<R>, event_name: &str) {
 
 fn main() {
     tauri::Builder::default()
+        .manage(decode::DecodeStore::default())
         .setup(|app| {
             let menu = build_menu(app)?;
             app.set_menu(menu)?;
@@ -78,6 +85,10 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_persisted_scope::init())
+        .invoke_handler(tauri::generate_handler![
+            decode::decode_frame,
+            decode::take_decoded_frame
+        ])
         .on_menu_event(|app, event| match event.id().as_ref() {
             MENU_OPEN_FOLDER => emit_menu_event(app, EVENT_OPEN_FOLDER),
             MENU_OPEN_HELP => emit_menu_event(app, EVENT_OPEN_HELP),

--- a/docs/index.html
+++ b/docs/index.html
@@ -201,6 +201,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <script src="js/app/rendering.js"></script>
     <script src="js/app/sources.js"></script>
     <script src="js/app/desktop-library.js"></script>
+    <script src="js/app/desktop-decode.js"></script>
     <script src="js/app/notes-reports.js"></script>
     <script src="js/app/help-viewer.js"></script>
     <script src="js/app/viewer.js"></script>

--- a/docs/js/app/desktop-decode.js
+++ b/docs/js/app/desktop-decode.js
@@ -1,6 +1,19 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
 
+    function describeBinaryPayload(payload) {
+        if (payload === null) {
+            return 'null';
+        }
+        if (typeof payload !== 'object') {
+            return typeof payload;
+        }
+
+        const tag = Object.prototype.toString.call(payload);
+        const keys = Object.keys(payload);
+        return keys.length > 0 ? `${tag} keys=${keys.join(',')}` : tag;
+    }
+
     function normalizeBinaryResponse(bytes) {
         if (bytes instanceof Uint8Array) {
             return bytes;
@@ -8,7 +21,47 @@
         if (bytes instanceof ArrayBuffer) {
             return new Uint8Array(bytes);
         }
-        return Uint8Array.from(bytes || []);
+        if (bytes?.buffer instanceof ArrayBuffer && typeof bytes.byteLength === 'number') {
+            return new Uint8Array(bytes.buffer, bytes.byteOffset || 0, bytes.byteLength);
+        }
+        if (Array.isArray(bytes)) {
+            return Uint8Array.from(bytes);
+        }
+        if (bytes && Object.prototype.hasOwnProperty.call(bytes, 'data')) {
+            return normalizeBinaryResponse(bytes.data);
+        }
+
+        throw new Error(`Unexpected decoded frame payload shape: ${describeBinaryPayload(bytes)}`);
+    }
+
+    function getPixelDataArrayType(bitsAllocated, pixelRepresentation) {
+        if (bitsAllocated <= 8) {
+            return pixelRepresentation === 1 ? Int8Array : Uint8Array;
+        }
+        if (bitsAllocated <= 16) {
+            return pixelRepresentation === 1 ? Int16Array : Uint16Array;
+        }
+        if (bitsAllocated <= 32) {
+            return pixelRepresentation === 1 ? Int32Array : Uint32Array;
+        }
+        throw new Error(`Unsupported Bits Allocated value from native decode: ${bitsAllocated}`);
+    }
+
+    function coercePixelData(bytes, bitsAllocated, pixelRepresentation) {
+        if (!Number.isFinite(bitsAllocated) || bitsAllocated <= 0 || bitsAllocated % 8 !== 0) {
+            throw new Error(`Native decode returned a non-byte-aligned Bits Allocated value: ${bitsAllocated}`);
+        }
+
+        const bytesPerSample = bitsAllocated / 8;
+        if (bytes.byteLength % bytesPerSample !== 0) {
+            throw new Error(
+                `Decoded frame payload length ${bytes.byteLength} is not aligned to ${bitsAllocated}-bit samples.`
+            );
+        }
+
+        const sampleCount = bytes.byteLength / bytesPerSample;
+        const PixelArrayType = getPixelDataArrayType(bitsAllocated, pixelRepresentation);
+        return new PixelArrayType(bytes.buffer, bytes.byteOffset, sampleCount).slice();
     }
 
     const DesktopDecode = {
@@ -31,7 +84,18 @@
 
         async decodeFrameWithPixels(path, frameIndex = 0) {
             const metadata = await this.decodeFrame(path, frameIndex);
-            const pixelData = await this.takeDecodedFrame(metadata.decodeId);
+            const pixelBytes = await this.takeDecodedFrame(metadata.decodeId);
+            if (Number.isFinite(metadata.pixelDataLength) && metadata.pixelDataLength !== pixelBytes.byteLength) {
+                throw new Error(
+                    `Decoded frame payload length mismatch: expected ${metadata.pixelDataLength} byte(s), received ${pixelBytes.byteLength}.`
+                );
+            }
+
+            const pixelData = coercePixelData(
+                pixelBytes,
+                Number(metadata.bitsAllocated),
+                Number(metadata.pixelRepresentation)
+            );
             return {
                 ...metadata,
                 pixelData

--- a/docs/js/app/desktop-decode.js
+++ b/docs/js/app/desktop-decode.js
@@ -1,0 +1,43 @@
+(() => {
+    const app = window.DicomViewerApp = window.DicomViewerApp || {};
+
+    function normalizeBinaryResponse(bytes) {
+        if (bytes instanceof Uint8Array) {
+            return bytes;
+        }
+        if (bytes instanceof ArrayBuffer) {
+            return new Uint8Array(bytes);
+        }
+        return Uint8Array.from(bytes || []);
+    }
+
+    const DesktopDecode = {
+        getRuntime() {
+            const tauri = window.__TAURI__;
+            if (typeof tauri?.core?.invoke !== 'function') {
+                throw new Error('Desktop decode runtime is not ready. Quit and reopen the app if this persists.');
+            }
+            return tauri;
+        },
+
+        decodeFrame(path, frameIndex = 0) {
+            return this.getRuntime().core.invoke('decode_frame', { path, frameIndex });
+        },
+
+        async takeDecodedFrame(decodeId) {
+            const bytes = await this.getRuntime().core.invoke('take_decoded_frame', { decodeId });
+            return normalizeBinaryResponse(bytes);
+        },
+
+        async decodeFrameWithPixels(path, frameIndex = 0) {
+            const metadata = await this.decodeFrame(path, frameIndex);
+            const pixelData = await this.takeDecodedFrame(metadata.decodeId);
+            return {
+                ...metadata,
+                pixelData
+            };
+        }
+    };
+
+    app.desktopDecode = DesktopDecode;
+})();

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -145,6 +145,9 @@
             core: {
                 convertFileSrc(filePath, protocol) {
                     return internals.convertFileSrc(filePath, protocol);
+                },
+                invoke(command, args, options) {
+                    return invoke(command, args, options);
                 }
             },
             dialog: {

--- a/tests/desktop-native-decode.spec.js
+++ b/tests/desktop-native-decode.spec.js
@@ -4,14 +4,32 @@ const { test, expect } = require('@playwright/test');
 
 const HOME_URL = 'http://127.0.0.1:5001/?nolib';
 
-async function installMockDesktopDecode(page) {
-    await page.addInitScript(() => {
+async function installMockDesktopDecode(page, options = {}) {
+    await page.addInitScript((opts) => {
         let callbackId = 1;
         const callbacks = new Map();
-        const decodedFrames = new Map([
-            ['decode-1', new Uint8Array([0x34, 0x12, 0x78, 0x56]).buffer]
-        ]);
+        const defaultMetadata = {
+            decodeId: 'decode-1',
+            rows: 2,
+            cols: 1,
+            bitsAllocated: 16,
+            pixelRepresentation: 0,
+            samplesPerPixel: 1,
+            planarConfiguration: 0,
+            photometricInterpretation: 'MONOCHROME2',
+            windowCenter: 42,
+            windowWidth: 84,
+            rescaleSlope: 1,
+            rescaleIntercept: -1024,
+            pixelDataLength: 4
+        };
+        const metadata = { ...defaultMetadata, ...(opts.metadata || {}) };
+        const decodedFrames = new Map(
+            (opts.decodedFrames || [['decode-1', [0x34, 0x12, 0x78, 0x56]]])
+                .map(([decodeId, bytes]) => [decodeId, new Uint8Array(bytes).buffer])
+        );
         const invokeCalls = [];
+        const binaryResponseMode = opts.binaryResponseMode || 'data-object';
 
         window.__desktopDecodeInvokeCalls = invokeCalls;
 
@@ -44,23 +62,27 @@ async function installMockDesktopDecode(page) {
                     case 'plugin:event|unlisten':
                         return null;
                     case 'decode_frame':
-                        return {
-                            decodeId: 'decode-1',
-                            rows: 2,
-                            cols: 1,
-                            bitsAllocated: 16,
-                            pixelRepresentation: 0,
-                            samplesPerPixel: 1,
-                            planarConfiguration: 0,
-                            photometricInterpretation: 'MONOCHROME2',
-                            windowCenter: 42,
-                            windowWidth: 84,
-                            rescaleSlope: 1,
-                            rescaleIntercept: -1024,
-                            pixelDataLength: 4
-                        };
-                    case 'take_decoded_frame':
-                        return decodedFrames.get(args.decodeId);
+                        return metadata;
+                    case 'take_decoded_frame': {
+                        const frame = decodedFrames.get(args.decodeId);
+                        if (!frame) {
+                            throw new Error(`Decoded frame not found: ${args.decodeId}`);
+                        }
+
+                        if (binaryResponseMode === 'uint8array') {
+                            return new Uint8Array(frame);
+                        }
+                        if (binaryResponseMode === 'arraybuffer') {
+                            return frame;
+                        }
+                        if (binaryResponseMode === 'data-object') {
+                            return { data: Array.from(new Uint8Array(frame)) };
+                        }
+                        if (binaryResponseMode === 'invalid-object') {
+                            return { bogus: [1, 2, 3] };
+                        }
+                        throw new Error(`Unhandled binaryResponseMode: ${binaryResponseMode}`);
+                    }
                     default:
                         throw new Error(`Unhandled command: ${cmd}`);
                 }
@@ -72,10 +94,10 @@ async function installMockDesktopDecode(page) {
                 callbacks.delete(id);
             }
         };
-    });
+    }, options);
 }
 
-test('desktop decode bridge invokes native metadata and binary commands', async ({ page }) => {
+test('desktop decode bridge coerces LE bytes into unsigned 16-bit samples', async ({ page }) => {
     await installMockDesktopDecode(page);
     await page.goto(HOME_URL);
 
@@ -90,7 +112,7 @@ test('desktop decode bridge invokes native metadata and binary commands', async 
                 pixelDataLength: decoded.pixelDataLength
             },
             pixelDataType: decoded.pixelData.constructor.name,
-            pixelBytes: Array.from(decoded.pixelData),
+            pixelSamples: Array.from(decoded.pixelData),
             invokeCalls: window.__desktopDecodeInvokeCalls
                 .filter(call => !call.cmd.startsWith('plugin:'))
                 .map(call => ({ cmd: call.cmd, args: call.args }))
@@ -104,8 +126,8 @@ test('desktop decode bridge invokes native metadata and binary commands', async 
         bitsAllocated: 16,
         pixelDataLength: 4
     });
-    expect(result.pixelDataType).toBe('Uint8Array');
-    expect(result.pixelBytes).toEqual([0x34, 0x12, 0x78, 0x56]);
+    expect(result.pixelDataType).toBe('Uint16Array');
+    expect(result.pixelSamples).toEqual([0x1234, 0x5678]);
     expect(result.invokeCalls).toEqual([
         {
             cmd: 'decode_frame',
@@ -123,6 +145,27 @@ test('desktop decode bridge invokes native metadata and binary commands', async 
     ]);
 });
 
+test('desktop decode bridge preserves signed sample types', async ({ page }) => {
+    await installMockDesktopDecode(page, {
+        metadata: {
+            pixelRepresentation: 1
+        },
+        decodedFrames: [['decode-1', [0xfe, 0xff, 0x00, 0x80]]]
+    });
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const decoded = await window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/signed.dcm', 0);
+        return {
+            pixelDataType: decoded.pixelData.constructor.name,
+            pixelSamples: Array.from(decoded.pixelData)
+        };
+    });
+
+    expect(result.pixelDataType).toBe('Int16Array');
+    expect(result.pixelSamples).toEqual([-2, -32768]);
+});
+
 test('desktop decode bridge surfaces a runtime-ready error when invoke is unavailable', async ({ page }) => {
     await page.goto(HOME_URL);
 
@@ -136,4 +179,37 @@ test('desktop decode bridge surfaces a runtime-ready error when invoke is unavai
     });
 
     expect(message).toContain('Desktop decode runtime is not ready');
+});
+
+test('desktop decode bridge surfaces invalid decode ids', async ({ page }) => {
+    await installMockDesktopDecode(page);
+    await page.goto(HOME_URL);
+
+    const message = await page.evaluate(async () => {
+        try {
+            await window.DicomViewerApp.desktopDecode.takeDecodedFrame('missing-decode-id');
+            return null;
+        } catch (error) {
+            return String(error?.message || error);
+        }
+    });
+
+    expect(message).toContain('Decoded frame not found: missing-decode-id');
+});
+
+test('desktop decode bridge rejects malformed binary payloads', async ({ page }) => {
+    await installMockDesktopDecode(page, { binaryResponseMode: 'invalid-object' });
+    await page.goto(HOME_URL);
+
+    const message = await page.evaluate(async () => {
+        try {
+            await window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/bad-payload.dcm', 0);
+            return null;
+        } catch (error) {
+            return String(error?.message || error);
+        }
+    });
+
+    expect(message).toContain('Unexpected decoded frame payload shape');
+    expect(message).toContain('bogus');
 });

--- a/tests/desktop-native-decode.spec.js
+++ b/tests/desktop-native-decode.spec.js
@@ -1,0 +1,139 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+const { test, expect } = require('@playwright/test');
+
+const HOME_URL = 'http://127.0.0.1:5001/?nolib';
+
+async function installMockDesktopDecode(page) {
+    await page.addInitScript(() => {
+        let callbackId = 1;
+        const callbacks = new Map();
+        const decodedFrames = new Map([
+            ['decode-1', new Uint8Array([0x34, 0x12, 0x78, 0x56]).buffer]
+        ]);
+        const invokeCalls = [];
+
+        window.__desktopDecodeInvokeCalls = invokeCalls;
+
+        window.__TAURI_INTERNALS__ = {
+            metadata: {
+                currentWindow: { label: 'main' },
+                currentWebview: { label: 'main', windowLabel: 'main' }
+            },
+            convertFileSrc(filePath, protocol = 'asset') {
+                return `${protocol}://localhost/${encodeURIComponent(filePath)}`;
+            },
+            transformCallback(callback, once = false) {
+                const id = callbackId++;
+                callbacks.set(id, (payload) => {
+                    if (once) {
+                        callbacks.delete(id);
+                    }
+                    return callback(payload);
+                });
+                return id;
+            },
+            unregisterCallback(id) {
+                callbacks.delete(id);
+            },
+            async invoke(cmd, args) {
+                invokeCalls.push({ cmd, args });
+                switch (cmd) {
+                    case 'plugin:event|listen':
+                        return args.handler;
+                    case 'plugin:event|unlisten':
+                        return null;
+                    case 'decode_frame':
+                        return {
+                            decodeId: 'decode-1',
+                            rows: 2,
+                            cols: 1,
+                            bitsAllocated: 16,
+                            pixelRepresentation: 0,
+                            samplesPerPixel: 1,
+                            planarConfiguration: 0,
+                            photometricInterpretation: 'MONOCHROME2',
+                            windowCenter: 42,
+                            windowWidth: 84,
+                            rescaleSlope: 1,
+                            rescaleIntercept: -1024,
+                            pixelDataLength: 4
+                        };
+                    case 'take_decoded_frame':
+                        return decodedFrames.get(args.decodeId);
+                    default:
+                        throw new Error(`Unhandled command: ${cmd}`);
+                }
+            }
+        };
+
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+            unregisterListener(_event, id) {
+                callbacks.delete(id);
+            }
+        };
+    });
+}
+
+test('desktop decode bridge invokes native metadata and binary commands', async ({ page }) => {
+    await installMockDesktopDecode(page);
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const decoded = await window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/MR2_J2KI.dcm', 3);
+        return {
+            metadata: {
+                decodeId: decoded.decodeId,
+                rows: decoded.rows,
+                cols: decoded.cols,
+                bitsAllocated: decoded.bitsAllocated,
+                pixelDataLength: decoded.pixelDataLength
+            },
+            pixelDataType: decoded.pixelData.constructor.name,
+            pixelBytes: Array.from(decoded.pixelData),
+            invokeCalls: window.__desktopDecodeInvokeCalls
+                .filter(call => !call.cmd.startsWith('plugin:'))
+                .map(call => ({ cmd: call.cmd, args: call.args }))
+        };
+    });
+
+    expect(result.metadata).toEqual({
+        decodeId: 'decode-1',
+        rows: 2,
+        cols: 1,
+        bitsAllocated: 16,
+        pixelDataLength: 4
+    });
+    expect(result.pixelDataType).toBe('Uint8Array');
+    expect(result.pixelBytes).toEqual([0x34, 0x12, 0x78, 0x56]);
+    expect(result.invokeCalls).toEqual([
+        {
+            cmd: 'decode_frame',
+            args: {
+                path: '/mock/study/MR2_J2KI.dcm',
+                frameIndex: 3
+            }
+        },
+        {
+            cmd: 'take_decoded_frame',
+            args: {
+                decodeId: 'decode-1'
+            }
+        }
+    ]);
+});
+
+test('desktop decode bridge surfaces a runtime-ready error when invoke is unavailable', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const message = await page.evaluate(async () => {
+        try {
+            await window.DicomViewerApp.desktopDecode.decodeFrame('/mock/no-runtime.dcm', 0);
+            return null;
+        } catch (error) {
+            return String(error?.message || error);
+        }
+    });
+
+    expect(message).toContain('Desktop decode runtime is not ready');
+});

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -110,6 +110,7 @@ test('desktop runtime shim enables desktop mode when only __TAURI_INTERNALS__ is
     const result = await page.evaluate(() => ({
         deploymentMode: window.CONFIG.deploymentMode,
         hasGlobalTauri: typeof window.__TAURI__ !== 'undefined',
+        hasCoreInvoke: typeof window.__TAURI__?.core?.invoke === 'function',
         hasDialogApi: typeof window.__TAURI__?.dialog?.open === 'function',
         hasFsApi: typeof window.__TAURI__?.fs?.readDir === 'function',
         libraryConfigVisible: getComputedStyle(document.getElementById('libraryFolderConfig')).display !== 'none'
@@ -117,6 +118,7 @@ test('desktop runtime shim enables desktop mode when only __TAURI_INTERNALS__ is
 
     expect(result.deploymentMode).toBe('desktop');
     expect(result.hasGlobalTauri).toBe(true);
+    expect(result.hasCoreInvoke).toBe(true);
     expect(result.hasDialogApi).toBe(true);
     expect(result.hasFsApi).toBe(true);
     expect(result.libraryConfigVisible).toBe(true);
@@ -246,6 +248,7 @@ test('tauri runtime shim installs when internals arrive after the script loads',
         return {
             hasReadyPromise: typeof window.__DICOM_VIEWER_TAURI_READY__?.then === 'function',
             hasGlobalTauri: typeof window.__TAURI__ !== 'undefined',
+            hasCoreInvoke: typeof runtime?.core?.invoke === 'function',
             hasDialogApi: typeof runtime?.dialog?.open === 'function',
             hasFsApi: typeof runtime?.fs?.readDir === 'function'
         };
@@ -253,6 +256,7 @@ test('tauri runtime shim installs when internals arrive after the script loads',
 
     expect(result.hasReadyPromise).toBe(true);
     expect(result.hasGlobalTauri).toBe(true);
+    expect(result.hasCoreInvoke).toBe(true);
     expect(result.hasDialogApi).toBe(true);
     expect(result.hasFsApi).toBe(true);
 });


### PR DESCRIPTION
## Summary
- add native Tauri `decode_frame` and `take_decoded_frame` commands backed by dicom-rs pixel decoding with OpenJPEG support
- cache decoded frame bytes in-memory so metadata returns as JSON and pixels return as raw IPC bytes
- expose `core.invoke` through the desktop compat layer and add `desktopDecode` browser helpers for the two-phase contract
- add Rust coverage against a real JPEG 2000 fixture plus Playwright coverage for the desktop decode bridge and runtime shim

## Validation
- cargo test
- npx playwright test tests/desktop-runtime-compat.spec.js tests/desktop-native-decode.spec.js
- npx playwright test

## Notes
- this PR is stacked on top of #20 (`base: codex/j2k-worker-timeout`)
- the native decode path is added but not yet wired into viewer fallback policy; that wiring stays for the next PR
- `dicom-transfer-syntax-registry` is enabled with `openjpeg-sys`, so the desktop build now depends on a C toolchain during Cargo builds