### PR TITLE
Add plain DMG release path

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "Tauri desktop shell for DICOM Viewer",
   "scripts": {
+    "build:plain-dmg": "./scripts/build-plain-dmg.sh",
     "dev:web": "python3 -m http.server 1420 --bind 127.0.0.1 --directory ../docs",
     "tauri": "tauri"
   },

--- a/desktop/scripts/build-plain-dmg.sh
+++ b/desktop/scripts/build-plain-dmg.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "Plain DMG packaging is only supported on macOS." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DESKTOP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+    cat <<'EOF'
+Build a plain macOS DMG for the Tauri desktop app.
+
+This path intentionally skips Finder AppleScript styling so it can run
+reliably in automation and other non-interactive environments.
+
+Usage:
+  ./scripts/build-plain-dmg.sh [--output /path/to/output.dmg]
+EOF
+}
+
+OUTPUT_PATH=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o|--output)
+            OUTPUT_PATH="${2:-}"
+            if [[ -z "$OUTPUT_PATH" ]]; then
+                echo "--output requires a path." >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+cd "$DESKTOP_DIR"
+
+PRODUCT_NAME="$(node -p "require('./src-tauri/tauri.conf.json').productName")"
+VERSION="$(node -p "require('./src-tauri/tauri.conf.json').version")"
+ARCH="$(uname -m)"
+APP_BUNDLE="src-tauri/target/release/bundle/macos/${PRODUCT_NAME}.app"
+DMG_DIR="src-tauri/target/release/bundle/dmg"
+DEFAULT_OUTPUT="${DMG_DIR}/${PRODUCT_NAME}_${VERSION}_${ARCH}_plain.dmg"
+
+if [[ -z "$OUTPUT_PATH" ]]; then
+    OUTPUT_PATH="$DEFAULT_OUTPUT"
+fi
+
+mkdir -p "$DMG_DIR" "$(dirname "$OUTPUT_PATH")"
+
+echo "Building ${PRODUCT_NAME}.app..."
+npm run tauri build -- --bundles app
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "Expected app bundle was not produced: $APP_BUNDLE" >&2
+    exit 1
+fi
+
+STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dicom-viewer-plain-dmg.XXXXXX")"
+cleanup() {
+    rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
+
+# Avoid copying Finder metadata from previous manual DMG experiments.
+rm -f "src-tauri/target/release/bundle/macos/.DS_Store"
+
+echo "Preparing plain DMG staging directory..."
+ditto "$APP_BUNDLE" "${STAGING_DIR}/$(basename "$APP_BUNDLE")"
+ln -s /Applications "${STAGING_DIR}/Applications"
+
+echo "Packaging plain DMG at ${OUTPUT_PATH}..."
+rm -f "$OUTPUT_PATH"
+hdiutil create \
+    -volname "$PRODUCT_NAME" \
+    -srcfolder "$STAGING_DIR" \
+    -fs HFS+ \
+    -format UDZO \
+    -imagekey zlib-level=9 \
+    -ov \
+    "$OUTPUT_PATH"
+
+echo "Plain DMG created: $OUTPUT_PATH"

--- a/desktop/scripts/build-plain-dmg.sh
+++ b/desktop/scripts/build-plain-dmg.sh
@@ -7,6 +7,11 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
+if ! command -v node >/dev/null 2>&1; then
+    echo "Node.js is required to read Tauri metadata from src-tauri/tauri.conf.json." >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DESKTOP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
@@ -18,13 +23,23 @@ This path intentionally skips Finder AppleScript styling so it can run
 reliably in automation and other non-interactive environments.
 
 Usage:
-  ./scripts/build-plain-dmg.sh [--output /path/to/output.dmg]
+  ./scripts/build-plain-dmg.sh [--skip-build] [--output /path/to/output.dmg]
+
+Examples:
+  ./scripts/build-plain-dmg.sh
+  npm run build:plain-dmg -- --output /tmp/DICOM-Viewer.dmg
+  ./scripts/build-plain-dmg.sh --skip-build --output /tmp/DICOM-Viewer-signed.dmg
 EOF
 }
 
 OUTPUT_PATH=""
