### PR TITLE
Wire native desktop decode fallback into rendering

### DIFF
--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -19,6 +19,8 @@
         decodeJpeg2000,
         decodeJpegBaseline
     } = app.dicom;
+    // JPEG 2000 fluoroscopy/angiography studies are the desktop-native-first route because
+    // the browser WASM path has shown vendor-specific failures on these modalities.
     const HIGH_RISK_SYNTAXES = new Map([
         ['1.2.840.10008.1.2.4.90', new Set(['RF', 'XA'])],
         ['1.2.840.10008.1.2.4.91', new Set(['RF', 'XA'])]
@@ -142,6 +144,16 @@
         };
     }
 
+    function getOptionalNumber(dataSet, tag) {
+        const value = getString(dataSet, tag);
+        if (!value) {
+            return null;
+        }
+
+        const parsed = parseFloat(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
     function getMrMetadata(dataSet) {
         return {
             repetitionTime: getNumber(dataSet, 'x00180080', 0),     // (0018,0080) TR
@@ -157,12 +169,12 @@
 
     function resolveWindowLevel(dataSet, modality, preferredWindowCenter = null, preferredWindowWidth = null) {
         const modalityDefaults = getModalityDefaults(modality);
-        const storedWindowCenter = getNumber(dataSet, 'x00281050', 0);  // (0028,1050)
-        const storedWindowWidth = getNumber(dataSet, 'x00281051', 0);   // (0028,1051)
+        const storedWindowCenter = getOptionalNumber(dataSet, 'x00281050');  // (0028,1050)
+        const storedWindowWidth = getOptionalNumber(dataSet, 'x00281051');   // (0028,1051)
         const hasPreferredWindowLevel = Number.isFinite(preferredWindowCenter) &&
-            Number.isFinite(preferredWindowWidth) &&
-            (preferredWindowCenter !== 0 || preferredWindowWidth !== 0);
-        const hasStoredWindowLevel = storedWindowCenter !== 0 || storedWindowWidth !== 0;
+            Number.isFinite(preferredWindowWidth);
+        const hasStoredWindowLevel = Number.isFinite(storedWindowCenter) &&
+            Number.isFinite(storedWindowWidth);
         const hasWindowLevel = hasPreferredWindowLevel || hasStoredWindowLevel;
 
         let windowCenter = hasPreferredWindowLevel ? preferredWindowCenter : storedWindowCenter;
@@ -178,6 +190,27 @@
             windowWidth,
             hasWindowLevel
         };
+    }
+
+    function validateRenderedPixelData(decoded, sourceLabel = 'Decoded image') {
+        const expectedSampleCount = decoded.rows * decoded.cols * decoded.samplesPerPixel;
+        if (!Number.isInteger(expectedSampleCount) || expectedSampleCount <= 0) {
+            throw new Error(
+                `${sourceLabel} returned invalid dimensions (${decoded.rows}x${decoded.cols}) or Samples Per Pixel (${decoded.samplesPerPixel}).`
+            );
+        }
+
+        if (decoded.pixelData.length !== expectedSampleCount) {
+            throw new Error(
+                `${sourceLabel} returned ${decoded.pixelData.length} sample(s) for ${decoded.rows}x${decoded.cols} with ${decoded.samplesPerPixel} sample(s) per pixel; expected ${expectedSampleCount}.`
+            );
+        }
+
+        if (decoded.samplesPerPixel !== 1) {
+            throw new Error(
+                `${sourceLabel} returned ${decoded.samplesPerPixel} sample(s) per pixel, but the current renderer only supports monochrome fallback data.`
+            );
+        }
     }
 
     function finalizeDecodedImage(decoded, hasWindowLevel) {
@@ -221,27 +254,27 @@
         return String(error);
     }
 
-    function buildFallbackDecodeError(dataSet, jsError = null, nativeError = null) {
+    function buildFallbackDecodeError(dataSet, jsFailure = null, nativeFailure = null) {
         const transferSyntax = getString(dataSet, 'x00020010');
         const modality = getString(dataSet, 'x00080060');
         const tsInfo = getTransferSyntaxInfo(transferSyntax);
 
-        if (!nativeError && jsError?.error) {
+        if (!nativeFailure && jsFailure?.error) {
             return {
-                ...jsError,
-                stage: jsError.stage || 'decode',
-                transferSyntax: jsError.transferSyntax || transferSyntax,
-                modality: jsError.modality || modality,
-                tsInfo: jsError.tsInfo || tsInfo
+                ...jsFailure,
+                stage: jsFailure.stage || 'decode',
+                transferSyntax: jsFailure.transferSyntax || transferSyntax,
+                modality: jsFailure.modality || modality,
+                tsInfo: jsFailure.tsInfo || tsInfo
             };
         }
 
         const detailParts = [];
-        if (jsError) {
-            detailParts.push(`JS: ${getDecodeFailureMessage(jsError)}`);
+        if (jsFailure) {
+            detailParts.push(`JS: ${getDecodeFailureMessage(jsFailure)}`);
         }
-        if (nativeError) {
-            detailParts.push(`Native: ${getDecodeFailureMessage(nativeError)}`);
+        if (nativeFailure) {
+            detailParts.push(`Native: ${getDecodeFailureMessage(nativeFailure)}`);
         }
 
         return buildDecodeError(
@@ -252,14 +285,14 @@
                 transferSyntax,
                 modality,
                 tsInfo,
-                jsErrorMessage: jsError ? getDecodeFailureMessage(jsError) : null,
-                nativeErrorMessage: nativeError ? getDecodeFailureMessage(nativeError) : null
+                jsErrorMessage: jsFailure ? getDecodeFailureMessage(jsFailure) : null,
+                nativeErrorMessage: nativeFailure ? getDecodeFailureMessage(nativeFailure) : null
             }
         );
     }
 
     function canUseNativeDecode(slice) {
-        return config?.deploymentMode === 'desktop' &&
+        return config.deploymentMode === 'desktop' &&
             typeof slice?.source?.path === 'string' &&
             slice.source.path.length > 0 &&
             typeof app.desktopDecode?.decodeFrameWithPixels === 'function';
@@ -273,11 +306,14 @@
         return 'js-first';
     }
 
-    function renderDecodeError(errorInfo) {
+    function renderDecodeError(errorInfo, options = {}) {
+        const { display = true } = options;
         state.pixelSpacing = null;
         app.tools.updateCalibrationWarning();
-        displayError(errorInfo.errorMessage, errorInfo.errorDetails);
-        app.tools.drawMeasurements?.();
+        if (display) {
+            displayError(errorInfo.errorMessage, errorInfo.errorDetails);
+            app.tools.drawMeasurements?.();
+        }
         return errorInfo;
     }
 
@@ -431,6 +467,12 @@
         const nativeDecoded = await app.desktopDecode.decodeFrameWithPixels(filePath, frameIndex);
         const modality = getString(dataSet, 'x00080060');
         const transferSyntax = getString(dataSet, 'x00020010');
+        const photometricInterpretation = nativeDecoded.photometricInterpretation || getString(dataSet, 'x00280004');
+        const rows = Number(nativeDecoded.rows);
+        const cols = Number(nativeDecoded.cols);
+        const bitsAllocated = Number(nativeDecoded.bitsAllocated);
+        const pixelRepresentation = Number(nativeDecoded.pixelRepresentation);
+        const samplesPerPixel = Number(nativeDecoded.samplesPerPixel || 1);
         const {
             windowCenter,
             windowWidth,
@@ -447,9 +489,14 @@
         const rescaleIntercept = Number.isFinite(nativeDecoded.rescaleIntercept)
             ? nativeDecoded.rescaleIntercept
             : getNumber(dataSet, 'x00281052', 0);
-
-        return finalizeDecodedImage({
-            ...nativeDecoded,
+        const decoded = {
+            pixelData: nativeDecoded.pixelData,
+            rows,
+            cols,
+            bitsAllocated,
+            pixelRepresentation,
+            samplesPerPixel,
+            photometricInterpretation,
             windowCenter,
             windowWidth,
             rescaleSlope,
@@ -458,8 +505,13 @@
             transferSyntax,
             mrMetadata: getMrMetadata(dataSet),
             pixelSpacing: app.tools.extractPixelSpacing(dataSet),
-            skipWindowLevel: false
-        }, hasWindowLevel);
+            skipWindowLevel: bitsAllocated <= 8 &&
+                samplesPerPixel === 1 &&
+                photometricInterpretation !== 'MONOCHROME1' &&
+                photometricInterpretation !== 'MONOCHROME2'
+        };
+        validateRenderedPixelData(decoded, 'Native decode');
+        return finalizeDecodedImage(decoded, hasWindowLevel);
     }
 
     async function decodeWithFallback(dataSet, frameIndex = 0, slice = null) {
@@ -590,13 +642,17 @@
      * @param {Object|null} wlOverride - Optional {center, width} to override DICOM values
      * @returns {Promise<Object>} Rendering info {rows, cols, wc, ww, transferSyntax} or {error: true}
      */
-    async function renderDicom(dataSet, wlOverride = null, frameIndex = 0, slice = null) {
+    async function renderDicom(dataSet, wlOverride = null, frameIndex = 0, slice = null, options = {}) {
+        const { displayErrors = true } = options;
         const decoded = await decodeWithFallback(dataSet, frameIndex, slice);
         if (!decoded) {
-            return renderDecodeError(buildDecodeError('Image decode failed', 'Unknown decode error'));
+            return renderDecodeError(
+                buildDecodeError('Image decode failed', 'Unknown decode error'),
+                { display: displayErrors }
+            );
         }
         if (decoded.error) {
-            return renderDecodeError(decoded);
+            return renderDecodeError(decoded, { display: displayErrors });
         }
         return renderPixels(decoded, wlOverride);
     }

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -1,5 +1,6 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
+    const config = window.CONFIG;
     const { state } = app;
     const { canvas, ctx } = app.dom;
     const { getString, getNumber } = app.utils;
@@ -18,6 +19,10 @@
         decodeJpeg2000,
         decodeJpegBaseline
     } = app.dicom;
+    const HIGH_RISK_SYNTAXES = new Map([
+        ['1.2.840.10008.1.2.4.90', new Set(['RF', 'XA'])],
+        ['1.2.840.10008.1.2.4.91', new Set(['RF', 'XA'])]
+    ]);
 
     function getPixelDataArrayType(bitsAllocated, pixelRepresentation) {
         if (bitsAllocated <= 8) {
@@ -137,6 +142,137 @@
         };
     }
 
+    function getMrMetadata(dataSet) {
+        return {
+            repetitionTime: getNumber(dataSet, 'x00180080', 0),     // (0018,0080) TR
+            echoTime: getNumber(dataSet, 'x00180081', 0),          // (0018,0081) TE
+            flipAngle: getNumber(dataSet, 'x00181314', 0),         // (0018,1314) Flip Angle
+            magneticFieldStrength: getNumber(dataSet, 'x00180087', 0), // (0018,0087) Field Strength
+            protocolName: getString(dataSet, 'x00181030'),         // (0018,1030) Protocol Name
+            sequenceName: getString(dataSet, 'x00180024'),         // (0018,0024) Sequence Name
+            scanningSequence: getString(dataSet, 'x00180020'),     // (0018,0020) Scanning Sequence
+            mrAcquisitionType: getString(dataSet, 'x00180023')    // (0018,0023) MR Acquisition Type (2D/3D)
+        };
+    }
+
+    function resolveWindowLevel(dataSet, modality, preferredWindowCenter = null, preferredWindowWidth = null) {
+        const modalityDefaults = getModalityDefaults(modality);
+        const storedWindowCenter = getNumber(dataSet, 'x00281050', 0);  // (0028,1050)
+        const storedWindowWidth = getNumber(dataSet, 'x00281051', 0);   // (0028,1051)
+        const hasPreferredWindowLevel = Number.isFinite(preferredWindowCenter) &&
+            Number.isFinite(preferredWindowWidth) &&
+            (preferredWindowCenter !== 0 || preferredWindowWidth !== 0);
+        const hasStoredWindowLevel = storedWindowCenter !== 0 || storedWindowWidth !== 0;
+        const hasWindowLevel = hasPreferredWindowLevel || hasStoredWindowLevel;
+
+        let windowCenter = hasPreferredWindowLevel ? preferredWindowCenter : storedWindowCenter;
+        let windowWidth = hasPreferredWindowLevel ? preferredWindowWidth : storedWindowWidth;
+
+        if (!hasWindowLevel) {
+            windowCenter = modalityDefaults.windowCenter;
+            windowWidth = modalityDefaults.windowWidth;
+        }
+
+        return {
+            windowCenter,
+            windowWidth,
+            hasWindowLevel
+        };
+    }
+
+    function finalizeDecodedImage(decoded, hasWindowLevel) {
+        if (isBlankSlice(decoded.pixelData, decoded.rescaleSlope, decoded.rescaleIntercept)) {
+            console.log('Detected blank slice (all pixels same value)');
+            return {
+                ...decoded,
+                isBlank: true
+            };
+        }
+
+        let { windowCenter, windowWidth } = decoded;
+        if (!hasWindowLevel && (decoded.modality === 'MR' || decoded.modality === 'PT' || decoded.modality === 'NM')) {
+            const autoWL = calculateAutoWindowLevel(decoded.pixelData, decoded.rescaleSlope, decoded.rescaleIntercept);
+            windowCenter = autoWL.windowCenter;
+            windowWidth = autoWL.windowWidth;
+            console.log(`Auto window/level for ${decoded.modality}: C=${windowCenter} W=${windowWidth}`);
+        }
+
+        return {
+            ...decoded,
+            windowCenter,
+            windowWidth,
+            isBlank: false
+        };
+    }
+
+    function getDecodeFailureMessage(error) {
+        if (!error) {
+            return 'Unknown decode error';
+        }
+        if (typeof error === 'string') {
+            return error;
+        }
+        if (error.errorMessage) {
+            return error.errorDetails ? `${error.errorMessage}: ${error.errorDetails}` : error.errorMessage;
+        }
+        if (error.message) {
+            return error.message;
+        }
+        return String(error);
+    }
+
+    function buildFallbackDecodeError(dataSet, jsError = null, nativeError = null) {
+        const transferSyntax = getString(dataSet, 'x00020010');
+        const modality = getString(dataSet, 'x00080060');
+        const tsInfo = getTransferSyntaxInfo(transferSyntax);
+
+        if (!nativeError && jsError?.error) {
+            return {
+                ...jsError,
+                stage: jsError.stage || 'decode',
+                transferSyntax: jsError.transferSyntax || transferSyntax,
+                modality: jsError.modality || modality,
+                tsInfo: jsError.tsInfo || tsInfo
+            };
+        }
+
+        const detailParts = [];
+        if (jsError) {
+            detailParts.push(`JS: ${getDecodeFailureMessage(jsError)}`);
+        }
+        if (nativeError) {
+            detailParts.push(`Native: ${getDecodeFailureMessage(nativeError)}`);
+        }
+
+        return buildDecodeError(
+            'Image decode failed',
+            detailParts.join(' | ') || tsInfo.name,
+            {
+                stage: 'decode',
+                transferSyntax,
+                modality,
+                tsInfo,
+                jsErrorMessage: jsError ? getDecodeFailureMessage(jsError) : null,
+                nativeErrorMessage: nativeError ? getDecodeFailureMessage(nativeError) : null
+            }
+        );
+    }
+
+    function canUseNativeDecode(slice) {
+        return config?.deploymentMode === 'desktop' &&
+            typeof slice?.source?.path === 'string' &&
+            slice.source.path.length > 0 &&
+            typeof app.desktopDecode?.decodeFrameWithPixels === 'function';
+    }
+
+    function getDecodeRoute(transferSyntax, modality) {
+        const riskyModalities = HIGH_RISK_SYNTAXES.get(transferSyntax);
+        if (riskyModalities?.has(modality)) {
+            return 'native-first';
+        }
+        return 'js-first';
+    }
+
     function renderDecodeError(errorInfo) {
         state.pixelSpacing = null;
         app.tools.updateCalibrationWarning();
@@ -163,32 +299,17 @@
         const rescaleIntercept = getNumber(dataSet, 'x00281052', 0); // (0028,1052)
 
         // Window/level for display - use modality-appropriate defaults
-        const modalityDefaults = getModalityDefaults(modality);
-        let windowCenter = getNumber(dataSet, 'x00281050', 0);  // (0028,1050)
-        let windowWidth = getNumber(dataSet, 'x00281051', 0);   // (0028,1051)
-
-        // If window/level not in DICOM, use modality defaults
-        // (we'll potentially override with auto-calculation for MRI later)
-        const hasWindowLevel = windowCenter !== 0 || windowWidth !== 0;
-        if (!hasWindowLevel) {
-            windowCenter = modalityDefaults.windowCenter;
-            windowWidth = modalityDefaults.windowWidth;
-        }
+        const {
+            windowCenter,
+            windowWidth,
+            hasWindowLevel
+        } = resolveWindowLevel(dataSet, modality);
 
         // Extract pixel spacing for measurement calibration
         const pixelSpacing = app.tools.extractPixelSpacing(dataSet);
 
         // Extract MRI-specific metadata
-        const mrMetadata = {
-            repetitionTime: getNumber(dataSet, 'x00180080', 0),     // (0018,0080) TR
-            echoTime: getNumber(dataSet, 'x00180081', 0),          // (0018,0081) TE
-            flipAngle: getNumber(dataSet, 'x00181314', 0),         // (0018,1314) Flip Angle
-            magneticFieldStrength: getNumber(dataSet, 'x00180087', 0), // (0018,0087) Field Strength
-            protocolName: getString(dataSet, 'x00181030'),         // (0018,1030) Protocol Name
-            sequenceName: getString(dataSet, 'x00180024'),         // (0018,0024) Sequence Name
-            scanningSequence: getString(dataSet, 'x00180020'),     // (0018,0020) Scanning Sequence
-            mrAcquisitionType: getString(dataSet, 'x00180023')    // (0018,0023) MR Acquisition Type (2D/3D)
-        };
+        const mrMetadata = getMrMetadata(dataSet);
 
         // Get transfer syntax to determine compression format
         const transferSyntax = getString(dataSet, 'x00020010');  // (0002,0010)
@@ -282,40 +403,7 @@
             }
         }
 
-        // Check for blank/uniform slices (common in MPR reconstructions as padding)
-        // This must be done before window/level calculations
-        if (isBlankSlice(pixelData, rescaleSlope, rescaleIntercept)) {
-            console.log('Detected blank slice (all pixels same value)');
-            return {
-                pixelData,
-                rows,
-                cols,
-                bitsAllocated,
-                pixelRepresentation,
-                samplesPerPixel,
-                photometricInterpretation,
-                windowCenter,
-                windowWidth,
-                rescaleSlope,
-                rescaleIntercept,
-                transferSyntax, modality,
-                mrMetadata,
-                pixelSpacing,
-                isBlank: true,
-                skipWindowLevel
-            };
-        }
-
-        // For MRI without window/level in DICOM, calculate auto window/level
-        // based on actual pixel data statistics
-        if (!hasWindowLevel && (modality === 'MR' || modality === 'PT' || modality === 'NM')) {
-            const autoWL = calculateAutoWindowLevel(pixelData, rescaleSlope, rescaleIntercept);
-            windowCenter = autoWL.windowCenter;
-            windowWidth = autoWL.windowWidth;
-            console.log(`Auto window/level for ${modality}: C=${windowCenter} W=${windowWidth}`);
-        }
-
-        return {
+        return finalizeDecodedImage({
             pixelData,
             rows,
             cols,
@@ -331,9 +419,101 @@
             transferSyntax,
             mrMetadata,
             pixelSpacing,
-            isBlank: false,
             skipWindowLevel
-        };
+        }, hasWindowLevel);
+    }
+
+    async function decodeNative(dataSet, filePath, frameIndex = 0) {
+        if (!filePath) {
+            throw new Error('Native decode requires a desktop path-backed slice.');
+        }
+
+        const nativeDecoded = await app.desktopDecode.decodeFrameWithPixels(filePath, frameIndex);
+        const modality = getString(dataSet, 'x00080060');
+        const transferSyntax = getString(dataSet, 'x00020010');
+        const {
+            windowCenter,
+            windowWidth,
+            hasWindowLevel
+        } = resolveWindowLevel(
+            dataSet,
+            modality,
+            nativeDecoded.windowCenter,
+            nativeDecoded.windowWidth
+        );
+        const rescaleSlope = Number.isFinite(nativeDecoded.rescaleSlope)
+            ? nativeDecoded.rescaleSlope
+            : getNumber(dataSet, 'x00281053', 1);
+        const rescaleIntercept = Number.isFinite(nativeDecoded.rescaleIntercept)
+            ? nativeDecoded.rescaleIntercept
+            : getNumber(dataSet, 'x00281052', 0);
+
+        return finalizeDecodedImage({
+            ...nativeDecoded,
+            windowCenter,
+            windowWidth,
+            rescaleSlope,
+            rescaleIntercept,
+            modality,
+            transferSyntax,
+            mrMetadata: getMrMetadata(dataSet),
+            pixelSpacing: app.tools.extractPixelSpacing(dataSet),
+            skipWindowLevel: false
+        }, hasWindowLevel);
+    }
+
+    async function decodeWithFallback(dataSet, frameIndex = 0, slice = null) {
+        const transferSyntax = getString(dataSet, 'x00020010');
+        const modality = getString(dataSet, 'x00080060');
+        const route = getDecodeRoute(transferSyntax, modality);
+        const nativeEligible = canUseNativeDecode(slice);
+        let nativeError = null;
+
+        if (route === 'native-first' && nativeEligible) {
+            try {
+                return await decodeNative(dataSet, slice.source.path, frameIndex);
+            } catch (error) {
+                nativeError = error;
+                console.warn('Native decode failed, falling back to JS:', error);
+            }
+
+            try {
+                const decoded = await decodeDicom(dataSet, frameIndex);
+                if (decoded && !decoded.error) {
+                    return decoded;
+                }
+                return buildFallbackDecodeError(dataSet, decoded, nativeError);
+            } catch (jsError) {
+                return buildFallbackDecodeError(dataSet, jsError, nativeError);
+            }
+        }
+
+        try {
+            const decoded = await decodeDicom(dataSet, frameIndex);
+            if (decoded && !decoded.error) {
+                return decoded;
+            }
+
+            if (!nativeEligible) {
+                return decoded || buildFallbackDecodeError(dataSet, null, null);
+            }
+
+            try {
+                return await decodeNative(dataSet, slice.source.path, frameIndex);
+            } catch (error) {
+                return buildFallbackDecodeError(dataSet, decoded, error);
+            }
+        } catch (jsError) {
+            if (!nativeEligible) {
+                return buildFallbackDecodeError(dataSet, jsError, null);
+            }
+
+            try {
+                return await decodeNative(dataSet, slice.source.path, frameIndex);
+            } catch (nativeFallbackError) {
+                return buildFallbackDecodeError(dataSet, jsError, nativeFallbackError);
+            }
+        }
     }
 
     function renderPixels(decoded, wlOverride = null) {
@@ -410,8 +590,8 @@
      * @param {Object|null} wlOverride - Optional {center, width} to override DICOM values
      * @returns {Promise<Object>} Rendering info {rows, cols, wc, ww, transferSyntax} or {error: true}
      */
-    async function renderDicom(dataSet, wlOverride = null, frameIndex = 0) {
-        const decoded = await decodeDicom(dataSet, frameIndex);
+    async function renderDicom(dataSet, wlOverride = null, frameIndex = 0, slice = null) {
+        const decoded = await decodeWithFallback(dataSet, frameIndex, slice);
         if (!decoded) {
             return renderDecodeError(buildDecodeError('Image decode failed', 'Unknown decode error'));
         }
@@ -425,6 +605,9 @@
     app.rendering = {
         displayError,
         decodeDicom,
+        decodeNative,
+        decodeWithFallback,
+        getDecodeRoute,
         renderPixels,
         renderDicom
     };

--- a/docs/js/app/tools.js
+++ b/docs/js/app/tools.js
@@ -331,7 +331,7 @@
         const wlOverride = (state.windowLevel.center !== null && state.windowLevel.width !== null)
             ? state.windowLevel
             : null;
-        await app.rendering.renderDicom(dataSet, wlOverride, slice.frameIndex || 0);
+        await app.rendering.renderDicom(dataSet, wlOverride, slice.frameIndex || 0, slice);
     }
 
     function handleWLDrag(dx, dy) {

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -49,7 +49,7 @@
             const wlOverride = (state.windowLevel.center !== null && state.windowLevel.width !== null)
                 ? state.windowLevel
                 : null;
-            const info = await renderDicom(dataSet, wlOverride, slice.frameIndex || 0);
+            const info = await renderDicom(dataSet, wlOverride, slice.frameIndex || 0, slice);
 
             updateWLDisplay();
 

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -636,6 +636,45 @@ test.describe('Desktop library scanning', () => {
         expect(result.after).toEqual(result.before);
     });
 
+    test('renderDicom can suppress error canvas writes for composable callers', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+            canvas.width = 2;
+            canvas.height = 2;
+            ctx.fillStyle = 'rgb(21, 43, 65)';
+            ctx.fillRect(0, 0, 2, 2);
+            const before = Array.from(ctx.getImageData(0, 0, 2, 2).data);
+
+            const info = await window.DicomViewerApp.rendering.renderDicom({
+                elements: {},
+                string() {
+                    return '';
+                },
+                uint16() {
+                    return 0;
+                }
+            }, null, 0, null, { displayErrors: false });
+
+            return {
+                info,
+                after: Array.from(ctx.getImageData(0, 0, 2, 2).data),
+                canvasSize: { width: canvas.width, height: canvas.height },
+                before
+            };
+        });
+
+        expect(result.info).toMatchObject({
+            error: true,
+            errorMessage: 'No pixel data found'
+        });
+        expect(result.canvasSize).toEqual({ width: 2, height: 2 });
+        expect(result.after).toEqual(result.before);
+    });
+
     test('decodeDicom returns a detached copy of uncompressed pixel data', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
@@ -759,6 +798,48 @@ test.describe('Desktop library scanning', () => {
         expect(result.pixelSpacing).toEqual({ row: 0.5, col: 0.25 });
     });
 
+    test('decodeNative rejects native payloads whose sample count does not match the geometry', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const message = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            app.desktopDecode.decodeFrameWithPixels = async () => ({
+                rows: 2,
+                cols: 2,
+                bitsAllocated: 16,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 50,
+                windowWidth: 100,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                pixelData: new Uint16Array([10, 20, 30])
+            });
+
+            try {
+                await app.rendering.decodeNative({
+                    string(tag) {
+                        const values = {
+                            x00020010: '1.2.840.10008.1.2.1',
+                            x00080060: 'CT',
+                            x00280004: 'MONOCHROME2',
+                            x00281050: '50',
+                            x00281051: '100'
+                        };
+                        return values[tag] || '';
+                    }
+                }, '/library/bad-native.dcm', 0);
+                return null;
+            } catch (error) {
+                return String(error?.message || error);
+            }
+        });
+
+        expect(message).toContain('expected 4');
+    });
+
     test('renderDicom matches decodeDicom plus renderPixels for a known slice', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
@@ -839,7 +920,7 @@ test.describe('Desktop library scanning', () => {
         expect(result.wrapperPixelSpacing).toEqual(result.splitPixelSpacing);
     });
 
-    test('viewer loadSlice falls back to native desktop decode for path-backed slices', async ({ page }) => {
+    test('viewer loadSlice falls back to native desktop decode after an explicit js-first decode error', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
 
@@ -867,6 +948,8 @@ test.describe('Desktop library scanning', () => {
             app.state.windowLevel = { center: null, width: null };
             app.state.baseWindowLevel = { center: null, width: null };
             app.state.pixelSpacing = null;
+            // Intentionally omit Pixel Data so the js-first route returns a decode error
+            // and the viewer must fall back to the native desktop path for this slice.
             app.state.sliceCache.set(cacheKey, {
                 elements: {},
                 string(tag) {
@@ -882,8 +965,15 @@ test.describe('Desktop library scanning', () => {
                     };
                     return values[tag] || '';
                 },
-                uint16() {
-                    return 0;
+                uint16(tag) {
+                    const values = {
+                        x00280010: 4,
+                        x00280011: 4,
+                        x00280100: 16,
+                        x00280103: 0,
+                        x00280002: 1
+                    };
+                    return values[tag] || 0;
                 }
             });
             app.desktopDecode.decodeFrameWithPixels = async (path, frameIndex) => {
@@ -912,6 +1002,7 @@ test.describe('Desktop library scanning', () => {
             const imageData = Array.from(ctx.getImageData(0, 0, 4, 4).data);
 
             return {
+                route: app.rendering.getDecodeRoute('1.2.840.10008.1.2.1', 'CT'),
                 nativeCalls,
                 firstChannel: imageData.filter((_, index) => index % 4 === 0),
                 baseWindowLevel: app.state.baseWindowLevel,
@@ -920,6 +1011,7 @@ test.describe('Desktop library scanning', () => {
             };
         });
 
+        expect(result.route).toBe('js-first');
         expect(result.nativeCalls).toEqual([
             {
                 path: '/library/native-fallback.dcm',
@@ -969,6 +1061,8 @@ test.describe('Desktop library scanning', () => {
                 };
             };
 
+            // This fixture is intentionally skeletal because native-first routing should
+            // use the desktop path before the JS decoder ever touches Pixel Data tags.
             const dataSet = {
                 elements: {},
                 string(tag) {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -839,6 +839,181 @@ test.describe('Desktop library scanning', () => {
         expect(result.wrapperPixelSpacing).toEqual(result.splitPixelSpacing);
     });
 
+    test('viewer loadSlice falls back to native desktop decode for path-backed slices', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const slice = {
+                frameIndex: 0,
+                sliceLocation: 12.34,
+                source: {
+                    kind: 'path',
+                    path: '/library/native-fallback.dcm'
+                }
+            };
+            const cacheKey = app.sources.getSliceCacheKey(slice, 0);
+            const nativeCalls = [];
+
+            app.state.currentStudy = {
+                studyInstanceUid: 'study-1'
+            };
+            app.state.currentSeries = {
+                seriesInstanceUid: 'series-1',
+                slices: [slice]
+            };
+            app.state.currentSliceIndex = 0;
+            app.state.windowLevel = { center: null, width: null };
+            app.state.baseWindowLevel = { center: null, width: null };
+            app.state.pixelSpacing = null;
+            app.state.sliceCache.set(cacheKey, {
+                elements: {},
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'CT',
+                        x00280004: 'MONOCHROME2',
+                        x00280030: '0.5\\0.25',
+                        x00281050: '40',
+                        x00281051: '400',
+                        x00281052: '0',
+                        x00281053: '1'
+                    };
+                    return values[tag] || '';
+                },
+                uint16() {
+                    return 0;
+                }
+            });
+            app.desktopDecode.decodeFrameWithPixels = async (path, frameIndex) => {
+                nativeCalls.push({ path, frameIndex });
+                return {
+                    rows: 4,
+                    cols: 4,
+                    bitsAllocated: 16,
+                    pixelRepresentation: 0,
+                    samplesPerPixel: 1,
+                    planarConfiguration: 0,
+                    photometricInterpretation: 'MONOCHROME2',
+                    windowCenter: 1500,
+                    windowWidth: 3000,
+                    rescaleSlope: 1,
+                    rescaleIntercept: 0,
+                    pixelDataLength: 32,
+                    pixelData: new Uint16Array(Array.from({ length: 16 }, (_, index) => index * 200))
+                };
+            };
+
+            await app.viewer.loadSlice(0);
+
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+            const imageData = Array.from(ctx.getImageData(0, 0, 4, 4).data);
+
+            return {
+                nativeCalls,
+                firstChannel: imageData.filter((_, index) => index % 4 === 0),
+                baseWindowLevel: app.state.baseWindowLevel,
+                pixelSpacing: app.state.pixelSpacing,
+                metadataText: document.getElementById('metadataContent').textContent
+            };
+        });
+
+        expect(result.nativeCalls).toEqual([
+            {
+                path: '/library/native-fallback.dcm',
+                frameIndex: 0
+            }
+        ]);
+        expect(result.firstChannel).toEqual([
+            0, 17, 34, 51,
+            68, 85, 102, 119,
+            136, 153, 170, 187,
+            204, 221, 238, 255
+        ]);
+        expect(result.baseWindowLevel).toEqual({ center: 1500, width: 3000 });
+        expect(result.pixelSpacing).toEqual({ row: 0.5, col: 0.25 });
+        expect(result.metadataText).toContain('CT');
+        expect(result.metadataText).toContain('4 x 4');
+    });
+
+    test('decodeWithFallback uses native-first routing for JPEG 2000 RF desktop slices', async ({ page }) => {
+        const consoleMessages = [];
+        page.on('console', (message) => {
+            consoleMessages.push(message.text());
+        });
+
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const nativeCalls = [];
+            app.desktopDecode.decodeFrameWithPixels = async (path, frameIndex) => {
+                nativeCalls.push({ path, frameIndex });
+                return {
+                    rows: 1,
+                    cols: 2,
+                    bitsAllocated: 16,
+                    pixelRepresentation: 0,
+                    samplesPerPixel: 1,
+                    planarConfiguration: 0,
+                    photometricInterpretation: 'MONOCHROME2',
+                    windowCenter: 150,
+                    windowWidth: 300,
+                    rescaleSlope: 1,
+                    rescaleIntercept: 0,
+                    pixelDataLength: 4,
+                    pixelData: new Uint16Array([100, 200])
+                };
+            };
+
+            const dataSet = {
+                elements: {},
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.4.90',
+                        x00080060: 'RF',
+                        x00280004: 'MONOCHROME2'
+                    };
+                    return values[tag] || '';
+                },
+                uint16() {
+                    return 0;
+                }
+            };
+
+            const decoded = await app.rendering.decodeWithFallback(dataSet, 0, {
+                frameIndex: 0,
+                source: {
+                    kind: 'path',
+                    path: '/risk/rf-j2k.dcm'
+                }
+            });
+
+            return {
+                route: app.rendering.getDecodeRoute('1.2.840.10008.1.2.4.90', 'RF'),
+                nativeCalls,
+                pixelValues: Array.from(decoded.pixelData),
+                modality: decoded.modality,
+                transferSyntax: decoded.transferSyntax
+            };
+        });
+
+        expect(result.route).toBe('native-first');
+        expect(result.nativeCalls).toEqual([
+            {
+                path: '/risk/rf-j2k.dcm',
+                frameIndex: 0
+            }
+        ]);
+        expect(result.pixelValues).toEqual([100, 200]);
+        expect(result.modality).toBe('RF');
+        expect(result.transferSyntax).toBe('1.2.840.10008.1.2.4.90');
+        expect(consoleMessages.some((message) => message.includes('No pixel data element found'))).toBe(false);
+    });
+
     test('encapsulated frame extraction falls back for single-frame files with an empty basic offset table', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);


### PR DESCRIPTION
## Summary
- add a desktop decode dispatcher in the rendering layer with js-first and native-first routing based on transfer syntax and modality
- enrich native decode results with DICOM-derived display metadata so they match the render contract used by `renderPixels`
- thread the slice through viewer and tool re-renders so desktop path-backed slices can use native fallback when JS decode fails
- add desktop rendering tests for path-backed native fallback and JPEG 2000 RF native-first routing

## Validation
- npx playwright test tests/desktop-library.spec.js tests/desktop-native-decode.spec.js tests/desktop-runtime-compat.spec.js
- npx playwright test