### PR TITLE
Add parallel agent worktree workflow and launchers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# Agent Workflow Instructions
+
+These instructions apply to any coding agent working in this repository.
+
+Read these first, before editing files.
+
+---
+
+## Mandatory Parallel-Work Rules
+
+1. Do not do active autonomous work directly on `main` or `local/WIP`.
+2. Use one branch per agent and one worktree per branch.
+3. Keep agent worktrees outside the repository root under:
+
+   ```text
+   ~/ai-worktrees/dicom-viewer/
+   ```
+
+4. Codex branches use `codex/<topic>`.
+5. Claude branches use `cc/<topic>` in this repo.
+6. Do not use `claude/<topic>` here because a bare `claude` branch already exists and blocks that namespace.
+7. Do not use `git stash` as the normal handoff mechanism.
+8. Do not use `git add -A` in the shared main checkout.
+9. If you are not sure which dirty files belong to your session, stop and report instead of committing.
+
+---
+
+## Starting New Work
+
+If the main checkout is clean and you are starting a new task:
+
+```bash
+npm run worktree:new -- codex <topic>
+npm run worktree:new -- cc <topic>
+```
+
+Then continue only in the new external worktree.
+
+---
+
+## If You Are Already in the Main Checkout With Changes
+
+If you are in `/Users/gabriel/claude 0/dicom-viewer` and already have uncommitted changes:
+
+1. Identify exactly which files belong to your session.
+2. Create a dedicated branch:
+
+   ```bash
+   git switch -c codex/<topic>
+   git switch -c cc/<topic>
+   ```
+
+3. Stage only your own files explicitly.
+4. Commit them.
+5. Switch the main checkout back to `local/WIP`.
+6. Create an external worktree for your branch:
+
+   ```bash
+   git worktree add "$HOME/ai-worktrees/dicom-viewer/codex-<topic>" codex/<topic>
+   git worktree add "$HOME/ai-worktrees/dicom-viewer/cc-<topic>" cc/<topic>
+   ```
+
+7. Continue only in the external worktree.
+
+---
+
+## Integration and Retirement
+
+- `local/WIP` is the integration branch.
+- Integrate finished agent work into `local/WIP` by commit, not by shared dirty state.
+- Retire integrated branches with:
+
+```bash
+npm run worktree:retire -- codex/<topic>
+npm run worktree:retire -- cc/<topic>
+```
+
+---
+
+## Shared Coordination Files
+
+Treat these as integration-time files whenever possible:
+
+- `docs/INDEX.md`
+- `docs/planning/SITEMAP.md`
+
+Do not edit them from multiple active agent branches unless the task is explicitly to
+perform the integration pass.
+
+---
+
+## Reference Docs
+
+For the compact workflow:
+
+- `docs/AGENT_WORKTREES.md`
+
+For the full beginner explanation of why this workflow exists:
+
+- `docs/AGENT_WORKTREES_EXPLAINER.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ Then continue only in the new external worktree.
 
 ## If You Are Already in the Main Checkout With Changes
 
-If you are in `/Users/gabriel/claude 0/dicom-viewer` and already have uncommitted changes:
+If you are in the shared main checkout at `<repo-root>` and already have
+uncommitted changes:
 
 1. Identify exactly which files belong to your session.
 2. Create a dedicated branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,52 @@ Supports multiple modalities: CT, MRI, and other imaging types.
 - **Stack**: Flask (Python) backend, vanilla JavaScript frontend
 - **Primary Workflow**: Client-side DICOM processing via File System Access API (Chrome/Edge)
 
+## Parallel Session Rules
+
+This repository may have multiple AI sessions running in parallel. Follow these rules
+before editing anything:
+
+1. Do not do active autonomous work directly on `main` or `local/WIP`.
+2. Use one branch per agent and one worktree per branch.
+3. Keep agent worktrees outside the repository root under:
+
+   ```text
+   ~/ai-worktrees/dicom-viewer/
+   ```
+
+4. Codex branches use `codex/<topic>`.
+5. Claude branches use `cc/<topic>` in this repo.
+6. Do not use `claude/<topic>` here because a bare `claude` branch already exists and blocks that namespace.
+7. Do not use `git stash` as the normal handoff mechanism.
+8. Do not use `git add -A` in the shared main checkout.
+9. If the shared checkout is dirty and you cannot prove which files are yours, stop and report instead of committing.
+
+### Starting a New Parallel Session
+
+If the shared checkout is clean, create a dedicated external worktree first:
+
+```bash
+npm run worktree:new -- codex <topic>
+npm run worktree:new -- cc <topic>
+```
+
+Then continue only in the new worktree.
+
+### Shared Coordination Files
+
+These files should usually be updated only during the integration step:
+
+- `docs/INDEX.md`
+- `docs/planning/SITEMAP.md`
+
+Do not edit them from multiple active agent branches unless the task is explicitly to
+perform the integration pass.
+
+### Reference Docs
+
+- Workflow rules: `docs/AGENT_WORKTREES.md`
+- Full explanation: `docs/AGENT_WORKTREES_EXPLAINER.md`
+
 ## Workspace Structure
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ Thank you for your interest in contributing to the DICOM Viewer project. This do
 1. [Getting Started](#getting-started)
 2. [Code Style Guidelines](#code-style-guidelines)
 3. [Git Workflow](#git-workflow)
-4. [Pull Request Process](#pull-request-process)
-5. [Reporting Issues](#reporting-issues)
-6. [Code of Conduct](#code-of-conduct)
+4. [Parallel Agent Workflow](#parallel-agent-workflow)
+5. [Pull Request Process](#pull-request-process)
+6. [Reporting Issues](#reporting-issues)
+7. [Code of Conduct](#code-of-conduct)
 
 ---
 
@@ -267,6 +268,48 @@ git diff --staged
 # Commit with message
 git commit -m "feat: Add zoom controls to toolbar"
 ```
+
+---
+
+## Parallel Agent Workflow
+
+When multiple AI agents are working at the same time, keep them isolated:
+
+- `main` stays aligned with `origin/main`
+- `local/WIP` is the integration branch
+- each agent gets one branch and one linked worktree
+- agent branches should be named `codex/<topic>` or `claude/<topic>`
+
+Do not run autonomous agent work directly on `local/WIP`. Use `local/WIP` to integrate finished commits from agent branches.
+
+### Worktree Location
+
+Keep agent worktrees outside the repository root. The standard location for this repo is:
+
+```text
+~/ai-worktrees/dicom-viewer/
+```
+
+This avoids nested worktree noise inside the main checkout and makes active sessions easier to see.
+
+### Helper Commands
+
+```bash
+npm run worktree:new -- codex ohif-deep-dive
+npm run worktree:list
+npm run worktree:list:all
+npm run worktree:retire -- codex/ohif-deep-dive
+```
+
+Direct script usage works too:
+
+```bash
+./scripts/agent-worktree-new.sh codex ohif-deep-dive
+./scripts/agent-worktree-list.sh --all
+./scripts/agent-worktree-retire.sh claude/visage-research
+```
+
+See [docs/AGENT_WORKTREES.md](./docs/AGENT_WORKTREES.md) for the full workflow and safety rules.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,9 +278,11 @@ When multiple AI agents are working at the same time, keep them isolated:
 - `main` stays aligned with `origin/main`
 - `local/WIP` is the integration branch
 - each agent gets one branch and one linked worktree
-- agent branches should be named `codex/<topic>` or `claude/<topic>`
+- agent branches should be named `codex/<topic>` or `cc/<topic>`
 
 Do not run autonomous agent work directly on `local/WIP`. Use `local/WIP` to integrate finished commits from agent branches.
+
+This repository already has a bare `claude` branch, which blocks the `claude/*` namespace in Git. Use `cc/<topic>` for Claude sessions here.
 
 ### Worktree Location
 
@@ -306,7 +308,7 @@ Direct script usage works too:
 ```bash
 ./scripts/agent-worktree-new.sh codex ohif-deep-dive
 ./scripts/agent-worktree-list.sh --all
-./scripts/agent-worktree-retire.sh claude/visage-research
+./scripts/agent-worktree-retire.sh cc/visage-research
 ```
 
 See [docs/AGENT_WORKTREES.md](./docs/AGENT_WORKTREES.md) for the full workflow and safety rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Write clear, descriptive commit messages that explain the change and its purpose
 
 <body - explain what and why, not how>
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
 **Types:**
@@ -243,7 +243,7 @@ MRI images without embedded W/L values auto-calculate from pixel
 statistics. This provides a reasonable starting point for viewing
 without manual adjustment.
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
 ### Important Git Rules

--- a/docs/AGENT_LAUNCHERS.md
+++ b/docs/AGENT_LAUNCHERS.md
@@ -12,20 +12,45 @@ launch the tool inside that worktree.
 That avoids the failure mode where a session starts in the shared checkout and
 tries to relocate later.
 
-This repository includes two launcher wrappers:
+This repository includes two repo-local launcher wrappers:
 
 - [scripts/ccw](/Users/gabriel/claude%200/dicom-viewer/scripts/ccw) for Claude
 - [scripts/codexw](/Users/gabriel/claude%200/dicom-viewer/scripts/codexw) for Codex
 
-Both wrappers call the shared launcher at
+The preferred path is to install the global commands `ccw` and `codexw` in
+`~/.local/bin/`. The repo-local wrappers prefer those global commands when
+available, then fall back to the repo-local shared launcher at
 [scripts/agent-session-launch.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-session-launch.sh).
 
 The wrappers accept launcher flags before the topic, so this works as expected:
 
 ```bash
-./scripts/ccw --dry-run volume-rendering
-./scripts/codexw --no-launch desktop-audit
+ccw --dry-run volume-rendering
+codexw --no-launch desktop-audit
 ```
