### PR TITLE
Add Tauri macOS release plan

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -36,6 +36,7 @@ Master index of all project documentation, organized by audience and purpose.
 
 | Document | Location | Description |
 |----------|----------|-------------|
+| [Tauri Release Plan](./planning/PLAN-tauri-release.md) | docs/planning/ | Release plan for the signed/notarized macOS desktop artifact, clean-Mac QA, and publication workflow |
 | [3D Volume Rendering Plan](../3D_VOLUME_RENDERING_PLAN.md) | Root | Implementation plan for 3D features: vtk.js, volume rendering, MIP |
 | [Tauri Desktop Plan](./planning/PLAN-tauri-desktop-app.md) | docs/planning/ | Restored historical plan for the Tauri desktop shell, with the original 6-PR breakdown and the commits/PRs that completed it |
 | [Project Sitemap](./planning/SITEMAP.md) | docs/planning/ | File structure map and active work tracking |
@@ -94,6 +95,7 @@ Research, decision logs, and feature planning.
 ```
 docs/planning/
 ├── PLAN-tauri-desktop-app.md                # Historical Tauri desktop implementation plan
+├── PLAN-tauri-release.md                    # Tauri macOS release plan
 ├── SITEMAP.md                              # Project structure map
 ├── RESEARCH-3d-volume-rendering.md         # 3D rendering research
 ├── RESEARCH-measurement-tool.md            # Measurement tool benchmarking
@@ -109,7 +111,8 @@ Architecture Decision Records (ADRs) for significant decisions and rationale.
 docs/decisions/
 ├── README.md                               # ADR template and conventions
 ├── 001-launch-command.md                   # Decision record for launch.command startup
-└── 002-persistent-local-library.md         # Decision record for persistent DICOM library
+├── 002-persistent-local-library.md         # Decision record for persistent DICOM library
+└── 003-tauri-desktop-shell-with-shared-web-core.md  # Decision record for the Tauri desktop direction
 ```
 
 ---
@@ -192,6 +195,9 @@ Project structure map showing workspace layout, file organization, and current w
 
 **PLAN-tauri-desktop-app.md**
 Historical implementation plan for the Tauri desktop shell. Restores the original 6-PR breakdown and maps it to the commits and PRs that shipped the desktop app.
+
+**PLAN-tauri-release.md**
+Release plan for shipping the Tauri desktop app as a signed, notarized macOS artifact. Covers release candidate freeze, Apple credentials, CI signing/notarization, clean-Mac QA, and publication.
 
 **RESEARCH-*.md**
 Research documents capturing benchmarking and analysis before feature implementation. Includes competitive analysis, technology comparisons, and design rationale.