+SKIP_BUILD=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --skip-build)
+            SKIP_BUILD=1
+            shift
+            ;;
         -o|--output)
             OUTPUT_PATH="${2:-}"
             if [[ -z "$OUTPUT_PATH" ]]; then
@@ -60,8 +75,12 @@ fi
 
 mkdir -p "$DMG_DIR" "$(dirname "$OUTPUT_PATH")"
 
-echo "Building ${PRODUCT_NAME}.app..."
-npm run tauri build -- --bundles app
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+    echo "Building ${PRODUCT_NAME}.app..."
+    npm run tauri build -- --bundles app
+else
+    echo "Skipping app build and packaging the existing bundle..."
+fi
 
 if [[ ! -d "$APP_BUNDLE" ]]; then
     echo "Expected app bundle was not produced: $APP_BUNDLE" >&2
@@ -75,7 +94,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Avoid copying Finder metadata from previous manual DMG experiments.
-rm -f "src-tauri/target/release/bundle/macos/.DS_Store"
+find "src-tauri/target/release/bundle/macos" -name '.DS_Store' -delete
 
 echo "Preparing plain DMG staging directory..."
 ditto "$APP_BUNDLE" "${STAGING_DIR}/$(basename "$APP_BUNDLE")"
@@ -89,7 +108,6 @@ hdiutil create \
     -fs HFS+ \
     -format UDZO \
     -imagekey zlib-level=9 \
-    -ov \
     "$OUTPUT_PATH"
 
 echo "Plain DMG created: $OUTPUT_PATH"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -36,7 +36,7 @@ Master index of all project documentation, organized by audience and purpose.
 
 | Document | Location | Description |
 |----------|----------|-------------|
-| [Tauri Release Plan](./planning/PLAN-tauri-release.md) | docs/planning/ | Release plan for the signed/notarized macOS desktop artifact, clean-Mac QA, and publication workflow |
+| [Tauri Release Plan](./planning/PLAN-tauri-release.md) | docs/planning/ | Release plan for the signed/notarized macOS desktop artifact, using the plain DMG path for reliable packaging, clean-Mac QA, and publication workflow |
 | [3D Volume Rendering Plan](../3D_VOLUME_RENDERING_PLAN.md) | Root | Implementation plan for 3D features: vtk.js, volume rendering, MIP |
 | [Tauri Desktop Plan](./planning/PLAN-tauri-desktop-app.md) | docs/planning/ | Restored historical plan for the Tauri desktop shell, with the original 6-PR breakdown and the commits/PRs that completed it |
 | [Project Sitemap](./planning/SITEMAP.md) | docs/planning/ | File structure map and active work tracking |
@@ -197,7 +197,7 @@ Project structure map showing workspace layout, file organization, and current w
 Historical implementation plan for the Tauri desktop shell. Restores the original 6-PR breakdown and maps it to the commits and PRs that shipped the desktop app.
 
 **PLAN-tauri-release.md**
-Release plan for shipping the Tauri desktop app as a signed, notarized macOS artifact. Covers release candidate freeze, Apple credentials, CI signing/notarization, clean-Mac QA, and publication.
+Release plan for shipping the Tauri desktop app as a signed, notarized macOS artifact. The official packaging path currently uses a plain DMG for reliability and defers Finder-styled DMG cosmetics to later work.
 
 **RESEARCH-*.md**
 Research documents capturing benchmarking and analysis before feature implementation. Includes competitive analysis, technology comparisons, and design rationale.

--- a/docs/planning/PLAN-tauri-release.md
+++ b/docs/planning/PLAN-tauri-release.md
@@ -4,7 +4,7 @@
 
 Ship the Tauri desktop app as a real macOS release artifact: signed, notarized, stapled, and downloadable as a plain DMG.
 
-**Status**: Planned
+**Status**: In Progress
 **As of**: March 9, 2026
 
 This plan starts after the Tauri desktop implementation work. The app already builds and runs on macOS, but the release/distribution work is still open.