+
+---
+
+## Preferred Path
+
+From any git repo:
+
+```bash
+ccw volume-rendering
+codexw desktop-audit
+```
+
+Those global commands call the canonical launcher in:
+
+```text
+~/.local/bin/agent-session-launch
+```
+
+That launcher detects repo-specific tooling when available and falls back to
+plain `git worktree add` when it is not.
+
+The global path is the source of truth. The repo-local wrappers exist as a
+fallback for contributors who have not installed the global commands yet.
 
 ---
 
@@ -65,7 +90,7 @@ second copy.
 
 ---
 
-## Usage
+## Repo-Local Fallback
 
 Claude:
 
@@ -102,34 +127,22 @@ Prepare the worktree but do not launch the tool:
 
 ---
 
-## Installation
+## Global Installation
 
-The simplest setup is to add shell functions to `~/.zshrc` that call the repo
-scripts by absolute path.
+Install these files in `~/.local/bin/`:
 
-Example:
+- `agent-session-launch`
+- `ccw`
+- `codexw`
 
-```bash
-ccw() {
-  "/Users/gabriel/claude 0/dicom-viewer/scripts/ccw" "$@"
-}
+If `~/.local/bin` is already on `PATH`, no shell functions are needed.
 
-codexw() {
-  "/Users/gabriel/claude 0/dicom-viewer/scripts/codexw" "$@"
-}
-```
-
-Then reload your shell:
+Verify:
 
 ```bash
-source ~/.zshrc
-```
-
-After that:
-
-```bash
-ccw volume-rendering
-codexw desktop-audit
+command -v ccw
+command -v codexw
+command -v agent-session-launch
 ```
 
 ---

--- a/docs/AGENT_LAUNCHERS.md
+++ b/docs/AGENT_LAUNCHERS.md
@@ -14,13 +14,13 @@ tries to relocate later.
 
 This repository includes two repo-local launcher wrappers:
 
-- [scripts/ccw](/Users/gabriel/claude%200/dicom-viewer/scripts/ccw) for Claude
-- [scripts/codexw](/Users/gabriel/claude%200/dicom-viewer/scripts/codexw) for Codex
+- [scripts/ccw](../scripts/ccw) for Claude
+- [scripts/codexw](../scripts/codexw) for Codex
 
 The preferred path is to install the global commands `ccw` and `codexw` in
 `~/.local/bin/`. The repo-local wrappers prefer those global commands when
 available, then fall back to the repo-local shared launcher at
-[scripts/agent-session-launch.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-session-launch.sh).
+[scripts/agent-session-launch.sh](../scripts/agent-session-launch.sh).
 
 The wrappers accept launcher flags before the topic, so this works as expected:
 
@@ -129,7 +129,7 @@ Prepare the worktree but do not launch the tool:
 
 ## Global Installation
 
-Install these files in `~/.local/bin/`:
+After manual installation, these files should exist in `~/.local/bin/`:
 
 - `agent-session-launch`
 - `ccw`
@@ -151,10 +151,10 @@ command -v agent-session-launch
 
 - In this repo, Claude branches use `cc/*`, not `claude/*`.
 - The launcher prefers the repo helper
-  [scripts/agent-worktree-new.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-new.sh)
+  [scripts/agent-worktree-new.sh](../scripts/agent-worktree-new.sh)
   when available so repo-specific conventions stay authoritative.
 - If the helper is not available in some other repo, the shared launcher falls
   back to plain `git worktree add` with the same naming rules.
 
 For the broader workflow and branch lifecycle, see
-[docs/AGENT_WORKTREES.md](/Users/gabriel/claude%200/dicom-viewer/docs/AGENT_WORKTREES.md).
+[docs/AGENT_WORKTREES.md](./AGENT_WORKTREES.md).

--- a/docs/AGENT_LAUNCHERS.md
+++ b/docs/AGENT_LAUNCHERS.md
@@ -1,0 +1,147 @@
+<!--
+  AGENT_LAUNCHERS.md - Session launcher workflow
+  Copyright (c) 2026 Divergent Health Technologies
+  https://divergent.health/
+-->
+
+# Agent Launchers
+
+The safest way to start a new AI session is to create the worktree first, then
+launch the tool inside that worktree.
+
+That avoids the failure mode where a session starts in the shared checkout and
+tries to relocate later.
+
+This repository includes two launcher wrappers:
+
+- [scripts/ccw](/Users/gabriel/claude%200/dicom-viewer/scripts/ccw) for Claude
+- [scripts/codexw](/Users/gabriel/claude%200/dicom-viewer/scripts/codexw) for Codex
+
+Both wrappers call the shared launcher at
+[scripts/agent-session-launch.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-session-launch.sh).
+
+The wrappers accept launcher flags before the topic, so this works as expected:
+
+```bash
+./scripts/ccw --dry-run volume-rendering
+./scripts/codexw --no-launch desktop-audit
+```
+
+---
+
+## What They Do
+
+Given a topic such as `volume-rendering`, the launcher:
+
+1. Resolves the repository root.
+2. Chooses the agent branch name:
+   - Claude -> `cc/volume-rendering`
+   - Codex -> `codex/volume-rendering`
+3. Chooses the worktree path:
+   - `~/ai-worktrees/dicom-viewer/cc-volume-rendering`
+   - `~/ai-worktrees/dicom-viewer/codex-volume-rendering`
+4. Reuses that branch/worktree if it already exists.
+5. Otherwise creates it from the repo base branch.
+6. Launches the tool from inside the worktree.
+
+This is safer than in-session relocation because the session never begins in the
+shared root checkout.
+
+---
+
+## Safety Rules
+
+The launcher refuses to create a new branch/worktree from a dirty shared base
+branch such as `local/WIP` or `main`.
+
+Reason:
+
+- a dirty shared checkout usually means there is uncaptured work already in play
+- starting a new agent from the last commit while that dirty state exists is how
+  changes get mixed up and lost
+
+If the target branch already exists, the launcher reuses it instead of creating a
+second copy.
+
+---
+
+## Usage
+
+Claude:
+
+```bash
+./scripts/ccw volume-rendering
+```
+
+Codex:
+
+```bash
+./scripts/codexw desktop-audit
+```
+
+Pass extra tool arguments after the topic:
+
+```bash
+./scripts/codexw bugfix-42 --resume
+./scripts/ccw docs-cleanup --dangerously-skip-permissions
+```
+
+Dry run:
+
+```bash
+./scripts/ccw --dry-run volume-rendering
+./scripts/codexw --dry-run desktop-audit
+```
+
+Prepare the worktree but do not launch the tool:
+
+```bash
+./scripts/ccw --no-launch volume-rendering
+./scripts/codexw --no-launch desktop-audit
+```
+
+---
+
+## Installation
+
+The simplest setup is to add shell functions to `~/.zshrc` that call the repo
+scripts by absolute path.
+
+Example:
+
+```bash
+ccw() {
+  "/Users/gabriel/claude 0/dicom-viewer/scripts/ccw" "$@"
+}
+
+codexw() {
+  "/Users/gabriel/claude 0/dicom-viewer/scripts/codexw" "$@"
+}
+```
+
+Then reload your shell:
+
+```bash
+source ~/.zshrc
+```
+
+After that:
+
+```bash
+ccw volume-rendering
+codexw desktop-audit
+```
+
+---
+
+## Repo-Specific Notes
+
+- In this repo, Claude branches use `cc/*`, not `claude/*`.
+- The launcher prefers the repo helper
+  [scripts/agent-worktree-new.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-new.sh)
+  when available so repo-specific conventions stay authoritative.
+- If the helper is not available in some other repo, the shared launcher falls
+  back to plain `git worktree add` with the same naming rules.
+
+For the broader workflow and branch lifecycle, see
+[docs/AGENT_WORKTREES.md](/Users/gabriel/claude%200/dicom-viewer/docs/AGENT_WORKTREES.md).

--- a/docs/AGENT_WORKTREES.md
+++ b/docs/AGENT_WORKTREES.md
@@ -99,7 +99,10 @@ See [AGENT_LAUNCHERS.md](./AGENT_LAUNCHERS.md) for the exact behavior and shell 
 5. Update shared index files once during integration, not inside every agent branch.
 6. Retire the agent branch only after its worktree is clean and integrated.
 
-Shared coordination files such as [docs/INDEX.md](/Users/gabriel/claude%200/dicom-viewer/docs/INDEX.md) and [docs/planning/SITEMAP.md](/Users/gabriel/claude%200/dicom-viewer/docs/planning/SITEMAP.md) should usually be touched only during the integration step. Let agent branches create or update content files first, then fold index updates in once.
+Shared coordination files such as [docs/INDEX.md](./INDEX.md) and
+[docs/planning/SITEMAP.md](./planning/SITEMAP.md) should usually be touched only
+during the integration step. Let agent branches create or update content files
+first, then fold index updates in once.
 
 If an agent needs to inherit local changes that are not on a branch yet, commit them first on `local/WIP`. Do not rely on stash as the handoff mechanism.
 
@@ -107,7 +110,9 @@ If an agent needs to inherit local changes that are not on a branch yet, commit 
 
 ## Helper Scripts
 
-These scripts live under [scripts/agent-worktree-new.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-new.sh), [scripts/agent-worktree-list.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-list.sh), and [scripts/agent-worktree-retire.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-retire.sh).
+These scripts live under [scripts/agent-worktree-new.sh](../scripts/agent-worktree-new.sh),
+[scripts/agent-worktree-list.sh](../scripts/agent-worktree-list.sh), and
+[scripts/agent-worktree-retire.sh](../scripts/agent-worktree-retire.sh).
 
 Create a worktree:
 
