### PR TITLE
Add native decode cache and stage diagnostics

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -652,6 +652,8 @@ dependencies = [
  "dicom-pixeldata",
  "dicom-transfer-syntax-registry",
  "serde",
+ "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,6 +17,8 @@ dicom-object = "0.9"
 dicom-pixeldata = { version = "0.9", default-features = false }
 dicom-transfer-syntax-registry = { version = "0.9", features = ["openjpeg-sys"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -23,6 +23,12 @@
         },
         {
           "path": "$APPDATA/reports/**"
+        },
+        {
+          "path": "$APPDATA/decode-cache"
+        },
+        {
+          "path": "$APPDATA/decode-cache/**"
         }
       ]
     }

--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -1,25 +1,49 @@
 use std::{
     collections::{HashMap, VecDeque},
+    fs,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
         Mutex,
     },
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use dicom_core::Tag;
 use dicom_dictionary_std::tags;
 use dicom_object::{open_file, DefaultDicomObject};
 use dicom_pixeldata::{DecodedPixelData, PixelDecoder};
-use serde::Serialize;
-use tauri::{ipc::Response, AppHandle, Runtime, State};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::{ipc::Response, AppHandle, Manager, Runtime, State};
 use tauri_plugin_fs::FsExt;
 
 const DECODE_TIMEOUT_SECS: u64 = 30;
 const MAX_DECODE_STORE_ENTRIES: usize = 8;