--- a/docs/planning/PLAN-tauri-release.md
+++ b/docs/planning/PLAN-tauri-release.md
@@ -1,0 +1,271 @@
+# Tauri macOS Release Plan
+
+## Overview
+
+Ship the Tauri desktop app as a real macOS release artifact: signed, notarized, stapled, and downloadable as a DMG.
+
+**Status**: Planned
+**As of**: March 9, 2026
+
+This plan starts after the Tauri desktop implementation work. The app already builds and runs on macOS, but the release/distribution work is still open.
+
+Related documents:
+- `docs/decisions/003-tauri-desktop-shell-with-shared-web-core.md`
+- `docs/history/session-summaries.md` (historical implementation timeline)
+
+---
+
+## Current State
+
+### Already done
+
+- Tauri desktop shell is implemented
+- Desktop library persistence is implemented
+- Desktop notes/report persistence is implemented
+- Native menus, icons, and general desktop productization work are implemented
+- Browser regression coverage exists via Playwright
+- CI already builds an unsigned macOS `.app` bundle in `.github/workflows/pr-validate.yml`
+
+### Still missing
+
+- Apple Developer Program enrollment and release credentials
+- Developer ID signing for the shipped app
+- Apple notarization and ticket stapling
+- Signed DMG artifact generation in CI
+- Clean-Mac install/release validation
+- GitHub release publication process
+
+### Scope decision before cutting a release candidate
+
+Decide whether the first signed desktop release includes the native desktop decode stack (PRs `#19` through `#23`).
+
+- If yes: merge that stack before cutting the release candidate.
+- If no: cut the release from the already-merged desktop shell and ship native decode in a later release.
+
+Do not mix that decision into the release week itself. Make it before the release candidate is frozen.
+
+---
+
+## Release Goal
+
+Produce these release artifacts:
+
+| Artifact | Purpose |
+|----------|---------|
+| Signed `.app` | Native macOS application bundle |
+| Notarized, stapled `.dmg` | Public installer/download artifact |
+| SHA256 checksum | Integrity verification for the published release |
+| Release notes | Version, install notes, known limitations |
+| Clean-Mac QA checklist | Manual release gate evidence |
+
+---
+
+## Release Gates
+
+The release is not complete until all of these are true:
+
+- `npx playwright test` passes on the release candidate commit
+- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` passes
+- macOS CI builds the app bundle successfully
+- Signed DMG build succeeds in CI
+- Apple notarization succeeds
+- Stapling succeeds for the shipped artifacts
+- Clean-Mac install/launch checklist passes end-to-end
+- No blocker issues remain in launch, file access, JPEG 2000 rendering, persistence, or quit/relaunch behavior
+
+---
+
+## Phase 1: Freeze the Release Candidate
+
+### Purpose
+
+Pick the exact commit that will become the release and stop mixing feature work with release work.
+
+### Tasks
+
+1. Decide whether native desktop decode is in or out for this release.
+2. Merge any required pre-release PRs.
+3. Cut a release candidate branch or tag from `main`.
+4. Stop landing unrelated feature work onto that release candidate.
+5. Update `CHANGELOG.md` with the desktop release notes draft.
+
+### Exit criteria
+
+- One release candidate commit is identified
+- Feature scope is frozen
+- Release notes draft exists
+
+---
+
+## Phase 2: Apple Account and Credentials
+
+### Purpose
+
+Acquire the Apple-side prerequisites needed for public macOS distribution.
+
+### Tasks
+
+1. Enroll the company/app owner in the Apple Developer Program.
+2. Create or confirm the Apple Team ID to use for release builds.
+3. Create a `Developer ID Application` signing certificate for the shipped app.
+4. Create notarization credentials for CI.
+5. Store all signing/notarization material in CI secrets.
+
+### CI inputs to prepare
+
+- Signing certificate material
+- Certificate password, if exported as a file
+- Signing identity name
+- Apple team identifier
+- Notarization credentials or API key material
+
+### Exit criteria
+
+- A local test machine can sign the app
+- CI has the required secrets configured
+
+---
+
+## Phase 3: Build, Sign, and Notarize in CI
+
+### Purpose
+
+Move from an unsigned build smoke to a repeatable release artifact pipeline.
+
+### Existing baseline
+
+`pr-validate.yml` already proves an unsigned macOS app bundle can be built:
+
+```bash
+npm run tauri build -- --bundles app
+```
+
+### Required release work
+
+1. Add a release-oriented macOS workflow or extend the existing macOS build path.
+2. Build the desktop app from `desktop/`.
+3. Produce a DMG bundle:
+
+```bash
+npm run tauri build -- --bundles dmg
+```
+
+4. Sign the generated app bundle.
+5. Submit the signed artifact for notarization.
+6. Staple the notarization ticket to the shipped artifact.
+7. Publish the DMG and checksum as CI artifacts for the release job.
+
+### Deliverables
+
+- Signed `.app`
+- Notarized, stapled `.dmg`
+- SHA256 checksum file
+- Build log with signing/notarization success
+
+### Exit criteria
+
+- CI can produce a signed, notarized, stapled DMG without manual patching
+
+---
+
+## Phase 4: Clean-Mac Release Validation
+
+### Purpose
+
+Validate the actual user experience on a machine that does not have a dev environment hiding packaging problems.
+
+### Test environment
+
+- A clean macOS machine
+- No local source checkout required
+- No dev certificates, local cargo toolchain, or Tauri CLI assumptions
+
+### Manual checklist
+
+1. Download the DMG from the release artifact.
+2. Open the DMG and drag the app to `Applications`.
+3. Launch the app through Finder.
+4. Confirm Gatekeeper behavior is normal for a signed/notarized app.
+5. Verify the app opens without a blank shell or missing assets.
+6. Verify sample data loads.
+7. Verify folder selection works.
+8. Verify drag-drop loading works.
+9. Verify library persistence survives relaunch.
+10. Verify notes persistence survives relaunch.
+11. Verify report persistence survives relaunch.
+12. Verify JPEG 2000 rendering works.
+13. If native desktop decode is in-scope, verify it on a real study.
+14. Quit and relaunch the app; verify state and permissions behave correctly.
+15. Re-test after revoking and re-granting folder access, if applicable.
+
+### Exit criteria
+
+- The entire install-to-use flow works on a clean machine with no release blockers
+
+---
+
+## Phase 5: Publish the Release
+
+### Purpose
+
+Turn the validated artifact into a public release that users can download confidently.
+
+### Tasks
+
+1. Create a GitHub release from the release candidate tag.
+2. Upload the stapled DMG.
+3. Upload the checksum file.
+4. Publish release notes with:
+   - version number
+   - minimum supported macOS version
+   - install instructions
+   - known limitations
+   - whether native desktop decode is included
+5. Keep the previous artifact available for rollback if a hotfix is needed.
+
+### Exit criteria
+
+- Public release page exists
+- Downloadable artifact matches the validated build
+
+---
+
+## Phase 6: Post-Release Watch
+
+### Purpose
+
+Handle first-release packaging and environment issues quickly.
+
+### Tasks
+
+1. Monitor for install failures, Gatekeeper complaints, and launch failures.
+2. Watch for desktop-only decode/render bugs.
+3. Watch for permission and persistence regressions.
+4. Keep a fast-follow patch window open immediately after release.
+
+### Exit criteria
+
+- No release-blocking desktop issues are emerging
+- Any hotfix work is clearly prioritized
+
+---
+
+## Recommended Sequence
+
+1. Make the native-decode inclusion decision.
+2. Freeze a release candidate.
+3. Complete Apple enrollment and credentials.
+4. Wire signing/notarization into CI.
+5. Produce the first signed/notarized DMG.
+6. Run the clean-Mac checklist.
+7. Publish the release.
+
+---
+
+## Out of Scope
+
+- Windows distribution
+- Auto-updater rollout
+- App Store distribution
+- Cloud sync or account features
+- New desktop features unrelated to shipping the existing app

--- a/docs/planning/SITEMAP.md
+++ b/docs/planning/SITEMAP.md
@@ -37,6 +37,7 @@ Research, decisions, and reference materials for feature development.
 | File | Description |
 |------|-------------|
 | `PLAN-tauri-desktop-app.md` | Historical implementation plan for the Tauri desktop shell, restored from the original Claude-authored planning doc and annotated with the commits/PRs that completed it |
+| `PLAN-tauri-release.md` | Release plan for shipping the Tauri desktop app as a signed, notarized macOS DMG: RC freeze, Apple credentials, CI signing/notarization, clean-Mac QA, publication |
 | `PLAN-notes.md` | Notes feature (descriptions + comments): design decisions, storage rationale, future improvements, recommended tests |
 | `RESEARCH-3d-volume-rendering.md` | 3D volume rendering research: architecture decisions, modularity, graceful degradation, testability considerations. Related: [CLAUDE.md Current Work](#current-work-in-progress) |
 | `RESEARCH-measurement-tool.md` | Benchmarking of measurement tools (Horos, NilRead, Ambra, Sectra UniView): calibration, pixel spacing, interaction models, display formats, clinical warnings. Related: [Feature Inventory - Measurement tool](../index.html) |


### PR DESCRIPTION
## Summary
- add a dedicated Tauri macOS release plan covering RC freeze, Apple signing/notarization, clean-Mac QA, and publication
- link the new plan from the docs planning index and master docs index
- add the missing ADR-003 entry to the docs index while touching the docs navigation

## Validation
- not run (docs-only change)