@@ -144,12 +149,15 @@ Start a parallel session:
 
 ```bash
 git switch local/WIP
-git add -A
+git status --short
+git add <explicit-path-1> <explicit-path-2>
 git commit -m "wip: integration checkpoint"
 
 ./scripts/agent-worktree-new.sh codex ohif-deep-dive
 ./scripts/agent-worktree-new.sh cc visage-research
 ```
+
+If `local/WIP` is already clean, skip the checkpoint commit.
 
 Integrate finished work:
 

--- a/docs/AGENT_WORKTREES.md
+++ b/docs/AGENT_WORKTREES.md
@@ -9,6 +9,9 @@
 This repository supports multiple AI agents working in parallel, but only if each
 agent gets its own branch and worktree.
 
+If you want the full story of what went wrong, what we changed, and why this workflow now
+looks the way it does, read [AGENT_WORKTREES_EXPLAINER.md](./AGENT_WORKTREES_EXPLAINER.md).
+
 The core rule is simple:
 
 - One agent

--- a/docs/AGENT_WORKTREES.md
+++ b/docs/AGENT_WORKTREES.md
@@ -24,16 +24,22 @@ Do not put autonomous agent work directly on `main` or `local/WIP`.
 - `main` tracks `origin/main` and stays deployable
 - `local/WIP` is the local integration branch
 - `codex/<topic>` is a Codex agent branch
-- `claude/<topic>` is a Claude agent branch
+- `cc/<topic>` is a Claude agent branch in this repo
 
 Examples:
 
 - `codex/ohif-deep-dive`
 - `codex/desktop-release-audit`
-- `claude/visage-research`
-- `claude/docs-cleanup`
+- `cc/visage-research`
+- `cc/docs-cleanup`
 
 Each topic should describe one unit of work. If the scope changes, create a new branch.
+
+Why `cc/*` instead of `claude/*`:
+
+- this repository already has a bare branch named `claude`
+- Git cannot have both `claude` and `claude/<topic>` refs at the same time
+- the helper scripts therefore reserve `cc/*` for Claude sessions here
 
 ---
 
@@ -50,7 +56,7 @@ Default location:
 Directory naming:
 
 - `~/ai-worktrees/dicom-viewer/codex-ohif-deep-dive`
-- `~/ai-worktrees/dicom-viewer/claude-visage-research`
+- `~/ai-worktrees/dicom-viewer/cc-visage-research`
 
 Why outside the repo:
 
@@ -86,7 +92,7 @@ Create a worktree:
 
 ```bash
 ./scripts/agent-worktree-new.sh codex ohif-deep-dive
-./scripts/agent-worktree-new.sh claude visage-research
+./scripts/agent-worktree-new.sh cc visage-research
 ```
 
 List active agent worktrees:
@@ -100,7 +106,7 @@ Retire an integrated agent branch:
 
 ```bash
 ./scripts/agent-worktree-retire.sh codex/ohif-deep-dive
-./scripts/agent-worktree-retire.sh --delete-remote claude/visage-research
+./scripts/agent-worktree-retire.sh --delete-remote cc/visage-research
 ```
 
 The retire command refuses to proceed if:
@@ -121,7 +127,7 @@ git add -A
 git commit -m "wip: integration checkpoint"
 
 ./scripts/agent-worktree-new.sh codex ohif-deep-dive
-./scripts/agent-worktree-new.sh claude visage-research
+./scripts/agent-worktree-new.sh cc visage-research
 ```
 
 Integrate finished work:
@@ -136,7 +142,7 @@ Retire cleanly:
 
 ```bash
 ./scripts/agent-worktree-retire.sh codex/ohif-deep-dive
-./scripts/agent-worktree-retire.sh claude/visage-research
+./scripts/agent-worktree-retire.sh cc/visage-research
 ```
 
 ---

--- a/docs/AGENT_WORKTREES.md
+++ b/docs/AGENT_WORKTREES.md
@@ -72,6 +72,24 @@ The helper scripts below default to this layout. Override with `AI_WORKTREE_HOME
 
 ---
 
+## Preferred Session Start
+
+If you are starting a fresh human-driven session, prefer the launcher wrappers instead of
+opening the tool in the shared checkout first.
+
+Examples:
+
+```bash
+./scripts/ccw volume-rendering
+./scripts/codexw desktop-audit
+```
+
+Those wrappers create or reuse the correct worktree and then launch the tool from inside it.
+
+See [AGENT_LAUNCHERS.md](./AGENT_LAUNCHERS.md) for the exact behavior and shell setup.
+
+---
+
 ## Safe Workflow
 
 1. Commit any integration state you need on `local/WIP`.

--- a/docs/AGENT_WORKTREES.md
+++ b/docs/AGENT_WORKTREES.md
@@ -1,0 +1,150 @@
+<!--
+  AGENT_WORKTREES.md - Parallel AI Worktree Workflow
+  Copyright (c) 2026 Divergent Health Technologies
+  https://divergent.health/
+-->
+
+# Agent Worktrees
+
+This repository supports multiple AI agents working in parallel, but only if each
+agent gets its own branch and worktree.
+
+The core rule is simple:
+
+- One agent
+- One branch
+- One worktree
+
+Do not put autonomous agent work directly on `main` or `local/WIP`.
+
+---
+
+## Branch Convention
+
+- `main` tracks `origin/main` and stays deployable
+- `local/WIP` is the local integration branch
+- `codex/<topic>` is a Codex agent branch
+- `claude/<topic>` is a Claude agent branch
+
+Examples:
+
+- `codex/ohif-deep-dive`
+- `codex/desktop-release-audit`
+- `claude/visage-research`
+- `claude/docs-cleanup`
+
+Each topic should describe one unit of work. If the scope changes, create a new branch.
+
+---
+
+## Worktree Convention
+
+Keep linked worktrees outside the repository root.
+
+Default location:
+
+```text
+~/ai-worktrees/dicom-viewer/
+```
+
+Directory naming:
+
+- `~/ai-worktrees/dicom-viewer/codex-ohif-deep-dive`
+- `~/ai-worktrees/dicom-viewer/claude-visage-research`
+
+Why outside the repo:
+
+- avoids nested-worktree noise in `git status`
+- keeps editor search and filesystem scans focused
+- makes active agent sessions easy to identify
+- reduces accidental edits in the wrong checkout
+
+The helper scripts below default to this layout. Override with `AI_WORKTREE_HOME` if needed.
+
+---
+
+## Safe Workflow
+
+1. Commit any integration state you need on `local/WIP`.
+2. Create one worktree per agent branch.
+3. Let each agent commit on its own branch only.
+4. Review and integrate with `cherry-pick` or merge into `local/WIP`.
+5. Update shared index files once during integration, not inside every agent branch.
+6. Retire the agent branch only after its worktree is clean and integrated.
+
+Shared coordination files such as [docs/INDEX.md](/Users/gabriel/claude%200/dicom-viewer/docs/INDEX.md) and [docs/planning/SITEMAP.md](/Users/gabriel/claude%200/dicom-viewer/docs/planning/SITEMAP.md) should usually be touched only during the integration step. Let agent branches create or update content files first, then fold index updates in once.
+
+If an agent needs to inherit local changes that are not on a branch yet, commit them first on `local/WIP`. Do not rely on stash as the handoff mechanism.
+
+---
+
+## Helper Scripts
+
+These scripts live under [scripts/agent-worktree-new.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-new.sh), [scripts/agent-worktree-list.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-list.sh), and [scripts/agent-worktree-retire.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-retire.sh).
+
+Create a worktree:
+
+```bash
+./scripts/agent-worktree-new.sh codex ohif-deep-dive
+./scripts/agent-worktree-new.sh claude visage-research
+```
+
+List active agent worktrees:
+
+```bash
+./scripts/agent-worktree-list.sh
+./scripts/agent-worktree-list.sh --all
+```
+
+Retire an integrated agent branch:
+
+```bash
+./scripts/agent-worktree-retire.sh codex/ohif-deep-dive
+./scripts/agent-worktree-retire.sh --delete-remote claude/visage-research
+```
+
+The retire command refuses to proceed if:
+
+- the branch is not merged into `local/WIP`
+- the branch is still checked out in the current worktree
+- the attached agent worktree has uncommitted changes
+
+---
+
+## Suggested Daily Pattern
+
+Start a parallel session:
+
+```bash
+git switch local/WIP
+git add -A
+git commit -m "wip: integration checkpoint"
+
+./scripts/agent-worktree-new.sh codex ohif-deep-dive
+./scripts/agent-worktree-new.sh claude visage-research
+```
+
+Integrate finished work:
+
+```bash
+git switch local/WIP
+git cherry-pick <commit-from-codex-branch>
+git cherry-pick <commit-from-claude-branch>
+```
+
+Retire cleanly:
+
+```bash
+./scripts/agent-worktree-retire.sh codex/ohif-deep-dive
+./scripts/agent-worktree-retire.sh claude/visage-research
+```
+
+---
+
+## Operational Rules
+
+- Never run two agents on the same branch.
+- Never delete a branch without checking whether a worktree is attached.
+- Never assume uncommitted changes belong to the current session.
+- Prefer cheap local commits over stashes.
+- Keep agent branches narrow and disposable.

--- a/docs/AGENT_WORKTREES_EXPLAINER.md
+++ b/docs/AGENT_WORKTREES_EXPLAINER.md
@@ -73,10 +73,10 @@ This is the key tool for parallel AI work.
 
 ### Shared Checkout
 
-The shared checkout is the main repository folder:
+The shared checkout is the main repository folder for this clone:
 
 ```text
-/Users/gabriel/claude 0/dicom-viewer
+<repo-root>
 ```
 
 This checkout is convenient for you as the human integrator, but it is a bad place to
@@ -277,9 +277,9 @@ This is the foundation of the new workflow.
 
 We added three scripts:
 