+const DECODE_CACHE_DIR_NAME: &str = "decode-cache";
+const DECODE_CACHE_MANIFEST_NAME: &str = "manifest.json";
+const MAX_DECODE_CACHE_ENTRIES: usize = 1000;
+const MAX_DECODE_CACHE_BYTES: u64 = 500 * 1024 * 1024;
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+type DecodeResult<T> = Result<T, DecodeError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeError {
+    pub stage: String,
+    pub message: String,
+}
+
+impl DecodeError {
+    fn new(stage: &str, message: impl Into<String>) -> Self {
+        Self {
+            stage: stage.to_string(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DecodeFrameMetadata {
     pub decode_id: String,
@@ -37,7 +61,7 @@ pub struct DecodeFrameMetadata {
     pub pixel_data_length: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct DecodedFrameMetadata {
     rows: u16,
     cols: u16,
@@ -73,7 +97,7 @@ impl DecodedFrameMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 struct DecodedFrame {
     metadata: DecodedFrameMetadata,
     pixel_bytes: Vec<u8>,
@@ -128,15 +152,58 @@ impl DecodeStore {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct DecodeCachePaths {
+    dir: PathBuf,
+    manifest: PathBuf,
+}
+
+impl DecodeCachePaths {
+    fn new(dir: PathBuf) -> Self {
+        Self {
+            manifest: dir.join(DECODE_CACHE_MANIFEST_NAME),
+            dir,
+        }
+    }
+
+    fn entry_paths(&self, cache_key: &str) -> DecodeCacheEntryPaths {
+        DecodeCacheEntryPaths {
+            pixel_bytes: self.dir.join(format!("{cache_key}.raw")),
+            metadata: self.dir.join(format!("{cache_key}.json")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DecodeCacheEntryPaths {
+    pixel_bytes: PathBuf,
+    metadata: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct DecodeCacheManifest {
+    entries: Vec<DecodeCacheManifestEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct DecodeCacheManifestEntry {
+    key: String,
+    pixel_data_length: usize,
+    last_accessed_ms: u128,
+}
+
 #[tauri::command]
 pub async fn decode_frame<R: Runtime>(
     app: AppHandle<R>,
     path: String,
     frame_index: u32,
     store: State<'_, DecodeStore>,
-) -> Result<DecodeFrameMetadata, String> {
+) -> DecodeResult<DecodeFrameMetadata> {
     let scoped_path = validate_decode_path(&app, &path)?;
-    let decode_result = run_decode_with_timeout(scoped_path, frame_index).await?;
+    let cache_paths = resolve_cache_paths(&app)?;
+    let decode_result = run_decode_with_timeout(scoped_path, frame_index, cache_paths).await?;
     let decode_id = store.insert(decode_result.pixel_bytes);
     Ok(decode_result.metadata.into_response(decode_id))
 }
@@ -145,73 +212,348 @@ pub async fn decode_frame<R: Runtime>(
 pub fn take_decoded_frame(
     decode_id: String,
     store: State<'_, DecodeStore>,
-) -> Result<Response, String> {
+) -> DecodeResult<Response> {
     let pixel_bytes = store
         .take(&decode_id)
-        .ok_or_else(|| format!("Decoded frame not found: {decode_id}"))?;
+        .ok_or_else(|| DecodeError::new("pixel-transfer", format!("Decoded frame not found: {decode_id}")))?;
     Ok(Response::new(pixel_bytes))
 }
 
-async fn run_decode_with_timeout(path: PathBuf, frame_index: u32) -> Result<DecodedFrame, String> {
-    let decode_task = tokio::task::spawn_blocking(move || decode_frame_impl(&path, frame_index));
+async fn run_decode_with_timeout(
+    path: PathBuf,
+    frame_index: u32,
+    cache_paths: DecodeCachePaths,
+) -> DecodeResult<DecodedFrame> {
+    let decode_task =
+        tokio::task::spawn_blocking(move || decode_frame_impl_with_cache(&path, frame_index, &cache_paths));
 
     match tokio::time::timeout(Duration::from_secs(DECODE_TIMEOUT_SECS), decode_task).await {
         Ok(Ok(result)) => result,
-        Ok(Err(error)) => Err(format!(
-            "Native decode worker ended before producing a result: {error}"
+        Ok(Err(error)) => Err(DecodeError::new(
+            "decode",
+            format!("Native decode worker ended before producing a result: {error}"),
         )),
-        Err(_) => Err(format!(
-            "Native decode timed out after {DECODE_TIMEOUT_SECS}s while waiting on the bounded blocking pool."
+        Err(_) => Err(DecodeError::new(
+            "decode-timeout",
+            format!(
+                "Native decode timed out after {DECODE_TIMEOUT_SECS}s while waiting on the bounded blocking pool."
+            ),
         )),
     }
 }
 
-fn validate_decode_path<R: Runtime>(app: &AppHandle<R>, path: &str) -> Result<PathBuf, String> {
+fn resolve_cache_paths<R: Runtime>(app: &AppHandle<R>) -> DecodeResult<DecodeCachePaths> {
+    let app_data_dir = app.path().app_data_dir().map_err(|error| {
+        DecodeError::new(
+            "cache-write",
+            format!("Failed to resolve the desktop app data directory: {error}"),
+        )
+    })?;
+    let cache_paths = DecodeCachePaths::new(app_data_dir.join(DECODE_CACHE_DIR_NAME));
+    fs::create_dir_all(&cache_paths.dir).map_err(|error| {
+        DecodeError::new(
+            "cache-write",
+            format!(
+                "Failed to create decode cache directory {}: {error}",
+                cache_paths.dir.display()
+            ),
+        )
+    })?;
+    Ok(cache_paths)
+}
+
+fn validate_decode_path<R: Runtime>(app: &AppHandle<R>, path: &str) -> DecodeResult<PathBuf> {
     let requested_path = PathBuf::from(path);
     if requested_path.as_os_str().is_empty() {
-        return Err("Decode path is empty.".into());
+        return Err(DecodeError::new("decode", "Decode path is empty."));
     }
     if !requested_path.is_absolute() {
-        return Err(format!("Decode path must be absolute: {path}"));
+        return Err(DecodeError::new(
+            "decode",
+            format!("Decode path must be absolute: {path}"),
+        ));
     }
 
-    let canonical_path = requested_path
-        .canonicalize()
-        .map_err(|e| format!("Failed to open DICOM file {path}: {e}"))?;
+    let canonical_path = requested_path.canonicalize().map_err(|error| {
+        DecodeError::new(
+            "decode",
+            format!("Failed to open DICOM file {path}: {error}"),
+        )
+    })?;
 
     if !app.fs_scope().is_allowed(&canonical_path) {
-        return Err(format!(
-            "Decode path is outside the allowed desktop file scope: {}",
-            canonical_path.display()
+        return Err(DecodeError::new(
+            "decode",
+            format!(
+                "Decode path is outside the allowed desktop file scope: {}",
+                canonical_path.display()
+            ),
         ));
     }
 
     Ok(canonical_path)
 }
 
-fn decode_frame_impl(path: &Path, frame_index: u32) -> Result<DecodedFrame, String> {
-    let object = open_file(path)
-        .map_err(|e| format!("Failed to open DICOM file {}: {e}", path.display()))?;
+fn decode_frame_impl_with_cache(
+    path: &Path,
+    frame_index: u32,
+    cache_paths: &DecodeCachePaths,
+) -> DecodeResult<DecodedFrame> {
+    let object = open_file(path).map_err(|error| {
+        DecodeError::new(
+            "decode",
+            format!("Failed to open DICOM file {}: {error}", path.display()),
+        )
+    })?;
 
-    let rows = required_u16(&object, tags::ROWS, "Rows")?;
-    let cols = required_u16(&object, tags::COLUMNS, "Columns")?;
-    let bits_allocated = required_u16(&object, tags::BITS_ALLOCATED, "Bits Allocated")?;
-    let pixel_representation = get_u16(&object, tags::PIXEL_REPRESENTATION).unwrap_or_default();
-    let samples_per_pixel = get_u16(&object, tags::SAMPLES_PER_PIXEL).unwrap_or(1);
-    let planar_configuration = get_u16(&object, tags::PLANAR_CONFIGURATION).unwrap_or(0);
+    let cache_key = match build_cache_key(path, &object, frame_index) {
+        Ok(key) => Some(key),
+        Err(error) => {
+            eprintln!("Skipping decode cache key generation: {error}");
+            None
+        }
+    };
+
+    if let Some(cache_key) = cache_key.as_deref() {
+        if let Some(cached_frame) = read_cached_frame(cache_paths, cache_key) {
+            return Ok(cached_frame);
+        }
+    }
+
+    let decoded_frame = decode_frame_from_object(path, &object, frame_index)?;
+
+    if let Some(cache_key) = cache_key.as_deref() {
+        if let Err(error) = write_cached_frame(cache_paths, cache_key, &decoded_frame) {
+            eprintln!("Skipping decode cache write for {}: {}", path.display(), error);
+        }
+    }
+
+    Ok(decoded_frame)
+}
+
+fn build_cache_key(
+    path: &Path,
+    object: &DefaultDicomObject,
+    frame_index: u32,
+) -> Result<String, String> {
+    let file_metadata =
+        fs::metadata(path).map_err(|error| format!("Failed to read file metadata: {error}"))?;
+    let modified = file_metadata
+        .modified()
+        .map_err(|error| format!("Failed to read file modification time: {error}"))?;
+    let modified_ms = modified
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("Invalid file modification time: {error}"))?
+        .as_millis()
+        .to_string();
+    let sop_instance_uid =
+        get_text(object, tags::SOP_INSTANCE_UID).unwrap_or_else(|| "missing-sop-instance-uid".into());
+    let transfer_syntax =
+        get_text(object, tags::TRANSFER_SYNTAX_UID).unwrap_or_else(|| "missing-transfer-syntax".into());
+
+    let mut hasher = Sha256::new();
+    hasher.update(path.as_os_str().as_encoded_bytes());
+    hasher.update(b"|");
+    hasher.update(sop_instance_uid.as_bytes());
+    hasher.update(b"|");
+    hasher.update(frame_index.to_string().as_bytes());
+    hasher.update(b"|");
+    hasher.update(transfer_syntax.as_bytes());
+    hasher.update(b"|");
+    hasher.update(modified_ms.as_bytes());
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn read_cached_frame(cache_paths: &DecodeCachePaths, cache_key: &str) -> Option<DecodedFrame> {
+    let entry_paths = cache_paths.entry_paths(cache_key);
+    if !entry_paths.pixel_bytes.exists() || !entry_paths.metadata.exists() {
+        return None;
+    }
+
+    let metadata_text = fs::read_to_string(&entry_paths.metadata).ok()?;
+    let metadata: DecodedFrameMetadata = serde_json::from_str(&metadata_text).ok()?;
+    let pixel_bytes = fs::read(&entry_paths.pixel_bytes).ok()?;
+    if pixel_bytes.len() != metadata.pixel_data_length {
+        return None;
+    }
+
+    if let Err(error) = touch_cache_manifest(cache_paths, cache_key, metadata.pixel_data_length) {
+        eprintln!("Failed to update decode cache manifest after hit: {error}");
+    }
+
+    Some(DecodedFrame {
+        metadata,
+        pixel_bytes,
+    })
+}
+
+fn write_cached_frame(
+    cache_paths: &DecodeCachePaths,
+    cache_key: &str,
+    decoded_frame: &DecodedFrame,
+) -> Result<(), String> {
+    fs::create_dir_all(&cache_paths.dir)
+        .map_err(|error| format!("Failed to create cache directory: {error}"))?;
+
+    let entry_paths = cache_paths.entry_paths(cache_key);
+    fs::write(&entry_paths.pixel_bytes, &decoded_frame.pixel_bytes)
+        .map_err(|error| format!("Failed to write cached pixels: {error}"))?;
+    let metadata_json = serde_json::to_vec_pretty(&decoded_frame.metadata)
+        .map_err(|error| format!("Failed to serialize cached metadata: {error}"))?;
+    fs::write(&entry_paths.metadata, metadata_json)
+        .map_err(|error| format!("Failed to write cached metadata: {error}"))?;
+
+    let mut manifest = load_cache_manifest(cache_paths)?;
+    upsert_manifest_entry(
+        &mut manifest,
+        cache_key,
+        decoded_frame.metadata.pixel_data_length,
+    );
+    enforce_cache_limits(
+        cache_paths,
+        &mut manifest,
+        MAX_DECODE_CACHE_ENTRIES,
+        MAX_DECODE_CACHE_BYTES,
+    )?;
+    save_cache_manifest(cache_paths, &manifest)
+}
+
+fn touch_cache_manifest(
+    cache_paths: &DecodeCachePaths,
+    cache_key: &str,
+    pixel_data_length: usize,
+) -> Result<(), String> {
+    let mut manifest = load_cache_manifest(cache_paths)?;
+    upsert_manifest_entry(&mut manifest, cache_key, pixel_data_length);
+    save_cache_manifest(cache_paths, &manifest)
+}
+
+fn load_cache_manifest(cache_paths: &DecodeCachePaths) -> Result<DecodeCacheManifest, String> {
+    if !cache_paths.manifest.exists() {
+        return Ok(DecodeCacheManifest::default());
+    }
+
+    let manifest_json = fs::read_to_string(&cache_paths.manifest)
+        .map_err(|error| format!("Failed to read cache manifest: {error}"))?;
+    let mut manifest: DecodeCacheManifest = serde_json::from_str(&manifest_json)
+        .map_err(|error| format!("Failed to parse cache manifest: {error}"))?;
+
+    manifest.entries.retain(|entry| {
+        let paths = cache_paths.entry_paths(&entry.key);
+        paths.pixel_bytes.exists() && paths.metadata.exists()
+    });
+
+    Ok(manifest)
+}
+
+fn save_cache_manifest(
+    cache_paths: &DecodeCachePaths,
+    manifest: &DecodeCacheManifest,
+) -> Result<(), String> {
+    let manifest_json = serde_json::to_vec_pretty(manifest)
+        .map_err(|error| format!("Failed to serialize cache manifest: {error}"))?;
+    fs::write(&cache_paths.manifest, manifest_json)
+        .map_err(|error| format!("Failed to write cache manifest: {error}"))
+}
+
+fn upsert_manifest_entry(
+    manifest: &mut DecodeCacheManifest,
+    cache_key: &str,
+    pixel_data_length: usize,
+) {
+    manifest.entries.retain(|entry| entry.key != cache_key);
+    manifest.entries.push(DecodeCacheManifestEntry {
+        key: cache_key.to_string(),
+        pixel_data_length,
+        last_accessed_ms: current_time_ms(),
+    });
+}
+
+fn enforce_cache_limits(
+    cache_paths: &DecodeCachePaths,
+    manifest: &mut DecodeCacheManifest,
+    max_entries: usize,
+    max_bytes: u64,
+) -> Result<(), String> {
+    manifest
+        .entries
+        .sort_by_key(|entry| (entry.last_accessed_ms, entry.key.clone()));
+
+    let mut total_bytes = manifest
+        .entries
+        .iter()
+        .map(|entry| entry.pixel_data_length as u64)
+        .sum::<u64>();
+
+    while manifest.entries.len() > max_entries || total_bytes > max_bytes {
+        let stale_entry = manifest.entries.remove(0);
+        total_bytes = total_bytes.saturating_sub(stale_entry.pixel_data_length as u64);
+        let stale_paths = cache_paths.entry_paths(&stale_entry.key);
+        remove_if_exists(&stale_paths.pixel_bytes)
+            .map_err(|error| format!("Failed to evict cached pixel payload: {error}"))?;
+        remove_if_exists(&stale_paths.metadata)
+            .map_err(|error| format!("Failed to evict cached metadata: {error}"))?;
+    }
+
+    Ok(())
+}
+
+fn remove_if_exists(path: &Path) -> std::io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn current_time_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn decode_frame_impl(path: &Path, frame_index: u32) -> DecodeResult<DecodedFrame> {
+    let object = open_file(path).map_err(|error| {
+        DecodeError::new(
+            "decode",
+            format!("Failed to open DICOM file {}: {error}", path.display()),
+        )
+    })?;
+    decode_frame_from_object(path, &object, frame_index)
+}
+
+fn decode_frame_from_object(
+    path: &Path,
+    object: &DefaultDicomObject,
+    frame_index: u32,
+) -> DecodeResult<DecodedFrame> {
+    let rows = required_u16(object, tags::ROWS, "Rows")?;
+    let cols = required_u16(object, tags::COLUMNS, "Columns")?;
+    let bits_allocated = required_u16(object, tags::BITS_ALLOCATED, "Bits Allocated")?;
+    let pixel_representation = get_u16(object, tags::PIXEL_REPRESENTATION).unwrap_or_default();
+    let samples_per_pixel = get_u16(object, tags::SAMPLES_PER_PIXEL).unwrap_or(1);
+    let planar_configuration = get_u16(object, tags::PLANAR_CONFIGURATION).unwrap_or(0);
     let photometric_interpretation =
-        get_text(&object, tags::PHOTOMETRIC_INTERPRETATION).unwrap_or_else(|| "MONOCHROME2".into());
-    let frame_count = get_u32(&object, tags::NUMBER_OF_FRAMES).unwrap_or(1);
+        get_text(object, tags::PHOTOMETRIC_INTERPRETATION).unwrap_or_else(|| "MONOCHROME2".into());
+    let frame_count = get_u32(object, tags::NUMBER_OF_FRAMES).unwrap_or(1);
 
     if frame_index >= frame_count {
-        return Err(format!(
-            "Requested frame {frame_index} but dataset only has {frame_count} frame(s)."
+        return Err(DecodeError::new(
+            "frame-extraction",
+            format!("Requested frame {frame_index} but dataset only has {frame_count} frame(s)."),
         ));
     }
 
-    let decoded = object
-        .decode_pixel_data_frame(frame_index)
-        .map_err(|e| format!("Failed to decode frame {frame_index}: {e}"))?;
+    let decoded = object.decode_pixel_data_frame(frame_index).map_err(|error| {
+        DecodeError::new(
+            "decode",
+            format!(
+                "Failed to decode frame {frame_index} from {}: {error}",
+                path.display()
+            ),
+        )
+    })?;
     let pixel_bytes = decoded_pixels_to_bytes(decoded);
 
     Ok(DecodedFrame {
@@ -223,10 +565,10 @@ fn decode_frame_impl(path: &Path, frame_index: u32) -> Result<DecodedFrame, Stri
             samples_per_pixel,
             planar_configuration,
             photometric_interpretation,
-            window_center: get_first_f64(&object, tags::WINDOW_CENTER),
-            window_width: get_first_f64(&object, tags::WINDOW_WIDTH),
-            rescale_slope: get_first_f64(&object, tags::RESCALE_SLOPE),
-            rescale_intercept: get_first_f64(&object, tags::RESCALE_INTERCEPT),
+            window_center: get_first_f64(object, tags::WINDOW_CENTER),
+            window_width: get_first_f64(object, tags::WINDOW_WIDTH),
+            rescale_slope: get_first_f64(object, tags::RESCALE_SLOPE),
+            rescale_intercept: get_first_f64(object, tags::RESCALE_INTERCEPT),
             pixel_data_length: pixel_bytes.len(),
         },
         pixel_bytes,
@@ -263,8 +605,13 @@ fn get_u32(object: &DefaultDicomObject, tag: Tag) -> Option<u32> {
         .and_then(|element| element.to_int::<u32>().ok())
 }
 
-fn required_u16(object: &DefaultDicomObject, tag: Tag, label: &str) -> Result<u16, String> {
-    get_u16(object, tag).ok_or_else(|| format!("Missing or invalid DICOM field: {label}"))
+fn required_u16(object: &DefaultDicomObject, tag: Tag, label: &str) -> DecodeResult<u16> {
+    get_u16(object, tag).ok_or_else(|| {
+        DecodeError::new(
+            "frame-extraction",
+            format!("Missing or invalid DICOM field: {label}"),
+        )
+    })
 }
 
 fn get_first_f64(object: &DefaultDicomObject, tag: Tag) -> Option<f64> {
@@ -285,6 +632,13 @@ mod tests {
             .join("..")
             .join("..")
             .join(relative)
+    }
+
+    fn test_cache_paths(label: &str) -> DecodeCachePaths {
+        let unique = format!("{label}-{}-{}", std::process::id(), current_time_ms());
+        let dir = std::env::temp_dir().join(unique);
+        fs::create_dir_all(&dir).expect("test cache dir should be creatable");
+        DecodeCachePaths::new(dir)
     }
 
     #[test]
@@ -314,6 +668,96 @@ mod tests {
     }
 
     #[test]
+    fn decode_cache_reads_back_written_frames() {
+        let cache_paths = test_cache_paths("decode-cache-roundtrip");
+        let cache_key = "sample-frame";
+        let decoded = DecodedFrame {
+            metadata: DecodedFrameMetadata {
+                rows: 2,
+                cols: 2,
+                bits_allocated: 16,
+                pixel_representation: 0,
+                samples_per_pixel: 1,
+                planar_configuration: 0,
+                photometric_interpretation: "MONOCHROME2".into(),
+                window_center: Some(40.0),
+                window_width: Some(400.0),
+                rescale_slope: Some(1.0),
+                rescale_intercept: Some(-1024.0),
+                pixel_data_length: 8,
+            },
+            pixel_bytes: vec![1, 0, 2, 0, 3, 0, 4, 0],
+        };
+
+        write_cached_frame(&cache_paths, cache_key, &decoded).expect("cache write should succeed");
+        let cached = read_cached_frame(&cache_paths, cache_key).expect("cache hit should succeed");
+
+        assert_eq!(cached, decoded);
+        assert!(cache_paths.entry_paths(cache_key).pixel_bytes.exists());
+        assert!(cache_paths.entry_paths(cache_key).metadata.exists());
+        assert!(cache_paths.manifest.exists());
+
+        let _ = fs::remove_dir_all(&cache_paths.dir);
+    }
+
+    #[test]
+    fn decode_cache_evicts_oldest_entries_when_limits_are_exceeded() {
+        let cache_paths = test_cache_paths("decode-cache-eviction");
+        let mut manifest = DecodeCacheManifest {
+            entries: vec![
+                DecodeCacheManifestEntry {
+                    key: "oldest".into(),
+                    pixel_data_length: 4,
+                    last_accessed_ms: 1,
+                },
+                DecodeCacheManifestEntry {
+                    key: "newest".into(),
+                    pixel_data_length: 4,
+                    last_accessed_ms: 2,
+                },
+            ],
+        };
+
+        for entry in &manifest.entries {
+            let entry_paths = cache_paths.entry_paths(&entry.key);
+            fs::write(&entry_paths.pixel_bytes, [0, 1, 2, 3]).expect("pixel payload should be written");
+            fs::write(&entry_paths.metadata, "{}").expect("metadata payload should be written");
+        }
+
+        enforce_cache_limits(&cache_paths, &mut manifest, 1, 4).expect("eviction should succeed");
+
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].key, "newest");
+        assert!(!cache_paths.entry_paths("oldest").pixel_bytes.exists());
+        assert!(cache_paths.entry_paths("newest").pixel_bytes.exists());
+
+        let _ = fs::remove_dir_all(&cache_paths.dir);
+    }
+
+    #[test]
+    fn decode_frame_impl_with_cache_uses_cached_pixels_after_first_decode() {
+        let fixture = fixture_path("test-data/mri-samples/MR2_J2KI.dcm");
+        let cache_paths = test_cache_paths("decode-cache-hit");
+
+        let first = decode_frame_impl_with_cache(&fixture, 0, &cache_paths)
+            .expect("first decode should populate cache");
+        let object = open_file(&fixture).expect("fixture should be readable");
+        let cache_key =
+            build_cache_key(&fixture, &object, 0).expect("cache key should be computed for fixture");
+        let entry_paths = cache_paths.entry_paths(&cache_key);
+        let cached_bytes = vec![7; first.metadata.pixel_data_length];
+        fs::write(&entry_paths.pixel_bytes, &cached_bytes).expect("cached payload should be rewritable");
+
+        let second = decode_frame_impl_with_cache(&fixture, 0, &cache_paths)
+            .expect("second decode should reuse cached payload");
+
+        assert_eq!(second.pixel_bytes, cached_bytes);
+        assert_eq!(second.metadata, first.metadata);
+
+        let _ = fs::remove_dir_all(&cache_paths.dir);
+    }
+
+    #[test]
     fn decode_frame_impl_decodes_real_jpeg2000_fixture() {
         let fixture = fixture_path("test-data/mri-samples/MR2_J2KI.dcm");
         let decoded = decode_frame_impl(&fixture, 0).expect("fixture should decode");
@@ -325,9 +769,6 @@ mod tests {
         assert_eq!(decoded.metadata.samples_per_pixel, 1);
         assert_eq!(decoded.metadata.photometric_interpretation, "MONOCHROME2");
         assert_eq!(decoded.metadata.pixel_data_length, 1024 * 1024 * 2);
-        assert_eq!(
-            decoded.pixel_bytes.len(),
-            decoded.metadata.pixel_data_length
-        );
+        assert_eq!(decoded.pixel_bytes.len(), decoded.metadata.pixel_data_length);
     }
 }

--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     fs,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
-        Mutex,
+        LazyLock, Mutex,
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -24,8 +24,12 @@ const DECODE_CACHE_DIR_NAME: &str = "decode-cache";
 const DECODE_CACHE_MANIFEST_NAME: &str = "manifest.json";
 const MAX_DECODE_CACHE_ENTRIES: usize = 1000;
 const MAX_DECODE_CACHE_BYTES: u64 = 500 * 1024 * 1024;
+const MAX_DECODE_CACHE_EVICTIONS_PER_WRITE: usize = 20;
 
 type DecodeResult<T> = Result<T, DecodeError>;
+
+static PENDING_CACHE_TOUCHES: LazyLock<Mutex<HashMap<String, u128>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -366,10 +370,6 @@ fn build_cache_key(
 
 fn read_cached_frame(cache_paths: &DecodeCachePaths, cache_key: &str) -> Option<DecodedFrame> {
     let entry_paths = cache_paths.entry_paths(cache_key);
-    if !entry_paths.pixel_bytes.exists() || !entry_paths.metadata.exists() {
-        return None;
-    }
-
     let metadata_text = fs::read_to_string(&entry_paths.metadata).ok()?;
     let metadata: DecodedFrameMetadata = serde_json::from_str(&metadata_text).ok()?;
     let pixel_bytes = fs::read(&entry_paths.pixel_bytes).ok()?;
@@ -377,9 +377,7 @@ fn read_cached_frame(cache_paths: &DecodeCachePaths, cache_key: &str) -> Option<
         return None;
     }
 
-    if let Err(error) = touch_cache_manifest(cache_paths, cache_key, metadata.pixel_data_length) {
-        eprintln!("Failed to update decode cache manifest after hit: {error}");
-    }
+    record_cache_touch(cache_key);
 
     Some(DecodedFrame {
         metadata,
@@ -395,15 +393,18 @@ fn write_cached_frame(
     fs::create_dir_all(&cache_paths.dir)
         .map_err(|error| format!("Failed to create cache directory: {error}"))?;
 
+    let mut manifest = load_cache_manifest(cache_paths)?;
+    reconcile_cache_directory(cache_paths, &mut manifest)?;
+
     let entry_paths = cache_paths.entry_paths(cache_key);
-    fs::write(&entry_paths.pixel_bytes, &decoded_frame.pixel_bytes)
+    write_atomic_file(&entry_paths.pixel_bytes, &decoded_frame.pixel_bytes)
         .map_err(|error| format!("Failed to write cached pixels: {error}"))?;
-    let metadata_json = serde_json::to_vec_pretty(&decoded_frame.metadata)
+    let metadata_json = serde_json::to_vec(&decoded_frame.metadata)
         .map_err(|error| format!("Failed to serialize cached metadata: {error}"))?;
-    fs::write(&entry_paths.metadata, metadata_json)
+    write_atomic_file(&entry_paths.metadata, &metadata_json)
         .map_err(|error| format!("Failed to write cached metadata: {error}"))?;
 
-    let mut manifest = load_cache_manifest(cache_paths)?;
+    apply_pending_cache_touches(&mut manifest);
     upsert_manifest_entry(
         &mut manifest,
         cache_key,
@@ -414,17 +415,8 @@ fn write_cached_frame(
         &mut manifest,
         MAX_DECODE_CACHE_ENTRIES,
         MAX_DECODE_CACHE_BYTES,
+        MAX_DECODE_CACHE_EVICTIONS_PER_WRITE,
     )?;
-    save_cache_manifest(cache_paths, &manifest)
-}
-
-fn touch_cache_manifest(
-    cache_paths: &DecodeCachePaths,
-    cache_key: &str,
-    pixel_data_length: usize,
-) -> Result<(), String> {
-    let mut manifest = load_cache_manifest(cache_paths)?;
-    upsert_manifest_entry(&mut manifest, cache_key, pixel_data_length);
     save_cache_manifest(cache_paths, &manifest)
 }
 
@@ -435,24 +427,17 @@ fn load_cache_manifest(cache_paths: &DecodeCachePaths) -> Result<DecodeCacheMani
 
     let manifest_json = fs::read_to_string(&cache_paths.manifest)
         .map_err(|error| format!("Failed to read cache manifest: {error}"))?;
-    let mut manifest: DecodeCacheManifest = serde_json::from_str(&manifest_json)
-        .map_err(|error| format!("Failed to parse cache manifest: {error}"))?;
-
-    manifest.entries.retain(|entry| {
-        let paths = cache_paths.entry_paths(&entry.key);
-        paths.pixel_bytes.exists() && paths.metadata.exists()
-    });
-
-    Ok(manifest)
+    serde_json::from_str(&manifest_json)
+        .map_err(|error| format!("Failed to parse cache manifest: {error}"))
 }
 
 fn save_cache_manifest(
     cache_paths: &DecodeCachePaths,
     manifest: &DecodeCacheManifest,
 ) -> Result<(), String> {
-    let manifest_json = serde_json::to_vec_pretty(manifest)
+    let manifest_json = serde_json::to_vec(manifest)
         .map_err(|error| format!("Failed to serialize cache manifest: {error}"))?;
-    fs::write(&cache_paths.manifest, manifest_json)
+    write_atomic_file(&cache_paths.manifest, &manifest_json)
         .map_err(|error| format!("Failed to write cache manifest: {error}"))
 }
 
@@ -474,6 +459,7 @@ fn enforce_cache_limits(
     manifest: &mut DecodeCacheManifest,
     max_entries: usize,
     max_bytes: u64,
+    max_evictions_per_pass: usize,
 ) -> Result<(), String> {
     manifest
         .entries
@@ -484,8 +470,11 @@ fn enforce_cache_limits(
         .iter()
         .map(|entry| entry.pixel_data_length as u64)
         .sum::<u64>();
+    let mut evictions = 0usize;
 
-    while manifest.entries.len() > max_entries || total_bytes > max_bytes {
+    while (manifest.entries.len() > max_entries || total_bytes > max_bytes)
+        && evictions < max_evictions_per_pass
+    {
         let stale_entry = manifest.entries.remove(0);
         total_bytes = total_bytes.saturating_sub(stale_entry.pixel_data_length as u64);
         let stale_paths = cache_paths.entry_paths(&stale_entry.key);
@@ -493,9 +482,175 @@ fn enforce_cache_limits(
             .map_err(|error| format!("Failed to evict cached pixel payload: {error}"))?;
         remove_if_exists(&stale_paths.metadata)
             .map_err(|error| format!("Failed to evict cached metadata: {error}"))?;
+        evictions += 1;
     }
 
     Ok(())
+}
+
+fn reconcile_cache_directory(
+    cache_paths: &DecodeCachePaths,
+    manifest: &mut DecodeCacheManifest,
+) -> Result<(), String> {
+    #[derive(Default)]
+    struct DiscoveredCacheFiles {
+        has_pixels: bool,
+        has_metadata: bool,
+    }
+
+    let mut discovered = HashMap::<String, DiscoveredCacheFiles>::new();
+    for entry in fs::read_dir(&cache_paths.dir)
+        .map_err(|error| format!("Failed to read cache directory: {error}"))?
+    {
+        let entry = entry.map_err(|error| format!("Failed to inspect cache directory entry: {error}"))?;
+        let path = entry.path();
+        if path == cache_paths.manifest {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if file_name.contains(".tmp-") {
+            remove_if_exists(&path)
+                .map_err(|error| format!("Failed to remove stale cache temp file: {error}"))?;
+            continue;
+        }
+
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some("raw") => {
+                let key = path
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .ok_or_else(|| format!("Failed to read cache key from {}", path.display()))?;
+                discovered.entry(key.to_string()).or_default().has_pixels = true;
+            }
+            Some("json") => {
+                let key = path
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .ok_or_else(|| format!("Failed to read cache key from {}", path.display()))?;
+                discovered.entry(key.to_string()).or_default().has_metadata = true;
+            }
+            _ => {}
+        }
+    }
+
+    manifest.entries.retain(|entry| {
+        discovered
+            .get(&entry.key)
+            .is_some_and(|files| files.has_pixels && files.has_metadata)
+    });
+    let manifest_keys = manifest
+        .entries
+        .iter()
+        .map(|entry| entry.key.clone())
+        .collect::<HashSet<_>>();
+
+    for (key, files) in discovered {
+        let entry_paths = cache_paths.entry_paths(&key);
+        if !files.has_pixels || !files.has_metadata {
+            remove_if_exists(&entry_paths.pixel_bytes)
+                .map_err(|error| format!("Failed to remove partial cached pixel payload: {error}"))?;
+            remove_if_exists(&entry_paths.metadata)
+                .map_err(|error| format!("Failed to remove partial cached metadata: {error}"))?;
+            continue;
+        }
+
+        if manifest_keys.contains(&key) {
+            continue;
+        }
+
+        let metadata_text = match fs::read_to_string(&entry_paths.metadata) {
+            Ok(text) => text,
+            Err(_) => {
+                remove_if_exists(&entry_paths.pixel_bytes)
+                    .map_err(|error| format!("Failed to remove unreadable cached pixel payload: {error}"))?;
+                remove_if_exists(&entry_paths.metadata)
+                    .map_err(|error| format!("Failed to remove unreadable cached metadata: {error}"))?;
+                continue;
+            }
+        };
+        let metadata: DecodedFrameMetadata = match serde_json::from_str(&metadata_text) {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                remove_if_exists(&entry_paths.pixel_bytes)
+                    .map_err(|error| format!("Failed to remove invalid cached pixel payload: {error}"))?;
+                remove_if_exists(&entry_paths.metadata)
+                    .map_err(|error| format!("Failed to remove invalid cached metadata: {error}"))?;
+                continue;
+            }
+        };
+        let pixel_byte_length = match fs::metadata(&entry_paths.pixel_bytes) {
+            Ok(metadata_info) => metadata_info.len() as usize,
+            Err(_) => {
+                remove_if_exists(&entry_paths.pixel_bytes)
+                    .map_err(|error| format!("Failed to remove missing cached pixel payload: {error}"))?;
+                remove_if_exists(&entry_paths.metadata)
+                    .map_err(|error| format!("Failed to remove missing cached metadata: {error}"))?;
+                continue;
+            }
+        };
+
+        if pixel_byte_length != metadata.pixel_data_length {
+            remove_if_exists(&entry_paths.pixel_bytes)
+                .map_err(|error| format!("Failed to remove mismatched cached pixel payload: {error}"))?;
+            remove_if_exists(&entry_paths.metadata)
+                .map_err(|error| format!("Failed to remove mismatched cached metadata: {error}"))?;
+            continue;
+        }
+
+        manifest.entries.push(DecodeCacheManifestEntry {
+            key,
+            pixel_data_length: metadata.pixel_data_length,
+            last_accessed_ms: current_time_ms(),
+        });
+    }
+
+    Ok(())
+}
+
+fn record_cache_touch(cache_key: &str) {
+    let mut pending_touches = PENDING_CACHE_TOUCHES
+        .lock()
+        .expect("decode cache touches poisoned");
+    pending_touches.insert(cache_key.to_string(), current_time_ms());
+}
+
+fn apply_pending_cache_touches(manifest: &mut DecodeCacheManifest) {
+    let pending_touches = {
+        let mut pending_touches = PENDING_CACHE_TOUCHES
+            .lock()
+            .expect("decode cache touches poisoned");
+        std::mem::take(&mut *pending_touches)
+    };
+
+    if pending_touches.is_empty() {
+        return;
+    }
+
+    for entry in &mut manifest.entries {
+        if let Some(last_accessed_ms) = pending_touches.get(&entry.key) {
+            entry.last_accessed_ms = entry.last_accessed_ms.max(*last_accessed_ms);
+        }
+    }
+}
+
+fn write_atomic_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let temp_path = temporary_cache_path(path);
+    fs::write(&temp_path, bytes)?;
+    fs::rename(temp_path, path)
+}
+
+fn temporary_cache_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("cache-entry");
+    path.with_file_name(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        current_time_ms()
+    ))
 }
 
 fn remove_if_exists(path: &Path) -> std::io::Result<()> {
@@ -513,6 +668,7 @@ fn current_time_ms() -> u128 {
         .as_millis()
 }
 
+#[cfg(test)]
 fn decode_frame_impl(path: &Path, frame_index: u32) -> DecodeResult<DecodedFrame> {
     let object = open_file(path).map_err(|error| {
         DecodeError::new(
@@ -724,7 +880,7 @@ mod tests {
             fs::write(&entry_paths.metadata, "{}").expect("metadata payload should be written");
         }
 
-        enforce_cache_limits(&cache_paths, &mut manifest, 1, 4).expect("eviction should succeed");
+        enforce_cache_limits(&cache_paths, &mut manifest, 1, 4, 1).expect("eviction should succeed");
 
         assert_eq!(manifest.entries.len(), 1);
         assert_eq!(manifest.entries[0].key, "newest");
@@ -753,6 +909,60 @@ mod tests {
 
         assert_eq!(second.pixel_bytes, cached_bytes);
         assert_eq!(second.metadata, first.metadata);
+
+        let _ = fs::remove_dir_all(&cache_paths.dir);
+    }
+
+    #[test]
+    fn reconcile_cache_directory_removes_orphans_and_restores_complete_pairs() {
+        let cache_paths = test_cache_paths("decode-cache-reconcile");
+        let complete_key = "complete";
+        let orphan_raw_key = "orphan-raw";
+        let orphan_json_key = "orphan-json";
+        let temp_file = cache_paths.dir.join(".dangling.tmp-1-1");
+
+        let complete_paths = cache_paths.entry_paths(complete_key);
+        let orphan_raw_paths = cache_paths.entry_paths(orphan_raw_key);
+        let orphan_json_paths = cache_paths.entry_paths(orphan_json_key);
+        let complete_metadata = DecodedFrameMetadata {
+            rows: 1,
+            cols: 1,
+            bits_allocated: 16,
+            pixel_representation: 0,
+            samples_per_pixel: 1,
+            planar_configuration: 0,
+            photometric_interpretation: "MONOCHROME2".into(),
+            window_center: None,
+            window_width: None,
+            rescale_slope: None,
+            rescale_intercept: None,
+            pixel_data_length: 2,
+        };
+
+        fs::write(&complete_paths.pixel_bytes, [1, 0]).expect("complete payload should be written");
+        fs::write(
+            &complete_paths.metadata,
+            serde_json::to_vec(&complete_metadata).expect("complete metadata should serialize"),
+        )
+        .expect("complete metadata should be written");
+        fs::write(&orphan_raw_paths.pixel_bytes, [9, 9]).expect("orphan raw should be written");
+        fs::write(
+            &orphan_json_paths.metadata,
+            serde_json::to_vec(&complete_metadata).expect("orphan metadata should serialize"),
+        )
+        .expect("orphan metadata should be written");
+        fs::write(&temp_file, [0, 1, 2]).expect("temp file should be written");
+
+        let mut manifest = DecodeCacheManifest::default();
+        reconcile_cache_directory(&cache_paths, &mut manifest).expect("reconcile should succeed");
+
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].key, complete_key);
+        assert!(complete_paths.pixel_bytes.exists());
+        assert!(complete_paths.metadata.exists());
+        assert!(!orphan_raw_paths.pixel_bytes.exists());
+        assert!(!orphan_json_paths.metadata.exists());
+        assert!(!temp_file.exists());
 
         let _ = fs::remove_dir_all(&cache_paths.dir);
     }

--- a/docs/js/app/decode-worker.js
+++ b/docs/js/app/decode-worker.js
@@ -87,9 +87,11 @@ self.onmessage = async (event) => {
     if (payload.type !== 'decode-j2k') return;
 
     let decoder = null;
+    let stage = 'codec-init';
 
     try {
         const openjpeg = await initOpenJpegWorker();
+        stage = 'decode';
         decoder = new openjpeg.J2KDecoder();
 
         const encodedBuffer = decoder.getEncodedBuffer(payload.frameData.length);
@@ -106,6 +108,7 @@ self.onmessage = async (event) => {
             console.warn('JPEG 2000 worker decoded unexpected width:', frameInfo.width, payload.expectedCols);
         }
 
+        stage = 'pixel-conversion';
         const pixelData = copyDecodedPixels(
             decoded,
             frameInfo,
@@ -126,7 +129,7 @@ self.onmessage = async (event) => {
         self.postMessage({
             type: 'error',
             requestId: payload.requestId,
-            stage: 'decode',
+            stage,
             message: String(error?.message || error || 'Unknown JPEG 2000 worker error')
         });
     } finally {

--- a/docs/js/app/desktop-decode.js
+++ b/docs/js/app/desktop-decode.js
@@ -1,31 +1,6 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
-
-    function createNativeError(message, stage = 'decode', extra = {}) {
-        const error = new Error(message);
-        error.stage = stage;
-        Object.assign(error, extra);
-        return error;
-    }
-
-    function normalizeNativeError(error, fallbackStage = 'decode') {
-        if (error instanceof Error) {
-            if (typeof error.stage !== 'string' || !error.stage) {
-                error.stage = fallbackStage;
-            }
-            return error;
-        }
-
-        if (error && typeof error === 'object') {
-            return createNativeError(
-                String(error.message || 'Unknown native decode error'),
-                typeof error.stage === 'string' && error.stage ? error.stage : fallbackStage,
-                { details: error.details }
-            );
-        }
-
-        return createNativeError(String(error || 'Unknown native decode error'), fallbackStage);
-    }
+    const { createStagedError, normalizeStagedError, getPixelDataArrayType } = app.utils;
 
     function describeBinaryPayload(payload) {
         if (payload === null) {
@@ -57,43 +32,34 @@
             return normalizeBinaryResponse(bytes.data);
         }
 
-        throw createNativeError(
+        throw createStagedError(
+            'pixel-conversion',
             `Unexpected decoded frame payload shape: ${describeBinaryPayload(bytes)}`,
-            'pixel-conversion'
         );
-    }
-
-    function getPixelDataArrayType(bitsAllocated, pixelRepresentation) {
-        if (bitsAllocated <= 8) {
-            return pixelRepresentation === 1 ? Int8Array : Uint8Array;
-        }
-        if (bitsAllocated <= 16) {
-            return pixelRepresentation === 1 ? Int16Array : Uint16Array;
-        }
-        if (bitsAllocated <= 32) {
-            return pixelRepresentation === 1 ? Int32Array : Uint32Array;
-        }
-        throw new Error(`Unsupported Bits Allocated value from native decode: ${bitsAllocated}`);
     }
 
     function coercePixelData(bytes, bitsAllocated, pixelRepresentation) {
         if (!Number.isFinite(bitsAllocated) || bitsAllocated <= 0 || bitsAllocated % 8 !== 0) {
-            throw createNativeError(
+            throw createStagedError(
+                'pixel-conversion',
                 `Native decode returned a non-byte-aligned Bits Allocated value: ${bitsAllocated}`,
-                'pixel-conversion'
             );
         }
 
         const bytesPerSample = bitsAllocated / 8;
         if (bytes.byteLength % bytesPerSample !== 0) {
-            throw createNativeError(
+            throw createStagedError(
+                'pixel-conversion',
                 `Decoded frame payload length ${bytes.byteLength} is not aligned to ${bitsAllocated}-bit samples.`,
-                'pixel-conversion'
             );
         }
 
         const sampleCount = bytes.byteLength / bytesPerSample;
-        const PixelArrayType = getPixelDataArrayType(bitsAllocated, pixelRepresentation);
+        const PixelArrayType = getPixelDataArrayType(
+            bitsAllocated,
+            pixelRepresentation,
+            'Unsupported Bits Allocated value from native decode'
+        );
         return new PixelArrayType(bytes.buffer, bytes.byteOffset, sampleCount).slice();
     }
 
@@ -101,9 +67,9 @@
         getRuntime() {
             const tauri = window.__TAURI__;
             if (typeof tauri?.core?.invoke !== 'function') {
-                throw createNativeError(
-                    'Desktop decode runtime is not ready. Quit and reopen the app if this persists.',
-                    'codec-init'
+                throw createStagedError(
+                    'codec-init',
+                    'Desktop decode runtime is not ready. Quit and reopen the app if this persists.'
                 );
             }
             return tauri;
@@ -113,7 +79,7 @@
             try {
                 return await this.getRuntime().core.invoke('decode_frame', { path, frameIndex });
             } catch (error) {
-                throw normalizeNativeError(error, 'decode');
+                throw normalizeStagedError(error, 'decode');
             }
         },
 
@@ -122,20 +88,20 @@
                 const bytes = await this.getRuntime().core.invoke('take_decoded_frame', { decodeId });
                 return normalizeBinaryResponse(bytes);
             } catch (error) {
-                throw normalizeNativeError(error, 'pixel-transfer');
+                throw normalizeStagedError(error, 'pixel-transfer');
             }
         },
 
         async decodeFrameWithPixels(path, frameIndex = 0) {
             const metadata = await this.decodeFrame(path, frameIndex);
             if (!metadata?.decodeId) {
-                throw createNativeError('Native decode response did not include a decodeId.', 'pixel-transfer');
+                throw createStagedError('pixel-transfer', 'Native decode response did not include a decodeId.');
             }
             const pixelBytes = await this.takeDecodedFrame(metadata.decodeId);
             if (Number.isFinite(metadata.pixelDataLength) && metadata.pixelDataLength !== pixelBytes.byteLength) {
-                throw createNativeError(
-                    `Decoded frame payload length mismatch: expected ${metadata.pixelDataLength} byte(s), received ${pixelBytes.byteLength}.`,
-                    'pixel-conversion'
+                throw createStagedError(
+                    'pixel-conversion',
+                    `Decoded frame payload length mismatch: expected ${metadata.pixelDataLength} byte(s), received ${pixelBytes.byteLength}.`
                 );
             }
 

--- a/docs/js/app/desktop-decode.js
+++ b/docs/js/app/desktop-decode.js
@@ -1,6 +1,32 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
 
+    function createNativeError(message, stage = 'decode', extra = {}) {
+        const error = new Error(message);
+        error.stage = stage;
+        Object.assign(error, extra);
+        return error;
+    }
+
+    function normalizeNativeError(error, fallbackStage = 'decode') {
+        if (error instanceof Error) {
+            if (typeof error.stage !== 'string' || !error.stage) {
+                error.stage = fallbackStage;
+            }
+            return error;
+        }
+
+        if (error && typeof error === 'object') {
+            return createNativeError(
+                String(error.message || 'Unknown native decode error'),
+                typeof error.stage === 'string' && error.stage ? error.stage : fallbackStage,
+                { details: error.details }
+            );
+        }
+
+        return createNativeError(String(error || 'Unknown native decode error'), fallbackStage);
+    }
+
     function describeBinaryPayload(payload) {
         if (payload === null) {
             return 'null';
@@ -31,7 +57,10 @@
             return normalizeBinaryResponse(bytes.data);
         }
 
-        throw new Error(`Unexpected decoded frame payload shape: ${describeBinaryPayload(bytes)}`);
+        throw createNativeError(
+            `Unexpected decoded frame payload shape: ${describeBinaryPayload(bytes)}`,
+            'pixel-conversion'
+        );
     }
 
     function getPixelDataArrayType(bitsAllocated, pixelRepresentation) {
@@ -49,13 +78,17 @@
 
     function coercePixelData(bytes, bitsAllocated, pixelRepresentation) {
         if (!Number.isFinite(bitsAllocated) || bitsAllocated <= 0 || bitsAllocated % 8 !== 0) {
-            throw new Error(`Native decode returned a non-byte-aligned Bits Allocated value: ${bitsAllocated}`);
+            throw createNativeError(
+                `Native decode returned a non-byte-aligned Bits Allocated value: ${bitsAllocated}`,
+                'pixel-conversion'
+            );
         }
 
         const bytesPerSample = bitsAllocated / 8;
         if (bytes.byteLength % bytesPerSample !== 0) {
-            throw new Error(
-                `Decoded frame payload length ${bytes.byteLength} is not aligned to ${bitsAllocated}-bit samples.`
+            throw createNativeError(
+                `Decoded frame payload length ${bytes.byteLength} is not aligned to ${bitsAllocated}-bit samples.`,
+                'pixel-conversion'
             );
         }
 
@@ -68,26 +101,41 @@
         getRuntime() {
             const tauri = window.__TAURI__;
             if (typeof tauri?.core?.invoke !== 'function') {
-                throw new Error('Desktop decode runtime is not ready. Quit and reopen the app if this persists.');
+                throw createNativeError(
+                    'Desktop decode runtime is not ready. Quit and reopen the app if this persists.',
+                    'codec-init'
+                );
             }
             return tauri;
         },
 
-        decodeFrame(path, frameIndex = 0) {
-            return this.getRuntime().core.invoke('decode_frame', { path, frameIndex });
+        async decodeFrame(path, frameIndex = 0) {
+            try {
+                return await this.getRuntime().core.invoke('decode_frame', { path, frameIndex });
+            } catch (error) {
+                throw normalizeNativeError(error, 'decode');
+            }
         },
 
         async takeDecodedFrame(decodeId) {
-            const bytes = await this.getRuntime().core.invoke('take_decoded_frame', { decodeId });
-            return normalizeBinaryResponse(bytes);
+            try {
+                const bytes = await this.getRuntime().core.invoke('take_decoded_frame', { decodeId });
+                return normalizeBinaryResponse(bytes);
+            } catch (error) {
+                throw normalizeNativeError(error, 'pixel-transfer');
+            }
         },
 
         async decodeFrameWithPixels(path, frameIndex = 0) {
             const metadata = await this.decodeFrame(path, frameIndex);
+            if (!metadata?.decodeId) {
+                throw createNativeError('Native decode response did not include a decodeId.', 'pixel-transfer');
+            }
             const pixelBytes = await this.takeDecodedFrame(metadata.decodeId);
             if (Number.isFinite(metadata.pixelDataLength) && metadata.pixelDataLength !== pixelBytes.byteLength) {
-                throw new Error(
-                    `Decoded frame payload length mismatch: expected ${metadata.pixelDataLength} byte(s), received ${pixelBytes.byteLength}.`
+                throw createNativeError(
+                    `Decoded frame payload length mismatch: expected ${metadata.pixelDataLength} byte(s), received ${pixelBytes.byteLength}.`,
+                    'pixel-conversion'
                 );
             }
 

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -320,6 +320,32 @@
     // Different compression formats require different decoders
     // =====================================================================
 
+    function createStagedError(stage, message, extra = {}) {
+        const error = new Error(message);
+        error.stage = stage;
+        Object.assign(error, extra);
+        return error;
+    }
+
+    function normalizeStagedError(error, fallbackStage = 'decode') {
+        if (error instanceof Error) {
+            if (typeof error.stage !== 'string' || !error.stage) {
+                error.stage = fallbackStage;
+            }
+            return error;
+        }
+
+        if (error && typeof error === 'object') {
+            return createStagedError(
+                typeof error.stage === 'string' && error.stage ? error.stage : fallbackStage,
+                String(error.message || 'Unknown decode error'),
+                { details: error.details }
+            );
+        }
+
+        return createStagedError(fallbackStage, String(error || 'Unknown decode error'));
+    }
+
     /**
      * Decode JPEG Lossless compressed pixel data
      * Uses the jpeg-lossless-decoder-js library
@@ -329,7 +355,7 @@
      * @param {number} rows - Image height
      * @param {number} cols - Image width
      * @param {number} bitsAllocated - Bits per pixel (8 or 16)
-     * @returns {TypedArray|null} Decoded pixel data or null on failure
+     * @returns {TypedArray} Decoded pixel data
      */
     function decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated, frameIndex = 0) {
         try {
@@ -365,8 +391,7 @@
             }
 
             if (!frameData) {
-                console.error('Could not extract frame data');
-                return null;
+                throw createStagedError('frame-extraction', 'Could not extract JPEG Lossless frame data.');
             }
 
             const decoder = new jpeg.lossless.Decoder();
@@ -380,7 +405,7 @@
             }
         } catch (e) {
             console.error('JPEG Lossless decode error:', e);
-            return null;
+            throw normalizeStagedError(e, 'decode');
         }
     }
 
@@ -434,7 +459,7 @@
 
     function formatJpeg2000WorkerError(event, workerUrl) {
         const eventMessage = event?.error?.message || event?.message || 'JPEG 2000 worker error';
-        return new Error(`${eventMessage} (${workerUrl})`);
+        return createStagedError('codec-init', `${eventMessage} (${workerUrl})`);
     }
 
     function pumpJpeg2000WorkerQueue() {
@@ -443,7 +468,7 @@
         }
 
         if (typeof Worker === 'undefined') {
-            const error = new Error('Web Workers are not available for JPEG 2000 decode.');
+            const error = createStagedError('codec-init', 'Web Workers are not available for JPEG 2000 decode.');
             while (jpeg2000WorkerState.queue.length) {
                 jpeg2000WorkerState.queue.shift().reject(error);
             }
@@ -457,7 +482,7 @@
             } catch (error) {
                 jpeg2000WorkerState.worker = null;
                 while (jpeg2000WorkerState.queue.length) {
-                    jpeg2000WorkerState.queue.shift().reject(error);
+                    jpeg2000WorkerState.queue.shift().reject(normalizeStagedError(error, 'codec-init'));
                 }
                 return;
             }
@@ -472,14 +497,21 @@
                     clearTimeout(activeRequest.timeoutId);
                     jpeg2000WorkerState.activeRequest = null;
                     disposeJpeg2000Worker();
-                    activeRequest.reject(new Error('JPEG 2000 worker returned an unexpected response.'));
+                    activeRequest.reject(
+                        createStagedError('pixel-conversion', 'JPEG 2000 worker returned an unexpected response.')
+                    );
                     pumpJpeg2000WorkerQueue();
                     return;
                 }
                 if (payload.type === 'error') {
                     clearTimeout(activeRequest.timeoutId);
                     jpeg2000WorkerState.activeRequest = null;
-                    activeRequest.reject(new Error(payload.message || 'JPEG 2000 worker decode failed'));
+                    activeRequest.reject(
+                        createStagedError(
+                            payload.stage || 'decode',
+                            payload.message || 'JPEG 2000 worker decode failed'
+                        )
+                    );
                     pumpJpeg2000WorkerQueue();
                     return;
                 }
@@ -487,7 +519,9 @@
                     clearTimeout(activeRequest.timeoutId);
                     jpeg2000WorkerState.activeRequest = null;
                     disposeJpeg2000Worker();
-                    activeRequest.reject(new Error('JPEG 2000 worker returned an invalid response.'));
+                    activeRequest.reject(
+                        createStagedError('pixel-conversion', 'JPEG 2000 worker returned an invalid response.')
+                    );
                     pumpJpeg2000WorkerQueue();
                     return;
                 }
@@ -538,7 +572,8 @@
             jpeg2000WorkerState.activeRequest = null;
             disposeJpeg2000Worker();
             request.reject(
-                new Error(
+                createStagedError(
+                    'decode-timeout',
                     `JPEG 2000 decode timeout (${JPEG2000_DECODE_TIMEOUT_MS / 1000}s, ${request.frameByteLength} bytes)`
                 )
             );
@@ -562,7 +597,7 @@
             clearTimeout(request.timeoutId);
             jpeg2000WorkerState.activeRequest = null;
             disposeJpeg2000Worker();
-            request.reject(error);
+            request.reject(normalizeStagedError(error, 'decode'));
             pumpJpeg2000WorkerQueue();
         }
     }
@@ -602,7 +637,7 @@
      * @param {number} cols - Image width
      * @param {number} bitsAllocated - Bits per pixel
      * @param {number} pixelRepresentation - 0=unsigned, 1=signed
-     * @returns {Promise<TypedArray|null>} Decoded pixel data or null on failure
+     * @returns {Promise<TypedArray>} Decoded pixel data
      */
     async function decodeJpeg2000(dataSet, pixelDataElement, rows, cols, bitsAllocated, pixelRepresentation, frameIndex = 0) {
         try {
@@ -610,17 +645,23 @@
 
             const jp2DataElement = dataSet.elements.x7fe00010;
             if (!jp2DataElement.encapsulatedPixelData) {
-                console.error('Pixel data is not encapsulated');
-                return null;
+                throw createStagedError('frame-extraction', 'JPEG 2000 pixel data is not encapsulated.');
             }
 
             const fragments = jp2DataElement.fragments;
             if (!fragments || fragments.length === 0) {
-                console.error('No fragments found for JPEG 2000');
-                return null;
+                throw createStagedError('frame-extraction', 'No fragments found for JPEG 2000 pixel data.');
             }
 
-            const j2kData = getEncapsulatedFrameData(dataSet, jp2DataElement, frameIndex);
+            let j2kData;
+            try {
+                j2kData = getEncapsulatedFrameData(dataSet, jp2DataElement, frameIndex);
+            } catch (error) {
+                throw createStagedError(
+                    'frame-extraction',
+                    String(error?.message || error || 'Failed to extract encapsulated JPEG 2000 frame data.')
+                );
+            }
             console.log('JPEG 2000 data length:', j2kData.length, 'bytes');
 
             return await decodeJ2KInWorker(
@@ -633,7 +674,7 @@
 
         } catch (e) {
             console.error('JPEG 2000 decode error:', e);
-            return null;
+            throw normalizeStagedError(e, 'decode');
         }
     }
 
@@ -645,7 +686,7 @@
      * @param {Object} pixelDataElement - Pixel data element (unused)
      * @param {number} rows - Image height
      * @param {number} cols - Image width
-     * @returns {Promise<Object|null>} {pixels, isRgb} or null on failure
+     * @returns {Promise<Object>} {pixels, isRgb}
      */
     async function decodeJpegBaseline(dataSet, pixelDataElement, rows, cols, frameIndex = 0) {
         try {
@@ -669,7 +710,7 @@
             return { pixels, isRgb: true };
         } catch (e) {
             console.error('JPEG Baseline decode error:', e);
-            return null;
+            throw normalizeStagedError(e, 'decode');
         }
     }
 

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -1,7 +1,7 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { canvas, ctx } = app.dom;
-    const { getString, getNumber } = app.utils;
+    const { getString, getNumber, createStagedError, normalizeStagedError } = app.utils;
 
     // =====================================================================
     // DICOM PARSING
@@ -319,32 +319,6 @@
     // IMAGE DECODING
     // Different compression formats require different decoders
     // =====================================================================
-
-    function createStagedError(stage, message, extra = {}) {
-        const error = new Error(message);
-        error.stage = stage;
-        Object.assign(error, extra);
-        return error;
-    }
-
-    function normalizeStagedError(error, fallbackStage = 'decode') {
-        if (error instanceof Error) {
-            if (typeof error.stage !== 'string' || !error.stage) {
-                error.stage = fallbackStage;
-            }
-            return error;
-        }
-
-        if (error && typeof error === 'object') {
-            return createStagedError(
-                typeof error.stage === 'string' && error.stage ? error.stage : fallbackStage,
-                String(error.message || 'Unknown decode error'),
-                { details: error.details }
-            );
-        }
-
-        return createStagedError(fallbackStage, String(error || 'Unknown decode error'));
-    }
 
     /**
      * Decode JPEG Lossless compressed pixel data

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -96,7 +96,7 @@
      * @param {string} message - Main error message
      * @param {string} details - Additional details (e.g., format name)
      */
-    function displayError(message, details) {
+    function displayError(message, details, diagnostics = []) {
         canvas.width = 512;
         canvas.height = 512;
         ctx.fillStyle = '#1a1a2e';
@@ -111,15 +111,24 @@
         ctx.font = '14px -apple-system, sans-serif';
         ctx.fillText(message, canvas.width / 2, 240);
 
+        let nextLineY = 270;
         if (details) {
             ctx.fillStyle = '#888';
             ctx.font = '12px -apple-system, sans-serif';
-            ctx.fillText(details, canvas.width / 2, 270);
+            ctx.fillText(details, canvas.width / 2, nextLineY);
+            nextLineY += 28;
+        }
+
+        for (const diagnosticLine of diagnostics.filter(Boolean)) {
+            ctx.fillStyle = '#9aa5b1';
+            ctx.font = '12px -apple-system, sans-serif';
+            ctx.fillText(diagnosticLine, canvas.width / 2, nextLineY);
+            nextLineY += 20;
         }
 
         ctx.fillStyle = '#666';
         ctx.font = '12px -apple-system, sans-serif';
-        ctx.fillText('This format may require additional decoders', canvas.width / 2, 310);
+        ctx.fillText('This format may require additional decoders', canvas.width / 2, Math.max(nextLineY + 12, 310));
     }
 
     function buildRenderInfo(decoded, windowCenter, windowWidth, extra = {}) {
@@ -140,8 +149,35 @@
             error: true,
             errorMessage,
             errorDetails,
+            stage: extra.stage || 'decode',
             ...extra
         };
+    }
+
+    function getDecodeFailureStage(error, fallbackStage = 'decode') {
+        return typeof error?.stage === 'string' && error.stage ? error.stage : fallbackStage;
+    }
+
+    function buildDecodeDiagnosticLines(errorInfo) {
+        const diagnosticLines = [];
+        if (errorInfo.stage) {
+            diagnosticLines.push(`Stage: ${errorInfo.stage}`);
+        }
+        if (errorInfo.tsInfo?.name) {
+            diagnosticLines.push(`Transfer Syntax: ${errorInfo.tsInfo.name}`);
+        } else if (errorInfo.transferSyntax) {
+            diagnosticLines.push(`Transfer Syntax UID: ${errorInfo.transferSyntax}`);
+        }
+        if (errorInfo.modality) {
+            diagnosticLines.push(`Modality: ${errorInfo.modality}`);
+        }
+        if (errorInfo.jsErrorStage) {
+            diagnosticLines.push(`JS Stage: ${errorInfo.jsErrorStage}`);
+        }
+        if (errorInfo.nativeErrorStage) {
+            diagnosticLines.push(`Native Stage: ${errorInfo.nativeErrorStage}`);
+        }
+        return diagnosticLines.slice(0, 5);
     }
 
     function getOptionalNumber(dataSet, tag) {
@@ -262,7 +298,7 @@
         if (!nativeFailure && jsFailure?.error) {
             return {
                 ...jsFailure,
-                stage: jsFailure.stage || 'decode',
+                stage: getDecodeFailureStage(jsFailure),
                 transferSyntax: jsFailure.transferSyntax || transferSyntax,
                 modality: jsFailure.modality || modality,
                 tsInfo: jsFailure.tsInfo || tsInfo
@@ -281,11 +317,13 @@
             'Image decode failed',
             detailParts.join(' | ') || tsInfo.name,
             {
-                stage: 'decode',
+                stage: getDecodeFailureStage(jsFailure, getDecodeFailureStage(nativeFailure)),
                 transferSyntax,
                 modality,
                 tsInfo,
+                jsErrorStage: jsFailure ? getDecodeFailureStage(jsFailure) : null,
                 jsErrorMessage: jsFailure ? getDecodeFailureMessage(jsFailure) : null,
+                nativeErrorStage: nativeFailure ? getDecodeFailureStage(nativeFailure) : null,
                 nativeErrorMessage: nativeFailure ? getDecodeFailureMessage(nativeFailure) : null
             }
         );
@@ -308,13 +346,21 @@
 
     function renderDecodeError(errorInfo, options = {}) {
         const { display = true } = options;
+        const normalizedError = {
+            ...errorInfo,
+            diagnosticLines: errorInfo.diagnosticLines || buildDecodeDiagnosticLines(errorInfo)
+        };
         state.pixelSpacing = null;
         app.tools.updateCalibrationWarning();
         if (display) {
-            displayError(errorInfo.errorMessage, errorInfo.errorDetails);
+            displayError(
+                normalizedError.errorMessage,
+                normalizedError.errorDetails,
+                normalizedError.diagnosticLines
+            );
             app.tools.drawMeasurements?.();
         }
-        return errorInfo;
+        return normalizedError;
     }
 
     async function decodeDicom(dataSet, frameIndex = 0) {
@@ -360,7 +406,12 @@
             return buildDecodeError(
                 'No pixel data found',
                 'The DICOM file may be corrupted or incomplete',
-                { transferSyntax, tsInfo: transferSyntaxInfo }
+                {
+                    stage: 'frame-extraction',
+                    transferSyntax,
+                    modality,
+                    tsInfo: transferSyntaxInfo
+                }
             );
         }
 
@@ -373,38 +424,64 @@
         if (isCompressedData) {
             // Decode compressed pixel data using appropriate decoder
             if (isJpeg2000(transferSyntax)) {
-                pixelData = await decodeJpeg2000(
-                    dataSet,
-                    pixelDataElement,
-                    rows,
-                    cols,
-                    bitsAllocated,
-                    pixelRepresentation,
-                    frameIndex
-                );
-                if (!pixelData) {
+                try {
+                    pixelData = await decodeJpeg2000(
+                        dataSet,
+                        pixelDataElement,
+                        rows,
+                        cols,
+                        bitsAllocated,
+                        pixelRepresentation,
+                        frameIndex
+                    );
+                } catch (error) {
                     return buildDecodeError(
                         'JPEG 2000 decode failed',
-                        transferSyntaxInfo.name,
-                        { transferSyntax, tsInfo: transferSyntaxInfo }
+                        getDecodeFailureMessage(error),
+                        {
+                            stage: getDecodeFailureStage(error),
+                            transferSyntax,
+                            modality,
+                            tsInfo: transferSyntaxInfo
+                        }
                     );
                 }
             } else if (isJpegLossless(transferSyntax)) {
-                pixelData = decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated, frameIndex);
-                if (!pixelData) {
+                try {
+                    pixelData = decodeJpegLossless(
+                        dataSet,
+                        pixelDataElement,
+                        rows,
+                        cols,
+                        bitsAllocated,
+                        frameIndex
+                    );
+                } catch (error) {
                     return buildDecodeError(
                         'JPEG Lossless decode failed',
-                        transferSyntaxInfo.name,
-                        { transferSyntax, tsInfo: transferSyntaxInfo }
+                        getDecodeFailureMessage(error),
+                        {
+                            stage: getDecodeFailureStage(error),
+                            transferSyntax,
+                            modality,
+                            tsInfo: transferSyntaxInfo
+                        }
                     );
                 }
             } else if (isJpegBaseline(transferSyntax)) {
-                const result = await decodeJpegBaseline(dataSet, pixelDataElement, rows, cols, frameIndex);
-                if (!result) {
+                let result;
+                try {
+                    result = await decodeJpegBaseline(dataSet, pixelDataElement, rows, cols, frameIndex);
+                } catch (error) {
                     return buildDecodeError(
                         'JPEG decode failed',
-                        transferSyntaxInfo.name,
-                        { transferSyntax, tsInfo: transferSyntaxInfo }
+                        getDecodeFailureMessage(error),
+                        {
+                            stage: getDecodeFailureStage(error),
+                            transferSyntax,
+                            modality,
+                            tsInfo: transferSyntaxInfo
+                        }
                     );
                 }
                 pixelData = result.pixels;
@@ -414,7 +491,12 @@
                 return buildDecodeError(
                     'Unsupported compression format',
                     transferSyntaxInfo.name,
-                    { transferSyntax, tsInfo: transferSyntaxInfo }
+                    {
+                        stage: 'decode',
+                        transferSyntax,
+                        modality,
+                        tsInfo: transferSyntaxInfo
+                    }
                 );
             }
         } else {
@@ -433,8 +515,13 @@
                 console.error('Native pixel data decode error:', error);
                 return buildDecodeError(
                     'Native pixel data decode failed',
-                    String(error?.message || error || 'Unknown native decode error'),
-                    { transferSyntax, tsInfo: transferSyntaxInfo }
+                    getDecodeFailureMessage(error),
+                    {
+                        stage: getDecodeFailureStage(error, 'pixel-conversion'),
+                        transferSyntax,
+                        modality,
+                        tsInfo: transferSyntaxInfo
+                    }
                 );
             }
         }
@@ -461,7 +548,9 @@
 
     async function decodeNative(dataSet, filePath, frameIndex = 0) {
         if (!filePath) {
-            throw new Error('Native decode requires a desktop path-backed slice.');
+            const error = new Error('Native decode requires a desktop path-backed slice.');
+            error.stage = 'decode';
+            throw error;
         }
 
         const nativeDecoded = await app.desktopDecode.decodeFrameWithPixels(filePath, frameIndex);
@@ -510,7 +599,12 @@
                 photometricInterpretation !== 'MONOCHROME1' &&
                 photometricInterpretation !== 'MONOCHROME2'
         };
-        validateRenderedPixelData(decoded, 'Native decode');
+        try {
+            validateRenderedPixelData(decoded, 'Native decode');
+        } catch (error) {
+            error.stage = getDecodeFailureStage(error, 'pixel-conversion');
+            throw error;
+        }
         return finalizeDecodedImage(decoded, hasWindowLevel);
     }
 

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -3,7 +3,7 @@
     const config = window.CONFIG;
     const { state } = app;
     const { canvas, ctx } = app.dom;
-    const { getString, getNumber } = app.utils;
+    const { getString, getNumber, getPixelDataArrayType } = app.utils;
     const {
         isCompressed,
         isJpegLossless,
@@ -25,19 +25,6 @@
         ['1.2.840.10008.1.2.4.90', new Set(['RF', 'XA'])],
         ['1.2.840.10008.1.2.4.91', new Set(['RF', 'XA'])]
     ]);
-
-    function getPixelDataArrayType(bitsAllocated, pixelRepresentation) {
-        if (bitsAllocated <= 8) {
-            return pixelRepresentation === 1 ? Int8Array : Uint8Array;
-        }
-        if (bitsAllocated <= 16) {
-            return pixelRepresentation === 1 ? Int16Array : Uint16Array;
-        }
-        if (bitsAllocated <= 32) {
-            return pixelRepresentation === 1 ? Int32Array : Uint32Array;
-        }
-        throw new Error(`Unsupported Bits Allocated value: ${bitsAllocated}`);
-    }
 
     function getUncompressedFramePixelData(
         dataSet,

--- a/docs/js/app/utils.js
+++ b/docs/js/app/utils.js
@@ -32,6 +32,42 @@
                 const r = Math.random() * 16 | 0;
                 return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
             });
+        },
+        createStagedError(stage, message, extra = {}) {
+            const error = new Error(message);
+            error.stage = stage;
+            Object.assign(error, extra);
+            return error;
+        },
+        normalizeStagedError(error, fallbackStage = 'decode') {
+            if (error instanceof Error) {
+                if (typeof error.stage !== 'string' || !error.stage) {
+                    error.stage = fallbackStage;
+                }
+                return error;
+            }
+
+            if (error && typeof error === 'object') {
+                return utils.createStagedError(
+                    typeof error.stage === 'string' && error.stage ? error.stage : fallbackStage,
+                    String(error.message || 'Unknown decode error'),
+                    { details: error.details }
+                );
+            }
+
+            return utils.createStagedError(fallbackStage, String(error || 'Unknown decode error'));
+        },
+        getPixelDataArrayType(bitsAllocated, pixelRepresentation, errorPrefix = 'Unsupported Bits Allocated value') {
+            if (bitsAllocated <= 8) {
+                return pixelRepresentation === 1 ? Int8Array : Uint8Array;
+            }
+            if (bitsAllocated <= 16) {
+                return pixelRepresentation === 1 ? Int16Array : Uint16Array;
+            }
+            if (bitsAllocated <= 32) {
+                return pixelRepresentation === 1 ? Int32Array : Uint32Array;
+            }
+            throw new Error(`${errorPrefix}: ${bitsAllocated}`);
         }
     };
 

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -728,6 +728,83 @@ test.describe('Desktop library scanning', () => {
         ]));
     });
 
+    test('renderDicom fallback diagnostics include both js and native failure stages', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const ctx = document.getElementById('imageCanvas').getContext('2d');
+            const drawnText = [];
+            const originalFillText = ctx.fillText.bind(ctx);
+            ctx.fillText = (...args) => {
+                drawnText.push(String(args[0]));
+                return originalFillText(...args);
+            };
+
+            app.desktopDecode.decodeFrameWithPixels = async () => {
+                const error = new Error('Native decoder timed out');
+                error.stage = 'decode-timeout';
+                throw error;
+            };
+
+            try {
+                const info = await app.rendering.renderDicom({
+                    elements: {},
+                    string(tag) {
+                        const values = {
+                            x00020010: '1.2.840.10008.1.2.1',
+                            x00080060: 'CT',
+                            x00280004: 'MONOCHROME2'
+                        };
+                        return values[tag] || '';
+                    },
+                    uint16(tag) {
+                        const values = {
+                            x00280010: 4,
+                            x00280011: 4,
+                            x00280100: 16,
+                            x00280103: 0,
+                            x00280002: 1
+                        };
+                        return values[tag] || 0;
+                    }
+                }, null, 0, {
+                    frameIndex: 0,
+                    source: {
+                        kind: 'path',
+                        path: '/library/fallback-failure.dcm'
+                    }
+                });
+
+                return {
+                    info,
+                    drawnText
+                };
+            } finally {
+                ctx.fillText = originalFillText;
+            }
+        });
+
+        expect(result.info).toMatchObject({
+            error: true,
+            stage: 'frame-extraction',
+            jsErrorStage: 'frame-extraction',
+            nativeErrorStage: 'decode-timeout'
+        });
+        expect(result.info.diagnosticLines).toEqual(expect.arrayContaining([
+            'Stage: frame-extraction',
+            'Transfer Syntax: Explicit VR Little Endian',
+            'Modality: CT',
+            'JS Stage: frame-extraction',
+            'Native Stage: decode-timeout'
+        ]));
+        expect(result.drawnText).toEqual(expect.arrayContaining([
+            'JS Stage: frame-extraction',
+            'Native Stage: decode-timeout'
+        ]));
+    });
+
     test('decodeDicom returns a detached copy of uncompressed pixel data', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -675,6 +675,59 @@ test.describe('Desktop library scanning', () => {
         expect(result.after).toEqual(result.before);
     });
 
+    test('renderDicom error overlay includes stage-level diagnostics', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const ctx = document.getElementById('imageCanvas').getContext('2d');
+            const drawnText = [];
+            const originalFillText = ctx.fillText.bind(ctx);
+            ctx.fillText = (...args) => {
+                drawnText.push(String(args[0]));
+                return originalFillText(...args);
+            };
+
+            try {
+                const info = await window.DicomViewerApp.rendering.renderDicom({
+                    elements: {},
+                    string(tag) {
+                        const values = {
+                            x00020010: '1.2.840.10008.1.2.4.90',
+                            x00080060: 'RF'
+                        };
+                        return values[tag] || '';
+                    },
+                    uint16() {
+                        return 0;
+                    }
+                });
+
+                return {
+                    info,
+                    drawnText
+                };
+            } finally {
+                ctx.fillText = originalFillText;
+            }
+        });
+
+        expect(result.info).toMatchObject({
+            error: true,
+            stage: 'frame-extraction'
+        });
+        expect(result.info.diagnosticLines).toEqual(expect.arrayContaining([
+            'Stage: frame-extraction',
+            'Transfer Syntax: JPEG 2000 Lossless',
+            'Modality: RF'
+        ]));
+        expect(result.drawnText).toEqual(expect.arrayContaining([
+            'Stage: frame-extraction',
+            'Transfer Syntax: JPEG 2000 Lossless',
+            'Modality: RF'
+        ]));
+    });
+
     test('decodeDicom returns a detached copy of uncompressed pixel data', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);

--- a/tests/desktop-native-decode.spec.js
+++ b/tests/desktop-native-decode.spec.js
@@ -62,8 +62,14 @@ async function installMockDesktopDecode(page, options = {}) {
                     case 'plugin:event|unlisten':
                         return null;
                     case 'decode_frame':
+                        if (opts.decodeFrameError) {
+                            throw opts.decodeFrameError;
+                        }
                         return metadata;
                     case 'take_decoded_frame': {
+                        if (opts.takeDecodedFrameError) {
+                            throw opts.takeDecodedFrameError;
+                        }
                         const frame = decodedFrames.get(args.decodeId);
                         if (!frame) {
                             throw new Error(`Decoded frame not found: ${args.decodeId}`);
@@ -172,44 +178,81 @@ test('desktop decode bridge surfaces a runtime-ready error when invoke is unavai
     const message = await page.evaluate(async () => {
         try {
             await window.DicomViewerApp.desktopDecode.decodeFrame('/mock/no-runtime.dcm', 0);
-            return null;
+            return {};
         } catch (error) {
-            return String(error?.message || error);
+            return {
+                message: String(error?.message || error),
+                stage: error?.stage || null
+            };
         }
     });
 
-    expect(message).toContain('Desktop decode runtime is not ready');
+    expect(message.message).toContain('Desktop decode runtime is not ready');
+    expect(message.stage).toBe('codec-init');
+});
+
+test('desktop decode bridge preserves structured native error stages', async ({ page }) => {
+    await installMockDesktopDecode(page, {
+        decodeFrameError: {
+            stage: 'decode-timeout',
+            message: 'Native decode timed out after 30s.'
+        }
+    });
+    await page.goto(HOME_URL);
+
+    const failure = await page.evaluate(async () => {
+        try {
+            await window.DicomViewerApp.desktopDecode.decodeFrame('/mock/study/timeout.dcm', 0);
+            return {};
+        } catch (error) {
+            return {
+                message: String(error?.message || error),
+                stage: error?.stage || null
+            };
+        }
+    });
+
+    expect(failure.message).toContain('Native decode timed out after 30s.');
+    expect(failure.stage).toBe('decode-timeout');
 });
 
 test('desktop decode bridge surfaces invalid decode ids', async ({ page }) => {
     await installMockDesktopDecode(page);
     await page.goto(HOME_URL);
 
-    const message = await page.evaluate(async () => {
+    const failure = await page.evaluate(async () => {
         try {
             await window.DicomViewerApp.desktopDecode.takeDecodedFrame('missing-decode-id');
-            return null;
+            return {};
         } catch (error) {
-            return String(error?.message || error);
+            return {
+                message: String(error?.message || error),
+                stage: error?.stage || null
+            };
         }
     });
 
-    expect(message).toContain('Decoded frame not found: missing-decode-id');
+    expect(failure.message).toContain('Decoded frame not found: missing-decode-id');
+    expect(failure.stage).toBe('pixel-transfer');
 });
 
 test('desktop decode bridge rejects malformed binary payloads', async ({ page }) => {
     await installMockDesktopDecode(page, { binaryResponseMode: 'invalid-object' });
     await page.goto(HOME_URL);
 
-    const message = await page.evaluate(async () => {
+    const failure = await page.evaluate(async () => {
         try {
             await window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/bad-payload.dcm', 0);
-            return null;
+            return {};
         } catch (error) {
-            return String(error?.message || error);
+            return {
+                message: String(error?.message || error),
+                stage: error?.stage || null
+            };
         }
     });
 
-    expect(message).toContain('Unexpected decoded frame payload shape');
-    expect(message).toContain('bogus');
+    expect(failure.message).toContain('Unexpected decoded frame payload shape');
+    expect(failure.message).toContain('bogus');
+    expect(failure.stage).toBe('pixel-conversion');
 });

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -276,3 +276,16 @@ test('desktop CSP allows the JPEG 2000 worker to load OpenJPEG WASM', async () =
     expect(tauriConfig.app.security.csp).toContain("worker-src 'self' 'wasm-unsafe-eval'");
     expect(tauriConfig.app.security.devCsp).toContain("worker-src 'self' 'wasm-unsafe-eval'");
 });
+
+test('desktop fs scope includes the native decode cache directory', async () => {
+    const capabilityPath = path.join(__dirname, '..', 'desktop', 'src-tauri', 'capabilities', 'default.json');
+    const capability = JSON.parse(fs.readFileSync(capabilityPath, 'utf8'));
+    const fsScope = capability.permissions.find(
+        permission => permission && typeof permission === 'object' && permission.identifier === 'fs:scope'
+    );
+
+    expect(fsScope?.allow).toEqual(expect.arrayContaining([
+        { path: '$APPDATA/decode-cache' },
+        { path: '$APPDATA/decode-cache/**' }
+    ]));
+});

--- a/tests/jpeg2000-worker.spec.js
+++ b/tests/jpeg2000-worker.spec.js
@@ -130,13 +130,15 @@ test('decodeJ2KInWorker times out and terminates a hanging worker', async ({ pag
 
         try {
             let errorMessage = null;
+            let errorStage = null;
             try {
                 await window.DicomViewerApp.dicom.decodeJ2KInWorker(new Uint8Array([9, 8, 7]), 16, 0, 1, 1);
             } catch (error) {
                 errorMessage = String(error?.message || error);
+                errorStage = error?.stage || null;
             }
 
-            return { errorMessage, terminated };
+            return { errorMessage, errorStage, terminated };
         } finally {
             window.Worker = originalWorker;
             window.setTimeout = originalSetTimeout;
@@ -145,6 +147,7 @@ test('decodeJ2KInWorker times out and terminates a hanging worker', async ({ pag
 
     expect(result.errorMessage).toContain('JPEG 2000 decode timeout');
     expect(result.errorMessage).toContain('3 bytes');
+    expect(result.errorStage).toBe('decode-timeout');
     expect(result.terminated).toBe(true);
 });
 
@@ -173,13 +176,15 @@ test('decodeJ2KInWorker includes the worker URL when the worker fails to load', 
 
         try {
             let errorMessage = null;
+            let errorStage = null;
             try {
                 await window.DicomViewerApp.dicom.decodeJ2KInWorker(new Uint8Array([1]), 16, 0, 1, 1);
             } catch (error) {
                 errorMessage = String(error?.message || error);
+                errorStage = error?.stage || null;
             }
 
-            return { errorMessage, terminated };
+            return { errorMessage, errorStage, terminated };
         } finally {
             window.Worker = originalWorker;
         }
@@ -187,6 +192,7 @@ test('decodeJ2KInWorker includes the worker URL when the worker fails to load', 
 
     expect(result.errorMessage).toContain('Script error.');
     expect(result.errorMessage).toContain('/js/app/decode-worker.js');
+    expect(result.errorStage).toBe('codec-init');
     expect(result.terminated).toBe(true);
 });
 

--- a/tests/jpeg2000-worker.spec.js
+++ b/tests/jpeg2000-worker.spec.js
@@ -237,37 +237,6 @@ test('decodeJpeg2000 decodes a real JPEG 2000 DICOM to the same pixels as its un
             bitsAllocated,
             pixelRepresentation
         );
-        if (!decodedPixels) {
-            let workerErrorMessage = null;
-            try {
-                const frameData = window.DicomViewerApp.dicom.getEncapsulatedFrameData(
-                    jpeg2000DataSet,
-                    jpeg2000DataSet.elements.x7fe00010,
-                    0
-                );
-                await window.DicomViewerApp.dicom.decodeJ2KInWorker(
-                    frameData,
-                    bitsAllocated,
-                    pixelRepresentation,
-                    rows,
-                    cols
-                );
-            } catch (error) {
-                workerErrorMessage = String(error?.message || error);
-            }
-
-            return {
-                decodedType: null,
-                sampleCount,
-                allEqual: false,
-                firstEightDecoded: [],
-                firstEightNative: [],
-                checksumDecoded: null,
-                checksumNative: null,
-                workerErrorMessage
-            };
-        }
-
         const nativePixels = readUncompressedPixels(uncompressedDataSet, sampleCount);
 
         let allEqual = decodedPixels.length === nativePixels.length;


### PR DESCRIPTION
## Summary
- add a disk-backed native decode cache in the Tauri backend with manifest-based eviction and cache scope coverage
- normalize native and JPEG 2000 worker failures into stage-aware errors and render stage diagnostics on the canvas overlay
- extend Rust and Playwright coverage for cache hits, error staging, overlay diagnostics, and desktop capability scope

## Validation
- cargo test
- npx playwright test tests/desktop-library.spec.js tests/desktop-native-decode.spec.js tests/desktop-runtime-compat.spec.js tests/jpeg2000-worker.spec.js
- npx playwright test