@@ -161,18 +161,29 @@ That script:
 - stages `DICOM Viewer.app` plus an `Applications` symlink
 - packages a plain DMG with `hdiutil`
 - skips Finder AppleScript styling entirely
+- also supports `--skip-build`, so release automation can package an already-signed `.app`
 
 ### Required release work
 
 1. Add a release-oriented macOS workflow or extend the existing macOS build path.
-2. Build the desktop app from `desktop/`.
-3. Produce a plain DMG bundle:
+2. Build the desktop app from `desktop/`:
 
 ```bash
-npm run build:plain-dmg
+npm run tauri build -- --bundles app
 ```
 
-4. Sign the generated app bundle.
+3. Sign the app bundle before packaging:
+
+```bash
+desktop/src-tauri/target/release/bundle/macos/DICOM\ Viewer.app
+```
+
+4. Produce a plain DMG from the already-signed app bundle:
+
+```bash
+npm run build:plain-dmg -- --skip-build
+```
+
 5. Submit the signed artifact for notarization.
 6. Staple the notarization ticket to the shipped artifact.
 7. Publish the DMG and checksum as CI artifacts for the release job.

--- a/docs/planning/PLAN-tauri-release.md
+++ b/docs/planning/PLAN-tauri-release.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Ship the Tauri desktop app as a real macOS release artifact: signed, notarized, stapled, and downloadable as a DMG.
+Ship the Tauri desktop app as a real macOS release artifact: signed, notarized, stapled, and downloadable as a plain DMG.
 
 **Status**: Planned
 **As of**: March 9, 2026
@@ -16,6 +16,16 @@ Related documents:
 ---
 
 ## Current State
+
+### Current artifact policy
+
+The official release path is now a plain DMG that skips Finder window styling.
+
+- Use `npm run build:plain-dmg` in `desktop/` for local packaging
+- This path builds the `.app`, stages the app plus an `Applications` symlink, and creates a functional DMG with `hdiutil`
+- It intentionally avoids the Finder AppleScript styling step used by Tauri's generated `create-dmg` flow
+- Reason: on March 9, 2026 the styled DMG flow was verified to fail in automation with Finder `AppleEvent timed out (-1712)`, while the plain DMG path worked
+- A polished drag-to-Applications DMG can be added later as a separate manual-release path
 
 ### Already done
 
@@ -53,7 +63,7 @@ Produce these release artifacts:
 | Artifact | Purpose |
 |----------|---------|
 | Signed `.app` | Native macOS application bundle |
-| Notarized, stapled `.dmg` | Public installer/download artifact |
+| Notarized, stapled plain `.dmg` | Public installer/download artifact |
 | SHA256 checksum | Integrity verification for the published release |
 | Release notes | Version, install notes, known limitations |
 | Clean-Mac QA checklist | Manual release gate evidence |
@@ -67,7 +77,7 @@ The release is not complete until all of these are true:
 - `npx playwright test` passes on the release candidate commit
 - `cargo test --manifest-path desktop/src-tauri/Cargo.toml` passes
 - macOS CI builds the app bundle successfully
-- Signed DMG build succeeds in CI
+- Signed plain DMG build succeeds in CI
 - Apple notarization succeeds
 - Stapling succeeds for the shipped artifacts
 - Clean-Mac install/launch checklist passes end-to-end
@@ -140,14 +150,26 @@ Move from an unsigned build smoke to a repeatable release artifact pipeline.
 npm run tauri build -- --bundles app
 ```
 
+The plain DMG path is now a repo-owned wrapper:
+
+```bash
+npm run build:plain-dmg
+```
+
+That script:
+- builds the app bundle with `tauri build -- --bundles app`
+- stages `DICOM Viewer.app` plus an `Applications` symlink
+- packages a plain DMG with `hdiutil`
+- skips Finder AppleScript styling entirely
+
 ### Required release work
 
 1. Add a release-oriented macOS workflow or extend the existing macOS build path.
 2. Build the desktop app from `desktop/`.
-3. Produce a DMG bundle:
+3. Produce a plain DMG bundle:
 
 ```bash
