### PR TITLE
Fix RGB secondary capture rendering

### DIFF
--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -253,7 +253,11 @@
         }
 
         let { windowCenter, windowWidth } = decoded;
-        if (!hasWindowLevel && (decoded.modality === 'MR' || decoded.modality === 'PT' || decoded.modality === 'NM')) {
+        if (
+            !hasWindowLevel &&
+            decoded.samplesPerPixel === 1 &&
+            (decoded.modality === 'MR' || decoded.modality === 'PT' || decoded.modality === 'NM')
+        ) {
             const autoWL = calculateAutoWindowLevel(decoded.pixelData, decoded.rescaleSlope, decoded.rescaleIntercept);
             windowCenter = autoWL.windowCenter;
             windowWidth = autoWL.windowWidth;
@@ -484,7 +488,7 @@
                 }
                 pixelData = result.pixels;
                 if (result.isRgb) {
-                    // Browser JPEG decode gives us display-ready grayscale values.
+                    // Browser JPEG decode path currently returns a display-ready single channel.
                     decodedSamplesPerPixel = 1;
                     decodedPlanarConfiguration = 0;
                     decodedPhotometricInterpretation = 'MONOCHROME2';
@@ -725,11 +729,17 @@
         if (decoded.samplesPerPixel === 3 && decoded.photometricInterpretation === 'RGB') {
             const planeSize = decoded.rows * decoded.cols;
             for (let i = 0; i < planeSize; i++) {
-                const rgbIndex = decoded.planarConfiguration === 1 ? i : i * 3;
                 const pixelIndex = i * 4;
-                outputPixels[pixelIndex] = decoded.pixelData[rgbIndex];
-                outputPixels[pixelIndex + 1] = decoded.pixelData[decoded.planarConfiguration === 1 ? i + planeSize : rgbIndex + 1];
-                outputPixels[pixelIndex + 2] = decoded.pixelData[decoded.planarConfiguration === 1 ? i + (planeSize * 2) : rgbIndex + 2];
+                if (decoded.planarConfiguration === 1) {
+                    outputPixels[pixelIndex] = decoded.pixelData[i];
+                    outputPixels[pixelIndex + 1] = decoded.pixelData[i + planeSize];
+                    outputPixels[pixelIndex + 2] = decoded.pixelData[i + (planeSize * 2)];
+                } else {
+                    const interleavedIndex = i * 3;
+                    outputPixels[pixelIndex] = decoded.pixelData[interleavedIndex];
+                    outputPixels[pixelIndex + 1] = decoded.pixelData[interleavedIndex + 1];
+                    outputPixels[pixelIndex + 2] = decoded.pixelData[interleavedIndex + 2];
+                }
                 outputPixels[pixelIndex + 3] = 255;
             }
         } else {

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -229,15 +229,22 @@
             );
         }
 
-        if (decoded.samplesPerPixel !== 1) {
+        const isRgb = decoded.samplesPerPixel === 3 && decoded.photometricInterpretation === 'RGB';
+        if (decoded.samplesPerPixel !== 1 && !isRgb) {
             throw new Error(
-                `${sourceLabel} returned ${decoded.samplesPerPixel} sample(s) per pixel, but the current renderer only supports monochrome fallback data.`
+                `${sourceLabel} returned ${decoded.samplesPerPixel} sample(s) per pixel with photometric interpretation ${decoded.photometricInterpretation || 'unknown'}, but the current renderer only supports monochrome and RGB fallback data.`
+            );
+        }
+
+        if (isRgb && decoded.planarConfiguration !== 0 && decoded.planarConfiguration !== 1) {
+            throw new Error(
+                `${sourceLabel} returned RGB data with unsupported Planar Configuration ${decoded.planarConfiguration}.`
             );
         }
     }
 
     function finalizeDecodedImage(decoded, hasWindowLevel) {
-        if (isBlankSlice(decoded.pixelData, decoded.rescaleSlope, decoded.rescaleIntercept)) {
+        if (decoded.samplesPerPixel === 1 && isBlankSlice(decoded.pixelData, decoded.rescaleSlope, decoded.rescaleIntercept)) {
             console.log('Detected blank slice (all pixels same value)');
             return {
                 ...decoded,
@@ -357,7 +364,11 @@
         const bitsAllocated = dataSet.uint16('x00280100') || 16;  // (0028,0100) Bits Allocated
         const pixelRepresentation = dataSet.uint16('x00280103') || 0;  // (0028,0103) 0=unsigned, 1=signed
         const samplesPerPixel = dataSet.uint16('x00280002') || 1;
+        const planarConfiguration = samplesPerPixel > 1 ? (dataSet.uint16('x00280006') || 0) : 0;
         const photometricInterpretation = getString(dataSet, 'x00280004');
+        let decodedSamplesPerPixel = samplesPerPixel;
+        let decodedPlanarConfiguration = planarConfiguration;
+        let decodedPhotometricInterpretation = photometricInterpretation;
 
         // Get modality for appropriate defaults
         const modality = getString(dataSet, 'x00080060');  // (0008,0060) Modality
@@ -472,7 +483,13 @@
                     );
                 }
                 pixelData = result.pixels;
-                skipWindowLevel = result.isRgb; // Already 0-255 from JPEG decode
+                if (result.isRgb) {
+                    // Browser JPEG decode gives us display-ready grayscale values.
+                    decodedSamplesPerPixel = 1;
+                    decodedPlanarConfiguration = 0;
+                    decodedPhotometricInterpretation = 'MONOCHROME2';
+                    skipWindowLevel = true;
+                }
             } else {
                 // Unsupported compression format
                 return buildDecodeError(
@@ -513,14 +530,15 @@
             }
         }
 
-        return finalizeDecodedImage({
+        const decoded = {
             pixelData,
             rows,
             cols,
             bitsAllocated,
             pixelRepresentation,
-            samplesPerPixel,
-            photometricInterpretation,
+            samplesPerPixel: decodedSamplesPerPixel,
+            planarConfiguration: decodedPlanarConfiguration,
+            photometricInterpretation: decodedPhotometricInterpretation,
             windowCenter,
             windowWidth,
             rescaleSlope,
@@ -530,7 +548,23 @@
             mrMetadata,
             pixelSpacing,
             skipWindowLevel
-        }, hasWindowLevel);
+        };
+        try {
+            validateRenderedPixelData(decoded, 'Decoded image');
+        } catch (error) {
+            return buildDecodeError(
+                'Decoded pixel data is not renderable',
+                getDecodeFailureMessage(error),
+                {
+                    stage: getDecodeFailureStage(error, 'pixel-conversion'),
+                    transferSyntax,
+                    modality,
+                    tsInfo: transferSyntaxInfo
+                }
+            );
+        }
+
+        return finalizeDecodedImage(decoded, hasWindowLevel);
     }
 
     async function decodeNative(dataSet, filePath, frameIndex = 0) {
@@ -549,6 +583,7 @@
         const bitsAllocated = Number(nativeDecoded.bitsAllocated);
         const pixelRepresentation = Number(nativeDecoded.pixelRepresentation);
         const samplesPerPixel = Number(nativeDecoded.samplesPerPixel || 1);
+        const planarConfiguration = Number(nativeDecoded.planarConfiguration || 0);
         const {
             windowCenter,
             windowWidth,
@@ -572,6 +607,7 @@
             bitsAllocated,
             pixelRepresentation,
             samplesPerPixel,
+            planarConfiguration,
             photometricInterpretation,
             windowCenter,
             windowWidth,
@@ -686,26 +722,38 @@
         const windowMax = windowCenter + windowWidth / 2;
         const windowDivisor = Math.max(windowMax - windowMin, 1);
 
-        // Apply rescale and window/level transform to each pixel
-        for (let i = 0; i < decoded.pixelData.length; i++) {
-            let grayscaleValue;
-            if (decoded.skipWindowLevel) {
-                // Already 0-255 (e.g., from JPEG baseline decode)
-                grayscaleValue = decoded.pixelData[i];
-            } else {
-                // Apply rescale slope/intercept
-                // CT: converts to Hounsfield Units; MR: arbitrary signal intensity
-                let pixelValue = decoded.pixelData[i] * decoded.rescaleSlope + decoded.rescaleIntercept;
-                // Clamp to window range and scale to 0-255
-                pixelValue = Math.max(windowMin, Math.min(windowMax, pixelValue));
-                grayscaleValue = Math.round(((pixelValue - windowMin) / windowDivisor) * 255);
+        if (decoded.samplesPerPixel === 3 && decoded.photometricInterpretation === 'RGB') {
+            const planeSize = decoded.rows * decoded.cols;
+            for (let i = 0; i < planeSize; i++) {
+                const rgbIndex = decoded.planarConfiguration === 1 ? i : i * 3;
+                const pixelIndex = i * 4;
+                outputPixels[pixelIndex] = decoded.pixelData[rgbIndex];
+                outputPixels[pixelIndex + 1] = decoded.pixelData[decoded.planarConfiguration === 1 ? i + planeSize : rgbIndex + 1];
+                outputPixels[pixelIndex + 2] = decoded.pixelData[decoded.planarConfiguration === 1 ? i + (planeSize * 2) : rgbIndex + 2];
+                outputPixels[pixelIndex + 3] = 255;
             }
-            // Set RGBA values (grayscale = R=G=B, alpha=255)
-            const pixelIndex = i * 4;
-            outputPixels[pixelIndex] = grayscaleValue;      // R
-            outputPixels[pixelIndex + 1] = grayscaleValue;  // G
-            outputPixels[pixelIndex + 2] = grayscaleValue;  // B
-            outputPixels[pixelIndex + 3] = 255;             // A (opaque)
+        } else {
+            // Apply rescale and window/level transform to each pixel
+            for (let i = 0; i < decoded.pixelData.length; i++) {
+                let grayscaleValue;
+                if (decoded.skipWindowLevel) {
+                    // Already 0-255 (e.g., from JPEG baseline decode)
+                    grayscaleValue = decoded.pixelData[i];
+                } else {
+                    // Apply rescale slope/intercept
+                    // CT: converts to Hounsfield Units; MR: arbitrary signal intensity
+                    let pixelValue = decoded.pixelData[i] * decoded.rescaleSlope + decoded.rescaleIntercept;
+                    // Clamp to window range and scale to 0-255
+                    pixelValue = Math.max(windowMin, Math.min(windowMax, pixelValue));
+                    grayscaleValue = Math.round(((pixelValue - windowMin) / windowDivisor) * 255);
+                }
+                // Set RGBA values (grayscale = R=G=B, alpha=255)
+                const pixelIndex = i * 4;
+                outputPixels[pixelIndex] = grayscaleValue;      // R
+                outputPixels[pixelIndex + 1] = grayscaleValue;  // G
+                outputPixels[pixelIndex + 2] = grayscaleValue;  // B
+                outputPixels[pixelIndex + 3] = 255;             // A (opaque)
+            }
         }
 
         // Draw to canvas and keep the measurement overlay aligned with the new image size.

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -928,7 +928,7 @@ test.describe('Desktop library scanning', () => {
         expect(result.pixelSpacing).toEqual({ row: 0.5, col: 0.25 });
     });
 
-    test('decodeDicom plus renderPixels preserves uncompressed RGB secondary-capture pixels', async ({ page }) => {
+    test('decodeDicom plus renderPixels preserves uncompressed interleaved RGB secondary-capture pixels', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
 
@@ -994,6 +994,82 @@ test.describe('Desktop library scanning', () => {
             cols: 2,
             transferSyntax: '1.2.840.10008.1.2.1',
             modality: 'OT'
+        });
+        expect(result.rgba).toEqual([
+            255, 0, 0, 255,
+            0, 255, 0, 255
+        ]);
+    });
+
+    test('decodeDicom plus renderPixels preserves planar RGB pixels and keeps MR defaults intact', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const { state, rendering } = window.DicomViewerApp;
+            state.baseWindowLevel = { center: null, width: null };
+            state.pixelSpacing = null;
+
+            const byteArray = new Uint8Array([
+                255, 0,
+                0, 255,
+                0, 0
+            ]);
+            const dataSet = {
+                byteArray,
+                elements: {
+                    x7fe00010: {
+                        dataOffset: 0,
+                        length: byteArray.byteLength
+                    }
+                },
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'MR',
+                        x00280004: 'RGB'
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    const values = {
+                        x00280010: 1,
+                        x00280011: 2,
+                        x00280100: 8,
+                        x00280103: 0,
+                        x00280002: 3,
+                        x00280006: 1
+                    };
+                    return values[tag] || 0;
+                }
+            };
+
+            const decoded = await rendering.decodeDicom(dataSet, 0);
+            const info = rendering.renderPixels(decoded);
+            const canvas = document.getElementById('imageCanvas');
+            const rgba = Array.from(canvas.getContext('2d').getImageData(0, 0, 2, 1).data);
+
+            return {
+                decodedError: decoded.error || false,
+                samplesPerPixel: decoded.samplesPerPixel,
+                planarConfiguration: decoded.planarConfiguration,
+                photometricInterpretation: decoded.photometricInterpretation,
+                info,
+                rgba
+            };
+        });
+
+        expect(result.decodedError).toBe(false);
+        expect(result.samplesPerPixel).toBe(3);
+        expect(result.planarConfiguration).toBe(1);
+        expect(result.photometricInterpretation).toBe('RGB');
+        expect(result.info).toMatchObject({
+            rows: 1,
+            cols: 2,
+            wc: 512,
+            ww: 1024,
+            transferSyntax: '1.2.840.10008.1.2.1',
+            modality: 'MR'
         });
         expect(result.rgba).toEqual([
             255, 0, 0, 255,

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -928,6 +928,79 @@ test.describe('Desktop library scanning', () => {
         expect(result.pixelSpacing).toEqual({ row: 0.5, col: 0.25 });
     });
 
+    test('decodeDicom plus renderPixels preserves uncompressed RGB secondary-capture pixels', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const { state, rendering } = window.DicomViewerApp;
+            state.baseWindowLevel = { center: null, width: null };
+            state.pixelSpacing = null;
+
+            const byteArray = new Uint8Array([
+                255, 0, 0,
+                0, 255, 0
+            ]);
+            const dataSet = {
+                byteArray,
+                elements: {
+                    x7fe00010: {
+                        dataOffset: 0,
+                        length: byteArray.byteLength
+                    }
+                },
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'OT',
+                        x00280004: 'RGB'
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    const values = {
+                        x00280010: 1,
+                        x00280011: 2,
+                        x00280100: 8,
+                        x00280103: 0,
+                        x00280002: 3,
+                        x00280006: 0
+                    };
+                    return values[tag] || 0;
+                }
+            };
+
+            const decoded = await rendering.decodeDicom(dataSet, 0);
+            const info = rendering.renderPixels(decoded);
+            const canvas = document.getElementById('imageCanvas');
+            const rgba = Array.from(canvas.getContext('2d').getImageData(0, 0, 2, 1).data);
+
+            return {
+                decodedError: decoded.error || false,
+                samplesPerPixel: decoded.samplesPerPixel,
+                planarConfiguration: decoded.planarConfiguration,
+                photometricInterpretation: decoded.photometricInterpretation,
+                info,
+                rgba
+            };
+        });
+
+        expect(result.decodedError).toBe(false);
+        expect(result.samplesPerPixel).toBe(3);
+        expect(result.planarConfiguration).toBe(0);
+        expect(result.photometricInterpretation).toBe('RGB');
+        expect(result.info).toMatchObject({
+            rows: 1,
+            cols: 2,
+            transferSyntax: '1.2.840.10008.1.2.1',
+            modality: 'OT'
+        });
+        expect(result.rgba).toEqual([
+            255, 0, 0, 255,
+            0, 255, 0, 255
+        ]);
+    });
+
     test('decodeNative rejects native payloads whose sample count does not match the geometry', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -75,6 +75,18 @@ async function getSliceInfo(page) {
     return null;
 }
 
+async function waitForSliceCurrent(page, expectedCurrent, timeout = 10000) {
+    await page.waitForFunction(
+        ({ selector, expected }) => {
+            const text = document.querySelector(selector)?.textContent || '';
+            const match = text.match(/(\d+)\s*\/\s*(\d+)/);
+            return Boolean(match) && Number(match[1]) === expected;
+        },
+        { selector: SLICE_INFO_SELECTOR, expected: expectedCurrent },
+        { timeout }
+    );
+}
+
 async function isButtonActive(page, selector) {
     const button = page.locator(selector);
     const classList = await button.getAttribute('class');
@@ -506,7 +518,7 @@ test.describe('Test Suite 16: Viewer Navigation Controls', () => {
         const initialSlice = await getSliceInfo(page);
 
         await page.click(NEXT_SLICE_SELECTOR);
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current + 1);
 
         const newSlice = await getSliceInfo(page);
         expect(newSlice.current).toBe(initialSlice.current + 1);
@@ -514,13 +526,14 @@ test.describe('Test Suite 16: Viewer Navigation Controls', () => {
 
     test('Previous slice button goes back by one slice', async ({ page }) => {
         // First, advance one slice so we can go back
+        const initialSlice = await getSliceInfo(page);
         await page.click(NEXT_SLICE_SELECTOR);
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current + 1);
 
         const midSlice = await getSliceInfo(page);
 
         await page.click(PREV_SLICE_SELECTOR);
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current);
 
         const backSlice = await getSliceInfo(page);
         expect(backSlice.current).toBe(midSlice.current - 1);
@@ -536,7 +549,7 @@ test.describe('Test Suite 16: Viewer Navigation Controls', () => {
             slider.dispatchEvent(new Event('input'));
         }, targetSlice);
 
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, targetSlice);
 
         const newSlice = await getSliceInfo(page);
         expect(newSlice.current).toBe(targetSlice);
@@ -555,14 +568,14 @@ test.describe('Test Suite 16: Viewer Navigation Controls', () => {
         // Scroll down should advance to next slice
         await page.mouse.move(centerX, centerY);
         await page.mouse.wheel(0, 100);
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current + 1);
 
         const afterScrollDown = await getSliceInfo(page);
         expect(afterScrollDown.current).toBe(initialSlice.current + 1);
 
         // Scroll up should go back
         await page.mouse.wheel(0, -100);
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current);
 
         const afterScrollUp = await getSliceInfo(page);
         expect(afterScrollUp.current).toBe(initialSlice.current);
@@ -577,7 +590,7 @@ test.describe('Test Suite 16: Viewer Navigation Controls', () => {
         const bounds = await getCanvasBounds(page);
         await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
         await page.mouse.wheel(0, 100);
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current + 1);
 
         const newSlice = await getSliceInfo(page);
         expect(newSlice.current).toBe(initialSlice.current + 1);
@@ -588,14 +601,14 @@ test.describe('Test Suite 16: Viewer Navigation Controls', () => {
 
         // Arrow down = next slice
         await page.keyboard.press('ArrowDown');
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current + 1);
 
         const afterDown = await getSliceInfo(page);
         expect(afterDown.current).toBe(initialSlice.current + 1);
 
         // Arrow up = previous slice
         await page.keyboard.press('ArrowUp');
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current);
 
         const afterUp = await getSliceInfo(page);
         expect(afterUp.current).toBe(initialSlice.current);
@@ -762,7 +775,7 @@ test.describe('Test Suite 19: Metadata Panel', () => {
 
         // Navigate to next slice
         await page.keyboard.press('ArrowRight');
-        await page.waitForTimeout(300);
+        await waitForSliceCurrent(page, initialSlice.current + 1);
 
         const newSlice = await getSliceInfo(page);
         expect(newSlice.current).toBe(initialSlice.current + 1);
@@ -1117,7 +1130,7 @@ test.describe('Test Suite 23: Viewer State - Full Navigation Workflow', () => {
         // Navigate a slice with arrow key (should always work)
         const initialSlice = await getSliceInfo(page);
         await page.keyboard.press('ArrowRight');
-        await page.waitForTimeout(200);
+        await waitForSliceCurrent(page, initialSlice.current + 1);
 
         const newSlice = await getSliceInfo(page);
         expect(newSlice.current).toBe(initialSlice.current + 1);

--- a/tests/viewing-tools.spec.js
+++ b/tests/viewing-tools.spec.js
@@ -95,6 +95,18 @@ async function getSliceInfo(page) {
   return null;
 }
 
+async function waitForSliceCurrent(page, expectedCurrent, timeout = 10000) {
+  await page.waitForFunction(
+    expected => {
+      const text = document.querySelector('#sliceInfo')?.textContent || '';
+      const match = text.match(/(\d+)\s*\/\s*(\d+)/);
+      return Boolean(match) && Number(match[1]) === expected;
+    },
+    expectedCurrent,
+    { timeout }
+  );
+}
+
 // Helper function to get canvas cursor style
 async function getCanvasCursor(page) {
   return await page.locator(CANVAS_SELECTOR).evaluate(el => {
@@ -1043,8 +1055,9 @@ test.describe('Test Suite 11: Slice Navigation & Persistence', () => {
     const adjustedWL = await getWLValues(page);
 
     // Navigate to next slice
+    const initialSlice = await getSliceInfo(page);
     await page.keyboard.press('ArrowRight');
-    await page.waitForTimeout(300);
+    await waitForSliceCurrent(page, initialSlice.current + 1);
 
     // W/L should be preserved
     const afterNavWL = await getWLValues(page);
@@ -1060,7 +1073,7 @@ test.describe('Test Suite 11: Slice Navigation & Persistence', () => {
 
     // Navigate forward
     await page.keyboard.press('ArrowRight');
-    await page.waitForTimeout(300);
+    await waitForSliceCurrent(page, initialSlice.current + 1);
 
     const newSlice = await getSliceInfo(page);
     expect(newSlice.current).toBe(initialSlice.current + 1);
@@ -1068,7 +1081,7 @@ test.describe('Test Suite 11: Slice Navigation & Persistence', () => {
 
     // Navigate back
     await page.keyboard.press('ArrowLeft');
-    await page.waitForTimeout(300);
+    await waitForSliceCurrent(page, initialSlice.current);
 
     const backSlice = await getSliceInfo(page);
     expect(backSlice.current).toBe(initialSlice.current);
@@ -1302,7 +1315,7 @@ test.describe('Test Suite 13: Series Switching', () => {
 
     // Navigate to a different slice (forward)
     await page.keyboard.press('ArrowRight');
-    await page.waitForTimeout(300);
+    await waitForSliceCurrent(page, initialSlice.current + 1);
 
     // Verify slice changed
     const newSlice = await getSliceInfo(page);


### PR DESCRIPTION
## Summary
- render uncompressed RGB DICOM frames correctly in the JS decode path instead of treating RGB samples as grayscale pixels
- carry planar configuration through decode validation and native decode metadata, while keeping browser JPEG baseline color decodes normalized to display-ready monochrome
- add a regression test that decodes and renders a synthetic RGB secondary-capture slice and checks exact canvas RGBA output

## Validation
- npx playwright test tests/desktop-library.spec.js
- npx playwright test
- npm run tauri build -- --bundles app

## Notes
- rebuilt desktop/src-tauri/target/release/bundle/macos/DICOM Viewer.app so the existing Desktop alias target picks up the fix