-- [scripts/agent-worktree-new.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-new.sh)
-- [scripts/agent-worktree-list.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-list.sh)
-- [scripts/agent-worktree-retire.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-retire.sh)
+- [scripts/agent-worktree-new.sh](../scripts/agent-worktree-new.sh)
+- [scripts/agent-worktree-list.sh](../scripts/agent-worktree-list.sh)
+- [scripts/agent-worktree-retire.sh](../scripts/agent-worktree-retire.sh)
 
 Why:
 

--- a/docs/AGENT_WORKTREES_EXPLAINER.md
+++ b/docs/AGENT_WORKTREES_EXPLAINER.md
@@ -1,0 +1,499 @@
+<!--
+  AGENT_WORKTREES_EXPLAINER.md - Beginner explainer for parallel AI sessions
+  Copyright (c) 2026 Divergent Health Technologies
+  https://divergent.health/
+-->
+
+# Parallel Agent Cleanup Explainer
+
+This document explains, step by step, what we did to clean up a repository that had
+multiple AI sessions working in parallel, why each step mattered, and what workflow
+should be used from now on.
+
+This is the detailed companion to [AGENT_WORKTREES.md](./AGENT_WORKTREES.md).
+
+---
+
+## Who This Is For
+
+This guide is written for someone who is comfortable using Git at a basic level but
+does not want to think about Git internals every time they open another AI session.
+
+If you only want the operating rules, read [AGENT_WORKTREES.md](./AGENT_WORKTREES.md).
+If you want to understand the reasoning behind those rules, read this document.
+
+---
+
+## The Short Version
+
+The main lesson is:
+
+1. Do not let multiple AI sessions work in the same checkout.
+2. Do not let multiple AI sessions share the same branch.
+3. Use cheap commits instead of stashes to preserve unfinished work.
+4. Keep agent worktrees outside the repository root.
+5. Use `local/WIP` as an integration branch, not as a shared scratchpad for active agents.
+
+In this repository, Claude sessions use `cc/<topic>` rather than `claude/<topic>`
+because a bare branch named `claude` already exists and blocks the `claude/*` namespace.
+
+---
+
+## The Core Git Concepts
+
+Before the cleanup steps make sense, it helps to define a few terms.
+
+### `origin/main`
+
+This is the remote-tracking reference for the main branch on GitHub. It tells you what
+the upstream repository currently considers the latest mainline state.
+
+### `main`
+
+This is your local branch named `main`. It should usually be aligned with `origin/main`.
+It is not a good place to do experimental or concurrent local work.
+
+### `local/WIP`
+
+This is a local integration branch used as a landing zone for work that has not been
+pushed upstream yet. It is useful, but it is not safe as a shared active branch for
+multiple autonomous agents.
+
+### Branch
+
+A branch is just a named pointer to a commit. If multiple agents move the same branch
+tip around or leave different uncommitted changes on top of it, ownership becomes unclear.
+
+### Worktree
+
+A worktree is a separate checked-out directory linked to the same Git repository. A
+worktree lets you have multiple branches checked out at the same time in different folders.
+
+This is the key tool for parallel AI work.
+
+### Shared Checkout
+
+The shared checkout is the main repository folder:
+
+```text
+/Users/gabriel/claude 0/dicom-viewer
+```
+
+This checkout is convenient for you as the human integrator, but it is a bad place to
+run multiple autonomous sessions because they can all see and modify the same files.
+
+---
+
+## What Went Wrong
+
+At the start of the cleanup, several things were mixed together in the same repository:
+
+1. A feature branch that had already been merged upstream.
+2. A local `local/WIP` branch that had fallen behind.
+3. Uncommitted documentation work sitting directly in the main checkout.
+4. Nested worktree folders inside `.claude/`, which showed up as local filesystem noise.
+5. Multiple AI sessions creating or updating files in the same checkout.
+6. Unclear ownership of some files, especially research drafts and shared index files.
+
+That is a dangerous state because it becomes easy to:
+
+- lose work by cleaning the wrong files
+- commit someone else’s changes by mistake
+- delete a branch that still has an attached worktree
+- keep using stale branches because the current state is hard to interpret
+
+---
+
+## What We Did
+
+This section walks through the cleanup in the order it happened.
+
+### 1. Checked the Branch Status
+
+The first step was to inspect:
+
+- the current branch
+- the dirty state of the working tree
+- branch tracking status
+- how the current branch compared with `origin/main`
+
+Why:
+
+- You should not clean anything until you know whether the branch is finished, stale,
+  ahead, behind, or already merged.
+
+What we found:
+
+- the current feature branch had already been merged into `origin/main`
+- the worktree itself was dirty
+- `local/WIP` existed, but it was stale relative to current mainline history
+
+### 2. Chose Commits Over Stash
+
+You explicitly said you did not want to keep relying on `git stash`.
+
+That was the right instinct.
+
+Why stash was the wrong tool here:
+
+- stash is temporary and easy to forget
+- stash does not explain ownership
+- stash makes multi-session cleanup harder because it hides work rather than giving it a home
+- stash is especially bad when several agents are already mixing state in one checkout
+
+Why commits were better:
+
+- commits are visible
+- commits are attributable
+- commits survive cleanup operations
+- commits can be moved, cherry-picked, reviewed, and retired safely
+
+### 3. Moved `local/WIP` and `main` Up to Current Mainline
+
+Because the old branch was already merged, we repointed:
+
+- `local/WIP` to the current `origin/main`
+- `main` to the current `origin/main`
+
+Then we switched the shared checkout to `local/WIP`.
+
+Why:
+
+- this turned the shared checkout into an integration branch based on current upstream state
+- it let us stop treating a stale branch as active work
+- it avoided an unnecessary stash-based branch hop
+
+This matters because branch names should reflect reality. A stale `local/WIP` branch is
+worse than useless if it makes you think you are resuming current work when you are not.
+
+### 4. Hid `.claude/` in Local Excludes
+
+The repository had nested worktree and settings files under `.claude/`. Those files were
+not intended for version control, but they were still being seen by Git as local noise.
+
+We added `.claude/` to:
+
+```text
+.git/info/exclude
+```
+
+Why that file:
+
+- it behaves like a local-only `.gitignore`
+- it is not committed
+- it keeps your personal machine-specific clutter out of `git status`
+
+Why this is better than editing `.gitignore`:
+
+- `.gitignore` is shared project policy
+- `.git/info/exclude` is local machine policy
+- `.claude/` here was a local workflow artifact, not a repository artifact
+
+Important limitation:
+
+- this did not delete `.claude/`
+- this did not remove the worktrees
+- it only stopped the shared checkout from reporting them as untracked noise
+
+### 5. Committed the Real Documentation Work
+
+There was a genuine set of documentation and audit files in the working tree that you
+wanted to keep. We staged those files explicitly and committed them on `local/WIP`.
+
+Why:
+
+- they were real work, not temporary clutter
+- committing them put them on solid ground
+- a commit is a better checkpoint than a stash
+
+This also separated "valuable project work" from "workflow noise".
+
+### 6. Deleted the Already-Merged Branch Safely
+
+Once we confirmed that the finished feature branch was:
+
+- already merged
+- not attached to any active worktree
+
+we deleted it locally and remotely.
+
+Why:
+
+- merged branches that are no longer in use add cognitive clutter
+- fewer stale branches means fewer chances to resume the wrong line of work
+
+Why the worktree check mattered:
+
+- deleting a branch that is still checked out in another worktree is a good way to break
+  someone else’s active session
+
+### 7. Investigated the Mystery Research Files
+
+We then found new files, such as the Visage research document, that had no Git history.
+
+Instead of guessing where they came from, we traced their provenance through local session
+logs and file timestamps.
+
+Why:
+
+- in a multi-agent environment, "untracked file" does not mean "safe to delete"
+- provenance matters before cleanup
+
+What we found:
+
+- another AI session had created or renamed those files
+- the same session had also updated shared coordination files such as `docs/INDEX.md`
+  and `docs/planning/SITEMAP.md`
+
+That discovery is what forced the stricter workflow rules.
+
+### 8. Identified the Real Process Problem
+
+The real problem was not one bad file. It was the lack of a strict parallel-work model.
+
+Multiple sessions were effectively using:
+
+- the same main checkout
+- overlapping branch space
+- shared uncommitted state
+- shared coordination files
+
+That is manageable for a human and a small amount of manual work. It is not manageable
+for multiple autonomous agents acting in parallel.
+
+### 9. Standardized the New Workflow
+
+We introduced a simple model:
+
+1. `main` mirrors upstream.
+2. `local/WIP` is the integration branch.
+3. Every active agent gets its own branch.
+4. Every active agent gets its own external worktree.
+5. Integration happens later by commit, not by shared dirty state.
+
+This is the foundation of the new workflow.
+
+### 10. Added Helper Scripts
+
+We added three scripts:
+
+- [scripts/agent-worktree-new.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-new.sh)
+- [scripts/agent-worktree-list.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-list.sh)
+- [scripts/agent-worktree-retire.sh](/Users/gabriel/claude%200/dicom-viewer/scripts/agent-worktree-retire.sh)
+
+Why:
+
+- the workflow needs to be easy enough to use consistently
+- good process fails if it requires too much memory or too many manual steps
+
+These scripts now provide:
+
+- safe creation of agent branches and worktrees
+- visibility into active agent branches
+- safe retirement of integrated branches
+
+### 11. Discovered the `claude/*` Namespace Collision
+
+While cleaning up the active Claude sessions, we found a Git namespace issue:
+
+- the repository already had a branch named `claude`
+- Git therefore could not create `claude/<topic>`
+
+Why this happens:
+
+- Git stores refs as paths
+- `claude` and `claude/something` cannot both exist as branch refs
+
+That meant the original convention was wrong for this repository.
+
+### 12. Switched Claude Sessions to `cc/*`
+
+We updated the workflow so:
+
+- Codex uses `codex/<topic>`
+- Claude uses `cc/<topic>`
+
+The helper script also accepts `claude` as an input alias, but internally maps it to `cc/*`.
+
+Why:
+
+- it preserves a readable namespace for Claude sessions
+- it avoids the collision with the existing `claude` branch
+- it means older prompts can still use `claude` without breaking the script
+
+### 13. Cleaned Up the Still-Running Claude Sessions
+
+For each running Claude session, the goal was:
+
+1. preserve its work
+2. get it off the shared checkout
+3. move it into its own branch and worktree
+
+The safe pattern was:
+
+1. identify which files actually belonged to that session
+2. create a `cc/<topic>` branch
+3. stage only those files explicitly
+4. commit them
+5. create an external worktree for that branch
+6. continue working only in the external worktree
+
+Why explicit staging mattered:
+
+- `git add -A` in a mixed shared checkout can silently capture someone else’s work
+
+This was the single most important safety rule during cleanup.
+
+### 14. Verified the Session Reports
+
+We then checked each session’s report against a simple checklist:
+
+- branch starts with `cc/`
+- worktree path is outside the repository root
+- the session is not still working in the main checkout
+- dirty state is either none or clearly confined to that dedicated worktree
+
+Why:
+
+- cleanup is not complete just because a session says it is done
+- the report format made it easy to validate correctness quickly
+
+---
+
+## Why External Worktrees Matter So Much
+
+This point deserves its own section.
+
+Keeping worktrees outside the repository root means:
+
+- the main checkout does not recurse into other checkouts
+- `git status` stays easier to interpret
+- editor search stays focused
+- file indexing and backups are cleaner
+- it is visually obvious which directory belongs to which agent
+
+The standard path is now:
+
+```text
+~/ai-worktrees/dicom-viewer/
+```
+
+Examples:
+
+- `~/ai-worktrees/dicom-viewer/codex-ohif-deep-dive`
+- `~/ai-worktrees/dicom-viewer/cc-rendering-correctness-tier1`
+
+This is much safer than hiding worktrees under `.claude/worktrees/...` inside the repo.
+
+---
+
+## Why `local/WIP` Still Exists
+
+It is reasonable to ask: if every agent gets its own branch, why keep `local/WIP`?
+
+Because `local/WIP` is still useful as:
+
+- your local integration branch
+- the place where you cherry-pick or merge approved agent commits
+- the branch that reflects "my current combined local state"
+
+What `local/WIP` should not be:
+
+- a branch shared by multiple active agents
+- a long-lived anonymous scratchpad full of uncommitted files
+
+So the rule is:
+
+- active agent work happens on `codex/*` or `cc/*`
+- integrated local state lives on `local/WIP`
+
+---
+
+## The New Normal Workflow
+
+### Starting New Parallel Work
+
+1. Make sure `local/WIP` contains any local base state you want agents to inherit.
+2. Commit that base state if needed.
+3. Create an agent worktree:
+
+```bash
+npm run worktree:new -- codex ohif-deep-dive
+npm run worktree:new -- cc visage-research
+```
+
+4. Open the new worktree path.
+5. Let that agent work only there.
+
+### Checking What Is Active
+
+Use:
+
+```bash
+npm run worktree:list
+npm run worktree:list:all
+```
+
+This tells you:
+
+- which agent branches exist
+- where they are checked out
+- whether their worktrees are clean or dirty
+
+### Integrating Finished Work
+
+From `local/WIP`:
+
+```bash
+git switch local/WIP
+git cherry-pick <agent-commit>
+```
+
+or, if you intentionally prefer it:
+
+```bash
+git merge <agent-branch>
+```
+
+The important point is that integration happens by commit, not by reusing the same dirty
+checkout for everybody.
+
+### Retiring Finished Branches
+
+After work is integrated and the agent worktree is clean:
+
+```bash
+npm run worktree:retire -- cc/visage-research
+```
+
+The retire script refuses unsafe removals, which protects you from deleting a branch that
+still has an attached or dirty worktree.
+
+---
+
+## Practical Rules to Remember
+
+If you remember nothing else, remember these:
+
+1. One agent, one branch, one worktree.
+2. Never let autonomous agents share `local/WIP`.
+3. Never use `git add -A` in a dirty shared checkout.
+4. Prefer commits over stashes.
+5. Keep worktrees outside the repository root.
+6. Treat `docs/INDEX.md` and `docs/planning/SITEMAP.md` as integration files whenever possible.
+7. For Claude sessions in this repo, use `cc/*`, not `claude/*`.
+
+---
+
+## What "Clean" Looks Like Now
+
+A healthy setup now looks like this:
+
+- `main` follows `origin/main`
+- `local/WIP` contains only your integrated local work
+- each active AI session appears as its own `codex/*` or `cc/*` branch
+- each active AI session has its own worktree under `~/ai-worktrees/dicom-viewer/`
+- the main checkout is reserved for you as the integrator, not for parallel agents
+
+That is the point of all this cleanup: not just to fix one messy moment, but to make the
+next ten parallel sessions predictable and safe.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,6 +27,8 @@ Master index of all project documentation, organized by audience and purpose.
 | [API Reference](./API.md) | docs/ | REST API endpoints for test mode (Flask backend) |
 | [Configuration](./CONFIG.md) | docs/ | Environment variables, runtime settings, browser requirements |
 | [Testing Guide](./TESTING.md) | docs/ | Playwright test setup, helper functions, writing tests, visual verification |