-npm run tauri build -- --bundles dmg
+npm run build:plain-dmg
 ```
 
 4. Sign the generated app bundle.
@@ -158,13 +180,13 @@ npm run tauri build -- --bundles dmg
 ### Deliverables
 
 - Signed `.app`
-- Notarized, stapled `.dmg`
+- Notarized, stapled plain `.dmg`
 - SHA256 checksum file
 - Build log with signing/notarization success
 
 ### Exit criteria
 
-- CI can produce a signed, notarized, stapled DMG without manual patching
+- CI can produce a signed, notarized, stapled plain DMG without manual patching
 
 ---
 
@@ -182,7 +204,7 @@ Validate the actual user experience on a machine that does not have a dev enviro
 
 ### Manual checklist
 
-1. Download the DMG from the release artifact.
+1. Download the plain DMG from the release artifact.
 2. Open the DMG and drag the app to `Applications`.
 3. Launch the app through Finder.
 4. Confirm Gatekeeper behavior is normal for a signed/notarized app.
@@ -213,7 +235,7 @@ Turn the validated artifact into a public release that users can download confid
 ### Tasks
 
 1. Create a GitHub release from the release candidate tag.
-2. Upload the stapled DMG.
+2. Upload the stapled plain DMG.
 3. Upload the checksum file.
 4. Publish release notes with:
    - version number
@@ -227,6 +249,18 @@ Turn the validated artifact into a public release that users can download confid
 
 - Public release page exists
 - Downloadable artifact matches the validated build
+
+---
+
+## Future Enhancement: Styled DMG
+
+The Finder-styled DMG is deferred work, not the current release path.
+
+If we revisit it later, treat it as a manual-release enhancement with its own validation:
+
+- restore a polished Finder layout only after the AppleScript timeout is understood and reliable
+- keep the plain DMG path as the automation-safe fallback
+- do not block signed/notarized releases on Finder cosmetics
 
 ---
 

--- a/docs/planning/SITEMAP.md
+++ b/docs/planning/SITEMAP.md
@@ -37,7 +37,7 @@ Research, decisions, and reference materials for feature development.
 | File | Description |
 |------|-------------|
 | `PLAN-tauri-desktop-app.md` | Historical implementation plan for the Tauri desktop shell, restored from the original Claude-authored planning doc and annotated with the commits/PRs that completed it |
-| `PLAN-tauri-release.md` | Release plan for shipping the Tauri desktop app as a signed, notarized macOS DMG: RC freeze, Apple credentials, CI signing/notarization, clean-Mac QA, publication |
+| `PLAN-tauri-release.md` | Release plan for shipping the Tauri desktop app as a signed, notarized macOS artifact, with the plain DMG as the official packaging path and Finder-styled DMG work deferred |
 | `PLAN-notes.md` | Notes feature (descriptions + comments): design decisions, storage rationale, future improvements, recommended tests |
 | `RESEARCH-3d-volume-rendering.md` | 3D volume rendering research: architecture decisions, modularity, graceful degradation, testability considerations. Related: [CLAUDE.md Current Work](#current-work-in-progress) |
 | `RESEARCH-measurement-tool.md` | Benchmarking of measurement tools (Horos, NilRead, Ambra, Sectra UniView): calibration, pixel spacing, interaction models, display formats, clinical warnings. Related: [Feature Inventory - Measurement tool](../index.html) |


### PR DESCRIPTION
## Summary
- add a repo-owned `desktop/scripts/build-plain-dmg.sh` wrapper that builds the `.app`, stages the app plus an `Applications` symlink, and packages a plain DMG without Finder AppleScript
- expose the new packaging path as `npm run build:plain-dmg` in `desktop/package.json`
- update the Tauri release docs to make the plain DMG the official artifact path for now and defer Finder-styled DMG cosmetics

## Validation
- `npm run build:plain-dmg -- --output /tmp/dicom-viewer-plain-validate.dmg`

## Notes
- local validation required unsandboxed macOS access because `hdiutil create` cannot run inside the Codex sandbox
- left `.claude/` untouched