+| [Parallel Agent Workflow](./AGENT_WORKTREES.md) | docs/ | Rules and helper commands for running multiple Codex and Claude sessions safely in parallel |
+| [Parallel Agent Explainer](./AGENT_WORKTREES_EXPLAINER.md) | docs/ | Beginner walkthrough of the multi-agent cleanup, the branch/worktree model, and why the current workflow exists |
 | [Deployment Guide](./DEPLOY.md) | docs/ | Local development, GitHub Pages, custom domains, troubleshooting |
 | [Contributing](../CONTRIBUTING.md) | Root | Code style, git workflow, pull request process, issue templates |
 | [Bug Tracking](./BUGS.md) | docs/ | Known issues, resolved bugs with root cause analysis, bug template |
@@ -78,6 +80,8 @@ Technical documentation for developers and operations.
 
 ```
 docs/
+├── AGENT_WORKTREES.md     # Parallel AI agent workflow rules and helper commands
+├── AGENT_WORKTREES_EXPLAINER.md  # Beginner explainer for the parallel workflow
 ├── INDEX.md               # This file - master documentation index
 ├── API.md                 # REST API reference
 ├── CONFIG.md              # Configuration reference
@@ -184,6 +188,12 @@ Deployment guide for local development (Flask, static server) and production (Gi
 
 **TESTING.md**
 Comprehensive testing documentation. Covers Playwright setup, test mode architecture, helper functions (with detailed explanations of `waitForViewerReady`, `getCanvasTransform`, `performDrag`), blank slice handling, visual verification with 9-region sampling, and test limitations.
+
+**AGENT_WORKTREES.md**
+Operational rules for running multiple AI coding sessions in parallel. Defines the `local/WIP` integration role, the `codex/*` and `cc/*` branch conventions, the external worktree layout, and the helper scripts for creating, listing, and retiring agent branches.
+
+**AGENT_WORKTREES_EXPLAINER.md**
+Beginner-friendly walkthrough of the cleanup that led to the current workflow. Explains what went wrong with shared dirty state, why commits beat stashes here, why worktrees must live outside the repo root, and how to reason about multi-agent Git safety.
 
 **BUGS.md**
 Bug tracking with full context. Each bug includes how it was encountered, root cause analysis, solution, why that solution was chosen, and prevention controls. Uses a standard template for consistency.

--- a/docs/planning/SITEMAP.md
+++ b/docs/planning/SITEMAP.md
@@ -24,6 +24,8 @@ claude 0/                          # Workspace/inbox - drop files here for Claud
 
 | File | Description |
 |------|-------------|
+| `AGENT_WORKTREES.md` | Parallel AI agent workflow rules: one agent per branch and worktree, `local/WIP` as integration branch, and helper scripts for create/list/retire |
+| `AGENT_WORKTREES_EXPLAINER.md` | Detailed beginner walkthrough of the multi-agent cleanup, why the workflow changed, and how to avoid shared-checkout collisions |
 | `BUGS.md` | Bug tracking and known issues |
 | `CODE_REVIEWS.md` | PR review findings and resolution tracking |
 | `DEPLOY.md` | Deployment guide: local dev, GitHub Pages, CI/CD workflow |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "A web-based DICOM medical imaging viewer (CT, MRI, etc.) with client-side processing for privacy. Supports JPEG Lossless, JPEG 2000, and uncompressed formats via browser-based decoders. Built with vanilla JS frontend and Flask backend for static serving. See docs/CLAUDE.md for architecture details.",
   "main": "app.py",
   "scripts": {
-    "test": "npx playwright test"
+    "test": "npx playwright test",
+    "worktree:new": "./scripts/agent-worktree-new.sh",
+    "worktree:list": "./scripts/agent-worktree-list.sh",
+    "worktree:list:all": "./scripts/agent-worktree-list.sh --all",
+    "worktree:retire": "./scripts/agent-worktree-retire.sh"
   },
   "keywords": [
     "dicom",

--- a/scripts/agent-session-launch.sh
+++ b/scripts/agent-session-launch.sh
@@ -101,6 +101,7 @@ create_worktree() {
 DRY_RUN=0
 NO_LAUNCH=0
 TOOL_CMD=""
+TOOL_ARGS=()
 AGENT_OVERRIDE=""
 BASE_BRANCH=""
 ROOT_OVERRIDE=""
@@ -170,7 +171,9 @@ else
   shift 2
 fi
 
-TOOL_ARGS=("$@")
+if [[ $# -gt 0 ]]; then
+  TOOL_ARGS=("$@")
+fi
 
 if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
   echo "This launcher must be run inside a git worktree." >&2
@@ -288,4 +291,7 @@ fi
 echo
 echo "Launching $TOOL_CMD in $WORKTREE_PATH"
 cd "$WORKTREE_PATH"
-exec "$TOOL_CMD" "${TOOL_ARGS[@]}"
+if [[ ${#TOOL_ARGS[@]} -gt 0 ]]; then
+  exec "$TOOL_CMD" "${TOOL_ARGS[@]}"
+fi
+exec "$TOOL_CMD"

--- a/scripts/agent-session-launch.sh
+++ b/scripts/agent-session-launch.sh
@@ -51,12 +51,35 @@ default_base_branch() {
 }
 
 find_attached_worktree_for_branch() {
-  local branch_ref="refs/heads/$1"
+  local target="$1"
+  local path=""
+  local branch=""
 
-  git worktree list --porcelain | awk -v branch_ref="$branch_ref" '
-    $1 == "worktree" { current_path = substr($0, 10) }
-    $1 == "branch" && $2 == branch_ref { print current_path; exit 0 }
-  '
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -z "$line" ]]; then
+      if [[ "$branch" == "$target" ]]; then
+        printf '%s\n' "$path"
+        return 0
+      fi
+      path=""
+      branch=""
+      continue
+    fi
+
+    case "$line" in
+      worktree\ *)
+        path="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        branch="${line#branch refs/heads/}"
+        ;;
+      detached)
+        branch=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain && printf '\n')
+
+  return 1
 }
 
 has_project_helper_script() {
@@ -237,7 +260,14 @@ else
   fi
 fi
 
-if [[ "$BRANCH_ALREADY_EXISTS" -eq 0 ]] && [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]] && [[ -n "$CURRENT_STATUS" ]] && [[ "$CURRENT_PATH" == "$REPO_ROOT" ]]; then
+IN_SHARED_CHECKOUT=0
+case "$CURRENT_PATH" in
+  "$REPO_ROOT"|"$REPO_ROOT"/*)
+    IN_SHARED_CHECKOUT=1
+    ;;
+esac
+
+if [[ "$BRANCH_ALREADY_EXISTS" -eq 0 ]] && [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]] && [[ -n "$CURRENT_STATUS" ]] && [[ "$IN_SHARED_CHECKOUT" -eq 1 ]]; then
   echo "Refusing to create a new agent worktree from dirty $BASE_BRANCH." >&2
   echo "Capture or commit the shared checkout state first, then retry." >&2
   exit 1

--- a/scripts/agent-session-launch.sh
+++ b/scripts/agent-session-launch.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  agent-session-launch.sh [options] <agent> <topic> [tool args...]
+  agent-session-launch.sh [options] --agent <agent> <topic> [tool args...]
+
+Creates or reuses a dedicated agent worktree, then launches the requested tool
+from inside that worktree.
+
+Agent values:
+  codex   -> codex/<topic>
+  cc      -> cc/<topic>
+  claude  -> alias for cc/<topic>
+
+Options:
+  --agent <agent>    Agent namespace to use for the branch/worktree
+  --tool <command>   Tool to launch after entering the worktree
+  --base <branch>    Base branch for new worktrees
+  --root <dir>       Override AI_WORKTREE_HOME / ~/ai-worktrees
+  --dry-run          Print what would happen without creating or launching
+  --no-launch        Create or reuse the worktree, but do not launch the tool
+  -h, --help         Show this help
+
+Examples:
+  ./scripts/agent-session-launch.sh --tool claude cc volume-rendering
+  ./scripts/agent-session-launch.sh --tool codex codex bugfix-42 --resume
+  ./scripts/agent-session-launch.sh --dry-run --tool claude claude docs-audit
+EOF
+}
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+default_base_branch() {
+  if git rev-parse --verify --quiet local/WIP^{commit} >/dev/null; then
+    printf '%s\n' "local/WIP"
+  elif git rev-parse --verify --quiet main^{commit} >/dev/null; then
+    printf '%s\n' "main"
+  elif git rev-parse --verify --quiet master^{commit} >/dev/null; then
+    printf '%s\n' "master"
+  else
+    git branch --show-current
+  fi
+}
+
+find_attached_worktree_for_branch() {
+  local branch_ref="refs/heads/$1"
+
+  git worktree list --porcelain | awk -v branch_ref="$branch_ref" '
+    $1 == "worktree" { current_path = substr($0, 10) }
+    $1 == "branch" && $2 == branch_ref { print current_path; exit 0 }
+  '
+}
+
+has_project_helper_script() {
+  [[ -x "$REPO_ROOT/scripts/agent-worktree-new.sh" ]]
+}
+
+has_project_worktree_npm_script() {
+  [[ -f "$REPO_ROOT/package.json" ]] || return 1
+
+  node -e '
+const pkg = require(process.argv[1]);
+process.exit(pkg.scripts && pkg.scripts["worktree:new"] ? 0 : 1);
+' "$REPO_ROOT/package.json" >/dev/null 2>&1
+}
+
+create_worktree() {
+  if has_project_helper_script; then
+    "$REPO_ROOT/scripts/agent-worktree-new.sh" \
+      --base "$BASE_BRANCH" \
+      --root "$WORKTREE_HOME" \
+      "$AGENT" \
+      "$TOPIC_RAW"
+    return
+  fi
+
+  if has_project_worktree_npm_script; then
+    (
+      cd "$REPO_ROOT"
+      npm run worktree:new -- \
+        --base "$BASE_BRANCH" \
+        --root "$WORKTREE_HOME" \
+        "$AGENT" \
+        "$TOPIC_RAW"
+    )
+    return
+  fi
+
+  mkdir -p "$WORKTREE_ROOT"
+  git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$BASE_BRANCH"
+}
+
+DRY_RUN=0
+NO_LAUNCH=0
+TOOL_CMD=""
+AGENT_OVERRIDE=""
+BASE_BRANCH=""
+ROOT_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)
+      AGENT_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    --tool)
+      TOOL_CMD="${2:-}"
+      shift 2
+      ;;
+    --base)
+      BASE_BRANCH="${2:-}"
+      shift 2
+      ;;
+    --root)
+      ROOT_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-launch)
+      NO_LAUNCH=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ -n "$AGENT_OVERRIDE" ]]; then
+  if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 1
+  fi
+
+  AGENT="$AGENT_OVERRIDE"
+  TOPIC_RAW="$1"
+  shift
+else
+  if [[ $# -lt 2 ]]; then
+    usage >&2
+    exit 1
+  fi
+
+  AGENT="$1"
+  TOPIC_RAW="$2"
+  shift 2
+fi
+
+TOOL_ARGS=("$@")
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "This launcher must be run inside a git worktree." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_NAME="$(basename "$REPO_ROOT")"
+CURRENT_BRANCH="$(git branch --show-current)"
+CURRENT_STATUS="$(git status --short)"
+CURRENT_PATH="$(pwd -P)"
+
+TOPIC_SLUG="$(slugify "$TOPIC_RAW")"
+if [[ -z "$TOPIC_SLUG" ]]; then
+  echo "Topic must contain at least one alphanumeric character." >&2
+  exit 1
+fi
+
+case "$AGENT" in
+  codex)
+    BRANCH_PREFIX="codex"
+    ;;
+  cc|claude)
+    BRANCH_PREFIX="cc"
+    ;;
+  *)
+    echo "Agent must be 'codex', 'cc', or 'claude'." >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "$BASE_BRANCH" ]]; then
+  BASE_BRANCH="$(default_base_branch)"
+fi
+
+git rev-parse --verify "$BASE_BRANCH^{commit}" >/dev/null
+
+WORKTREE_HOME="${ROOT_OVERRIDE:-${AI_WORKTREE_HOME:-$HOME/ai-worktrees}}"
+WORKTREE_ROOT="${WORKTREE_HOME%/}/$REPO_NAME"
+BRANCH_NAME="$BRANCH_PREFIX/$TOPIC_SLUG"
+WORKTREE_PATH="$WORKTREE_ROOT/$BRANCH_PREFIX-$TOPIC_SLUG"
+
+if [[ -z "$TOOL_CMD" ]]; then
+  TOOL_CMD="$AGENT"
+  if [[ "$TOOL_CMD" == "cc" ]]; then
+    TOOL_CMD="claude"
+  fi
+fi
+
+if [[ "$CURRENT_BRANCH" == "$BRANCH_NAME" ]]; then
+  WORKTREE_PATH="$REPO_ROOT"
+  BRANCH_ALREADY_EXISTS=1
+else
+  BRANCH_ALREADY_EXISTS=0
+  if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+    BRANCH_ALREADY_EXISTS=1
+    ATTACHED_WORKTREE="$(find_attached_worktree_for_branch "$BRANCH_NAME")"
+    if [[ -n "$ATTACHED_WORKTREE" ]]; then
+      WORKTREE_PATH="$ATTACHED_WORKTREE"
+    fi
+  fi
+fi
+
+if [[ "$BRANCH_ALREADY_EXISTS" -eq 0 ]] && [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]] && [[ -n "$CURRENT_STATUS" ]] && [[ "$CURRENT_PATH" == "$REPO_ROOT" ]]; then
+  echo "Refusing to create a new agent worktree from dirty $BASE_BRANCH." >&2
+  echo "Capture or commit the shared checkout state first, then retry." >&2
+  exit 1
+fi
+
+echo "Repo root:      $REPO_ROOT"
+echo "Base branch:    $BASE_BRANCH"
+echo "Agent branch:   $BRANCH_NAME"
+echo "Worktree path:  $WORKTREE_PATH"
+echo "Launch tool:    $TOOL_CMD"
+
+if [[ "$AGENT" == "claude" ]] && git show-ref --verify --quiet refs/heads/claude; then
+  echo "Namespace note: using cc/* because the bare 'claude' branch blocks claude/* in this repo."
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  if [[ "$BRANCH_ALREADY_EXISTS" -eq 1 ]]; then
+    echo "Dry run: would reuse existing branch/worktree if available."
+  else
+    echo "Dry run: would create a new branch and worktree."
+  fi
+  if [[ "$NO_LAUNCH" -eq 1 ]]; then
+    echo "Dry run: would not launch the tool."
+  else
+    echo "Dry run: would launch '$TOOL_CMD' from the worktree."
+  fi
+  exit 0
+fi
+
+if [[ "$BRANCH_ALREADY_EXISTS" -eq 0 ]]; then
+  create_worktree
+elif [[ ! -d "$WORKTREE_PATH" ]]; then
+  mkdir -p "$WORKTREE_ROOT"
+  git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+fi
+
+if [[ "$NO_LAUNCH" -eq 1 ]]; then
+  echo
+  echo "Worktree ready."
+  echo "Open: $WORKTREE_PATH"
+  echo "Branch: $BRANCH_NAME"
+  exit 0
+fi
+
+if ! command -v "$TOOL_CMD" >/dev/null 2>&1; then
+  echo "Tool not found in PATH: $TOOL_CMD" >&2
+  echo "Worktree is ready at: $WORKTREE_PATH" >&2
+  exit 1
+fi
+
+echo
+echo "Launching $TOOL_CMD in $WORKTREE_PATH"
+cd "$WORKTREE_PATH"
+exec "$TOOL_CMD" "${TOOL_ARGS[@]}"

--- a/scripts/agent-worktree-list.sh
+++ b/scripts/agent-worktree-list.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  agent-worktree-list.sh [--all]
+
+Lists active agent worktrees. By default this shows only codex/* and claude/* branches.
+Use --all to include every linked worktree in the repository.
+EOF
+}
+
+SHOW_ALL=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      SHOW_ALL=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+is_agent_branch() {
+  case "$1" in
+    codex/*|claude/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+status_for_path() {
+  local path="$1"
+  if [[ -n "$(git -C "$path" status --short 2>/dev/null)" ]]; then
+    printf 'dirty'
+  else
+    printf 'clean'
+  fi
+}
+
+print_entry() {
+  local path="$1"
+  local branch="$2"
+  local head="$3"
+
+  if [[ -z "$path" ]]; then
+    return
+  fi
+
+  if [[ -z "$branch" ]]; then
+    branch="(detached)"
+  fi
+
+  if [[ "$SHOW_ALL" -ne 1 ]] && ! is_agent_branch "$branch"; then
+    return
+  fi
+
+  printf '%-36s %-10s %-8s %s\n' "$branch" "${head:0:10}" "$(status_for_path "$path")" "$path"
+}
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "Repo: $REPO_ROOT"
+echo
+printf '%-36s %-10s %-8s %s\n' "BRANCH" "HEAD" "STATUS" "PATH"
+printf '%-36s %-10s %-8s %s\n' "------" "----" "------" "----"
+
+current_path=""
+current_branch=""
+current_head=""
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ -z "$line" ]]; then
+    print_entry "$current_path" "$current_branch" "$current_head"
+    current_path=""
+    current_branch=""
+    current_head=""
+    continue
+  fi
+
+  case "$line" in
+    worktree\ *)
+      current_path="${line#worktree }"
+      ;;
+    HEAD\ *)
+      current_head="${line#HEAD }"
+      ;;
+    branch\ refs/heads/*)
+      current_branch="${line#branch refs/heads/}"
+      ;;
+    detached)
+      current_branch=""
+      ;;
+  esac
+done < <(git worktree list --porcelain && printf '\n')

--- a/scripts/agent-worktree-list.sh
+++ b/scripts/agent-worktree-list.sh
@@ -7,7 +7,7 @@ usage() {
 Usage:
   agent-worktree-list.sh [--all]
 
-Lists active agent worktrees. By default this shows only codex/* and claude/* branches.
+Lists active agent worktrees. By default this shows only codex/* and cc/* branches.
 Use --all to include every linked worktree in the repository.
 EOF
 }
@@ -34,7 +34,7 @@ done
 
 is_agent_branch() {
   case "$1" in
-    codex/*|claude/*) return 0 ;;
+    codex/*|cc/*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/agent-worktree-new.sh
+++ b/scripts/agent-worktree-new.sh
@@ -9,13 +9,18 @@ Usage:
 
 Creates a dedicated branch and worktree for one AI agent.
 
+Agent values:
+  codex   -> codex/<topic>
+  cc      -> cc/<topic>
+  claude  -> alias for cc/<topic>
+
 Defaults:
   base branch: local/WIP
   worktree root: $AI_WORKTREE_HOME/<repo-name> or ~/ai-worktrees/<repo-name>
 
 Examples:
   ./scripts/agent-worktree-new.sh codex visage-research
-  ./scripts/agent-worktree-new.sh --base main claude docs-audit
+  ./scripts/agent-worktree-new.sh --base main cc docs-audit
   ./scripts/agent-worktree-new.sh --dry-run codex ohif-deep-dive
 EOF
 }
@@ -71,6 +76,7 @@ fi
 AGENT="$1"
 TOPIC_RAW="$2"
 TOPIC_SLUG="$(slugify "$TOPIC_RAW")"
+BRANCH_PREFIX=""
 
 if [[ -z "$TOPIC_SLUG" ]]; then
   echo "Topic must contain at least one alphanumeric character." >&2
@@ -78,10 +84,14 @@ if [[ -z "$TOPIC_SLUG" ]]; then
 fi
 
 case "$AGENT" in
-  codex|claude)
+  codex)
+    BRANCH_PREFIX="codex"
+    ;;
+  cc|claude)
+    BRANCH_PREFIX="cc"
     ;;
   *)
-    echo "Agent must be 'codex' or 'claude'." >&2
+    echo "Agent must be 'codex', 'cc', or 'claude'." >&2
     exit 1
     ;;
 esac
@@ -90,8 +100,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 REPO_NAME="$(basename "$REPO_ROOT")"
 WORKTREE_HOME="${ROOT_OVERRIDE:-${AI_WORKTREE_HOME:-$HOME/ai-worktrees}}"
 WORKTREE_ROOT="${WORKTREE_HOME%/}/$REPO_NAME"
-BRANCH_NAME="$AGENT/$TOPIC_SLUG"
-WORKTREE_PATH="$WORKTREE_ROOT/$AGENT-$TOPIC_SLUG"
+BRANCH_NAME="$BRANCH_PREFIX/$TOPIC_SLUG"
+WORKTREE_PATH="$WORKTREE_ROOT/$BRANCH_PREFIX-$TOPIC_SLUG"
 CURRENT_BRANCH="$(git branch --show-current)"
 
 git rev-parse --verify "$BASE_BRANCH^{commit}" >/dev/null
@@ -114,6 +124,10 @@ echo "Repo root:      $REPO_ROOT"
 echo "Base branch:    $BASE_BRANCH"
 echo "Agent branch:   $BRANCH_NAME"
 echo "Worktree path:  $WORKTREE_PATH"
+
+if [[ "$AGENT" == "claude" ]]; then
+  echo "Namespace note: using cc/* because the bare 'claude' branch blocks claude/* in this repo."
+fi
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
   echo

--- a/scripts/agent-worktree-new.sh
+++ b/scripts/agent-worktree-new.sh
@@ -15,7 +15,7 @@ Agent values:
   claude  -> alias for cc/<topic>
 
 Defaults:
-  base branch: local/WIP
+  base branch: local/WIP when present, else main, master, or the current branch
   worktree root: $AI_WORKTREE_HOME/<repo-name> or ~/ai-worktrees/<repo-name>
 
 Examples:
@@ -31,8 +31,20 @@ slugify() {
     | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
 }
 
+default_base_branch() {
+  if git rev-parse --verify --quiet local/WIP^{commit} >/dev/null; then
+    printf '%s\n' "local/WIP"
+  elif git rev-parse --verify --quiet main^{commit} >/dev/null; then
+    printf '%s\n' "main"
+  elif git rev-parse --verify --quiet master^{commit} >/dev/null; then
+    printf '%s\n' "master"
+  else
+    git branch --show-current
+  fi
+}
+
 DRY_RUN=0
-BASE_BRANCH="local/WIP"
+BASE_BRANCH=""
 ROOT_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
@@ -103,6 +115,15 @@ WORKTREE_ROOT="${WORKTREE_HOME%/}/$REPO_NAME"
 BRANCH_NAME="$BRANCH_PREFIX/$TOPIC_SLUG"
 WORKTREE_PATH="$WORKTREE_ROOT/$BRANCH_PREFIX-$TOPIC_SLUG"
 CURRENT_BRANCH="$(git branch --show-current)"
+
+if [[ -z "$BASE_BRANCH" ]]; then
+  BASE_BRANCH="$(default_base_branch)"
+fi
+
+if [[ -z "$BASE_BRANCH" ]]; then
+  echo "Could not determine a default base branch. Re-run with --base <branch>." >&2
+  exit 1
+fi
 
 git rev-parse --verify "$BASE_BRANCH^{commit}" >/dev/null
 

--- a/scripts/agent-worktree-new.sh
+++ b/scripts/agent-worktree-new.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  agent-worktree-new.sh [--dry-run] [--base <branch>] [--root <dir>] <agent> <topic>
+
+Creates a dedicated branch and worktree for one AI agent.
+
+Defaults:
+  base branch: local/WIP
+  worktree root: $AI_WORKTREE_HOME/<repo-name> or ~/ai-worktrees/<repo-name>
+
+Examples:
+  ./scripts/agent-worktree-new.sh codex visage-research
+  ./scripts/agent-worktree-new.sh --base main claude docs-audit
+  ./scripts/agent-worktree-new.sh --dry-run codex ohif-deep-dive
+EOF
+}
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+DRY_RUN=0
+BASE_BRANCH="local/WIP"
+ROOT_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --base)
+      BASE_BRANCH="${2:-}"
+      shift 2
+      ;;
+    --root)
+      ROOT_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+AGENT="$1"
+TOPIC_RAW="$2"
+TOPIC_SLUG="$(slugify "$TOPIC_RAW")"
+
+if [[ -z "$TOPIC_SLUG" ]]; then
+  echo "Topic must contain at least one alphanumeric character." >&2
+  exit 1
+fi
+
+case "$AGENT" in
+  codex|claude)
+    ;;
+  *)
+    echo "Agent must be 'codex' or 'claude'." >&2
+    exit 1
+    ;;
+esac
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_NAME="$(basename "$REPO_ROOT")"
+WORKTREE_HOME="${ROOT_OVERRIDE:-${AI_WORKTREE_HOME:-$HOME/ai-worktrees}}"
+WORKTREE_ROOT="${WORKTREE_HOME%/}/$REPO_NAME"
+BRANCH_NAME="$AGENT/$TOPIC_SLUG"
+WORKTREE_PATH="$WORKTREE_ROOT/$AGENT-$TOPIC_SLUG"
+CURRENT_BRANCH="$(git branch --show-current)"
+
+git rev-parse --verify "$BASE_BRANCH^{commit}" >/dev/null
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  echo "Branch already exists: $BRANCH_NAME" >&2
+  exit 1
+fi
+
+if [[ -e "$WORKTREE_PATH" ]]; then
+  echo "Worktree path already exists: $WORKTREE_PATH" >&2
+  exit 1
+fi
+
+if [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]] && [[ -n "$(git status --short)" ]]; then
+  echo "Note: $BASE_BRANCH has uncommitted changes; the new branch starts from the last commit only." >&2
+fi
+
+echo "Repo root:      $REPO_ROOT"
+echo "Base branch:    $BASE_BRANCH"
+echo "Agent branch:   $BRANCH_NAME"
+echo "Worktree path:  $WORKTREE_PATH"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo
+  echo "Dry run only. No branch or worktree created."
+  exit 0
+fi
+
+mkdir -p "$WORKTREE_ROOT"
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$BASE_BRANCH"
+
+echo
+echo "Created agent worktree."
+echo "Open: $WORKTREE_PATH"
+echo "Branch: $BRANCH_NAME"

--- a/scripts/agent-worktree-retire.sh
+++ b/scripts/agent-worktree-retire.sh
@@ -15,7 +15,7 @@ Defaults:
 
 Examples:
   ./scripts/agent-worktree-retire.sh codex/visage-research
-  ./scripts/agent-worktree-retire.sh --into main claude/docs-audit
+  ./scripts/agent-worktree-retire.sh --into main cc/docs-audit
   ./scripts/agent-worktree-retire.sh --dry-run codex/ohif-deep-dive
 EOF
 }

--- a/scripts/agent-worktree-retire.sh
+++ b/scripts/agent-worktree-retire.sh
@@ -97,6 +97,13 @@ fi
 BRANCH_NAME="$1"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+case "$BRANCH_NAME" in
+  main|master|local/WIP)
+    echo "Refusing to retire protected branch: $BRANCH_NAME" >&2
+    exit 1
+    ;;
+esac
+
 git rev-parse --verify "$BRANCH_NAME^{commit}" >/dev/null
 git rev-parse --verify "$INTO_BRANCH^{commit}" >/dev/null
 

--- a/scripts/agent-worktree-retire.sh
+++ b/scripts/agent-worktree-retire.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  agent-worktree-retire.sh [--dry-run] [--into <branch>] [--delete-remote] <branch>
+
+Safely removes an agent worktree and deletes its local branch after the branch
+has been integrated into the target branch.
+
+Defaults:
+  integration branch: local/WIP
+
+Examples:
+  ./scripts/agent-worktree-retire.sh codex/visage-research
+  ./scripts/agent-worktree-retire.sh --into main claude/docs-audit
+  ./scripts/agent-worktree-retire.sh --dry-run codex/ohif-deep-dive
+EOF
+}
+
+find_worktree_for_branch() {
+  local target="$1"
+  local path=""
+  local branch=""
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -z "$line" ]]; then
+      if [[ "$branch" == "$target" ]]; then
+        printf '%s\n' "$path"
+        return 0
+      fi
+      path=""
+      branch=""
+      continue
+    fi
+
+    case "$line" in
+      worktree\ *)
+        path="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        branch="${line#branch refs/heads/}"
+        ;;
+      detached)
+        branch=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain && printf '\n')
+
+  return 1
+}
+
+DRY_RUN=0
+INTO_BRANCH="local/WIP"
+DELETE_REMOTE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --into)
+      INTO_BRANCH="${2:-}"
+      shift 2
+      ;;
+    --delete-remote)
+      DELETE_REMOTE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+BRANCH_NAME="$1"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+git rev-parse --verify "$BRANCH_NAME^{commit}" >/dev/null
+git rev-parse --verify "$INTO_BRANCH^{commit}" >/dev/null
+
+if ! git merge-base --is-ancestor "$BRANCH_NAME" "$INTO_BRANCH"; then
+  echo "Refusing to retire $BRANCH_NAME: it is not merged into $INTO_BRANCH." >&2
+  exit 1
+fi
+
+ATTACHED_PATH="$(find_worktree_for_branch "$BRANCH_NAME" || true)"
+
+echo "Repo root:         $REPO_ROOT"
+echo "Branch to retire:  $BRANCH_NAME"
+echo "Merged into:       $INTO_BRANCH"
+
+if [[ -n "$ATTACHED_PATH" ]]; then
+  echo "Attached worktree: $ATTACHED_PATH"
+
+  if [[ "$ATTACHED_PATH" == "$REPO_ROOT" ]]; then
+    echo "Refusing to retire the branch checked out in the current worktree." >&2
+    exit 1
+  fi
+
+  if [[ -n "$(git -C "$ATTACHED_PATH" status --short 2>/dev/null)" ]]; then
+    echo "Refusing to remove $ATTACHED_PATH: worktree is dirty." >&2
+    exit 1
+  fi
+else
+  echo "Attached worktree: (none)"
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo
+  echo "Dry run only. No worktree or branch removed."
+  exit 0
+fi
+
+if [[ -n "$ATTACHED_PATH" ]]; then
+  git worktree remove "$ATTACHED_PATH"
+fi
+
+git branch -d "$BRANCH_NAME"
+
+if [[ "$DELETE_REMOTE" -eq 1 ]]; then
+  git push origin --delete "$BRANCH_NAME"
+fi
+
+echo
+echo "Retired $BRANCH_NAME"

--- a/scripts/ccw
+++ b/scripts/ccw
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if [[ $# -eq 0 ]]; then
+  echo "ccw requires a topic or launcher flag. Try: ccw <topic> or ccw --help" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELF_PATH="$(cd "$SCRIPT_DIR" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 GLOBAL_CCW="$(command -v ccw || true)"

--- a/scripts/ccw
+++ b/scripts/ccw
@@ -3,4 +3,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$SCRIPT_DIR/agent-session-launch.sh" --tool claude --agent cc "$@"
+SELF_PATH="$(cd "$SCRIPT_DIR" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+GLOBAL_CCW="$(command -v ccw || true)"
+
+if [[ -n "$GLOBAL_CCW" ]] && [[ "$GLOBAL_CCW" != "$SELF_PATH" ]]; then
+  exec "$GLOBAL_CCW" "$@"
+fi
+
+exec "$SCRIPT_DIR/agent-session-launch.sh" --tool "${CLAUDE_CMD:-claude}" --agent cc "$@"

--- a/scripts/ccw
+++ b/scripts/ccw
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/agent-session-launch.sh" --tool claude --agent cc "$@"

--- a/scripts/codexw
+++ b/scripts/codexw
@@ -3,4 +3,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$SCRIPT_DIR/agent-session-launch.sh" --tool codex --agent codex "$@"
+SELF_PATH="$(cd "$SCRIPT_DIR" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+GLOBAL_CODEXW="$(command -v codexw || true)"
+
+if [[ -n "$GLOBAL_CODEXW" ]] && [[ "$GLOBAL_CODEXW" != "$SELF_PATH" ]]; then
+  exec "$GLOBAL_CODEXW" "$@"
+fi
+
+exec "$SCRIPT_DIR/agent-session-launch.sh" --tool "${CODEX_CMD:-codex}" --agent codex "$@"

--- a/scripts/codexw
+++ b/scripts/codexw
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/agent-session-launch.sh" --tool codex --agent codex "$@"

--- a/scripts/codexw
+++ b/scripts/codexw
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if [[ $# -eq 0 ]]; then
+  echo "codexw requires a topic or launcher flag. Try: codexw <topic> or codexw --help" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELF_PATH="$(cd "$SCRIPT_DIR" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 GLOBAL_CODEXW="$(command -v codexw || true)"


### PR DESCRIPTION
## Summary
- add repo-level documentation for running Codex and Claude sessions in isolated worktrees
- add helper scripts to create, list, retire, and launch agent worktrees
- add startup guidance in `AGENTS.md` and `CLAUDE.md`
- switch Claude branch guidance to `cc/*` because the bare `claude` branch blocks `claude/*`
- fix launcher handoff when no extra tool arguments are provided

## Validation
- smoke-tested `scripts/agent-session-launch.sh` with `/usr/bin/true` as the launched tool
- verified create/reuse behavior for the global launcher path and confirmed the empty-args crash is fixed
