### PR TITLE
Fix collision-based series splitting edge cases

### DIFF
--- a/app.py
+++ b/app.py
@@ -405,14 +405,13 @@ def _resolve_series_key(series_map, bare_uid, desc):
         if existing['series_description'] == desc:
             return bare_uid
         # Collision: re-key the existing series
-        old_key = f"{bare_uid}|{existing['series_description']}" if existing['series_description'] else bare_uid
-        if old_key != bare_uid:
-            series_map[old_key] = existing
-            existing['series_id'] = old_key
-            del series_map[bare_uid]
-        return f"{bare_uid}|{desc}" if desc else bare_uid
+        old_key = f"{bare_uid}|{existing['series_description'] or ''}"
+        series_map[old_key] = existing
+        existing['series_id'] = old_key
+        del series_map[bare_uid]
+        return f"{bare_uid}|{desc or ''}"
 
-    composite_key = f"{bare_uid}|{desc}" if desc else bare_uid
+    composite_key = f"{bare_uid}|{desc or ''}"
     if composite_key in series_map:
         return composite_key
     has_collision = any(k.startswith(f"{bare_uid}|") for k in series_map)
@@ -669,7 +668,7 @@ def get_test_studies():
     return jsonify(test_source.format_studies())
 
 
-@app.route('/api/test-data/dicom/<study_id>/<series_id>/<int:slice_num>')
+@app.route('/api/test-data/dicom/<study_id>/<path:series_id>/<int:slice_num>')
 def get_test_dicom(study_id, series_id, slice_num):
     """Get raw DICOM file bytes for a test data slice."""
     file_path = test_source.get_safe_slice_path(study_id, series_id, slice_num)
@@ -816,7 +815,7 @@ def get_library_studies():
     return jsonify(payload)
 
 
-@app.route('/api/library/dicom/<study_id>/<series_id>/<int:slice_num>')
+@app.route('/api/library/dicom/<study_id>/<path:series_id>/<int:slice_num>')
 def get_library_dicom(study_id, series_id, slice_num):
     """Get raw DICOM file bytes for a local library slice."""
     file_path = library_source.get_safe_slice_path(study_id, series_id, slice_num)
@@ -1000,7 +999,7 @@ def save_study_description(study_uid):
     return jsonify({'studyUid': study_uid, 'description': description, 'updatedAt': now})
 
 
-@app.route('/api/notes/<study_uid>/series/<series_uid>/description', methods=['PUT'])
+@app.route('/api/notes/<study_uid>/series/<path:series_uid>/description', methods=['PUT'])
 def save_series_description(study_uid, series_uid):
     data = request.get_json(silent=True) or {}
     description = (data.get('description') or '').strip()

--- a/app.py
+++ b/app.py
@@ -393,6 +393,32 @@ def _read_single_dicom(file_path):
         return None
 
 
+def _resolve_series_key(series_map, bare_uid, desc):
+    """Resolve the map key for a series, splitting on collision.
+
+    Uses the bare UID unless the same UID already maps to a different
+    description (e.g. X-ray stitching). Only then switches to composite
+    uid|description keys, so conformant datasets keep their original keys.
+    """
+    existing = series_map.get(bare_uid)
+    if existing is not None:
+        if existing['series_description'] == desc:
+            return bare_uid
+        # Collision: re-key the existing series
+        old_key = f"{bare_uid}|{existing['series_description']}" if existing['series_description'] else bare_uid
+        if old_key != bare_uid:
+            series_map[old_key] = existing
+            existing['series_id'] = old_key
+            del series_map[bare_uid]
+        return f"{bare_uid}|{desc}" if desc else bare_uid
+
+    composite_key = f"{bare_uid}|{desc}" if desc else bare_uid
+    if composite_key in series_map:
+        return composite_key
+    has_collision = any(k.startswith(f"{bare_uid}|") for k in series_map)
+    return composite_key if has_collision else bare_uid
+
+
 def scan_dicom_folder(folder_path):
     """Scan a folder for DICOM files and organize by study/series."""
     studies = {}
@@ -413,7 +439,8 @@ def scan_dicom_folder(folder_path):
                 continue
 
             study_id = meta['study_instance_uid']
-            series_id = meta['series_instance_uid']
+            bare_uid = meta['series_instance_uid']
+            series_desc = meta['series_description'] or ''
 
             # Initialize study
             if study_id not in studies:
@@ -428,18 +455,24 @@ def scan_dicom_folder(folder_path):
                     'image_count': 0
                 }
 
+            # Resolve series key -- only use composite uid|description when a
+            # collision is detected (same UID, different description). Common
+            # with X-ray stitching modalities. Conformant datasets keep bare UIDs.
+            series_map = studies[study_id]['series']
+            series_id = _resolve_series_key(series_map, bare_uid, series_desc)
+
             # Initialize series
-            if series_id not in studies[study_id]['series']:
-                studies[study_id]['series'][series_id] = {
+            if series_id not in series_map:
+                series_map[series_id] = {
                     'series_id': series_id,
-                    'series_description': meta['series_description'],
+                    'series_description': series_desc,
                     'series_number': meta['series_number'],
                     'modality': meta['modality'],
                     'slices': []
                 }
 
             # Add slice
-            studies[study_id]['series'][series_id]['slices'].append({
+            series_map[series_id]['slices'].append({
                 'file_path': meta['file_path'],
                 'instance_number': meta['instance_number'],
                 'slice_location': meta['slice_location'],
@@ -569,13 +602,13 @@ class DicomFolderSource:
                 'imageCount': study['image_count'],
                 'series': [
                     {
-                        'seriesInstanceUid': series_id,
+                        'seriesInstanceUid': series['series_id'],
                         'seriesDescription': series['series_description'],
                         'seriesNumber': series['series_number'],
                         'modality': series['modality'],
                         'sliceCount': len(series['slices'])
                     }
-                    for series_id, series in study['series'].items()
+                    for series in study['series'].values()
                 ]
             }
             for study_id, study in studies.items()

--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -22,7 +22,7 @@
 
     const openPanels = {
         studyPanels: new Set(),
-        seriesPanels: new Set(),
+        seriesPanels: new Map(),
         seriesDropdowns: new Set()
     };
 
@@ -36,6 +36,24 @@
             callback();
         }, 500);
         descriptionSaveTimers.set(key, handle);
+    }
+
+    function rememberOpenSeriesPanel(studyUid, seriesUid) {
+        let seriesUids = openPanels.seriesPanels.get(studyUid);
+        if (!seriesUids) {
+            seriesUids = new Set();
+            openPanels.seriesPanels.set(studyUid, seriesUids);
+        }
+        seriesUids.add(seriesUid);
+    }
+
+    function forgetOpenSeriesPanel(studyUid, seriesUid) {
+        const seriesUids = openPanels.seriesPanels.get(studyUid);
+        if (!seriesUids) return;
+        seriesUids.delete(seriesUid);
+        if (!seriesUids.size) {
+            openPanels.seriesPanels.delete(studyUid);
+        }
     }
 
     function setLibraryFolderStatus(message, tone = '') {
@@ -468,16 +486,15 @@
                 e.stopPropagation();
                 const studyUid = btn.dataset.studyUid;
                 const seriesUid = btn.dataset.seriesUid;
-                const key = `${studyUid}:${seriesUid}`;
                 const panel = studiesBody.querySelector(`.series-comment-panel[data-study-uid="${CSS.escape(studyUid)}"][data-series-uid="${CSS.escape(seriesUid)}"]`);
                 const isOpen = panel.style.display !== 'none';
                 panel.style.display = isOpen ? 'none' : 'block';
                 if (isOpen) {
-                    openPanels.seriesPanels.delete(key);
+                    forgetOpenSeriesPanel(studyUid, seriesUid);
                     const count = state.studies[studyUid]?.series[seriesUid]?.comments?.length || 0;
                     btn.textContent = count > 0 ? `${count} comment${count > 1 ? 's' : ''}` : 'Add comment';
                 } else {
-                    openPanels.seriesPanels.add(key);
+                    rememberOpenSeriesPanel(studyUid, seriesUid);
                     btn.textContent = 'Hide comments';
                 }
             };
@@ -562,19 +579,20 @@
             const btn = studiesBody.querySelector(`.comment-toggle[data-study-uid="${CSS.escape(studyUid)}"]:not(.series-comment-toggle)`);
             if (btn) btn.textContent = 'Hide comments';
         });
-        openPanels.seriesPanels.forEach(key => {
-            const [studyUid, seriesUid] = key.split(':');
-            const panel = studiesBody.querySelector(`.series-comment-panel[data-study-uid="${CSS.escape(studyUid)}"][data-series-uid="${CSS.escape(seriesUid)}"]`);
-            if (panel) panel.style.display = 'block';
-            const btn = studiesBody.querySelector(`.series-comment-toggle[data-study-uid="${CSS.escape(studyUid)}"][data-series-uid="${CSS.escape(seriesUid)}"]`);
-            if (btn) btn.textContent = 'Hide comments';
-            const dropdown = studiesBody.querySelector(`.series-dropdown-row[data-study-uid="${CSS.escape(studyUid)}"]`);
-            if (dropdown) dropdown.style.display = 'table-row';
-            const icon = studiesBody.querySelector(`.study-row[data-uid="${CSS.escape(studyUid)}"] .expand-icon`);
-            if (icon) {
-                icon.textContent = '\u25BC';
-                icon.classList.add('expanded');
-            }
+        openPanels.seriesPanels.forEach((seriesUids, studyUid) => {
+            seriesUids.forEach(seriesUid => {
+                const panel = studiesBody.querySelector(`.series-comment-panel[data-study-uid="${CSS.escape(studyUid)}"][data-series-uid="${CSS.escape(seriesUid)}"]`);
+                if (panel) panel.style.display = 'block';
+                const btn = studiesBody.querySelector(`.series-comment-toggle[data-study-uid="${CSS.escape(studyUid)}"][data-series-uid="${CSS.escape(seriesUid)}"]`);
+                if (btn) btn.textContent = 'Hide comments';
+                const dropdown = studiesBody.querySelector(`.series-dropdown-row[data-study-uid="${CSS.escape(studyUid)}"]`);
+                if (dropdown) dropdown.style.display = 'table-row';
+                const icon = studiesBody.querySelector(`.study-row[data-uid="${CSS.escape(studyUid)}"] .expand-icon`);
+                if (icon) {
+                    icon.textContent = '\u25BC';
+                    icon.classList.add('expanded');
+                }
+            });
         });
         openPanels.seriesDropdowns.forEach(studyUid => {
             const dropdown = studiesBody.querySelector(`.series-dropdown-row[data-study-uid="${CSS.escape(studyUid)}"]`);

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -34,9 +34,32 @@
         progressFill.style.animation = 'none';
     }
 
+    // Resolve the map key for a series within a study. Uses bare UID unless a
+    // collision is detected (same UID, different description) -- common with
+    // X-ray stitching modalities. Only then does it switch to composite keys,
+    // so conformant datasets keep their original bare-UID keys and existing
+    // notes/measurements are preserved.
+    function resolveSeriesKey(studyMap, bareUid, desc) {
+        const existing = studyMap[bareUid];
+        if (existing) {
+            if (existing.seriesDescription === desc) return bareUid;
+            // Collision: re-key the existing series to a composite key
+            const oldKey = `${bareUid}|${existing.seriesDescription || ''}`;
+            studyMap[oldKey] = existing;
+            existing.seriesInstanceUid = oldKey;
+            delete studyMap[bareUid];
+            return `${bareUid}|${desc}`;
+        }
+        // Check if a collision was already detected for this UID
+        const compositeKey = `${bareUid}|${desc}`;
+        if (studyMap[compositeKey]) return compositeKey;
+        const hasCollision = Object.keys(studyMap).some(k => k.startsWith(`${bareUid}|`));
+        return hasCollision ? compositeKey : bareUid;
+    }
+
     function addSliceToStudies(studies, meta, source) {
         const studyUid = meta.studyInstanceUid;
-        const seriesUid = meta.seriesInstanceUid || 'default';
+        const bareUid = meta.seriesInstanceUid || 'default';
 
         if (!studies[studyUid]) {
             studies[studyUid] = {
@@ -48,6 +71,9 @@
                 reports: []
             };
         }
+        const seriesUid = resolveSeriesKey(
+            studies[studyUid].series, bareUid, meta.seriesDescription || ''
+        );
         if (!studies[studyUid].series[seriesUid]) {
             studies[studyUid].series[seriesUid] = {
                 seriesInstanceUid: seriesUid,
@@ -293,7 +319,7 @@
                 return source.blob.arrayBuffer();
             case 'api': {
                 const resp = await fetch(
-                    `${source.apiBase}/dicom/${source.studyId}/${source.seriesId}/${source.sliceIndex}`
+                    `${source.apiBase}/dicom/${encodeURIComponent(source.studyId)}/${encodeURIComponent(source.seriesId)}/${source.sliceIndex}`
                 );
                 if (!resp.ok) throw new Error(`Failed to ${purpose} slice: ${resp.status}`);
                 return resp.arrayBuffer();

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -3,6 +3,10 @@
 const fs = require('fs');
 const path = require('path');
 const { test, expect } = require('@playwright/test');
+const {
+    createSyntheticDicomFolder,
+    removeSyntheticDicomFolder
+} = require('./dicom-fixture-helper');
 
 const TEST_BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:5001';
 const HOME_URL = `${TEST_BASE_URL}/?nolib`;
@@ -402,6 +406,68 @@ test.describe('Desktop library scanning', () => {
             seriesCount: 1,
             sliceCount: 1
         });
+    });
+
+    test('processFilesFromSources splits colliding series UIDs, including empty and pipe-bearing descriptions', async ({ page }) => {
+        const fixture = createSyntheticDicomFolder([
+            { description: '' },
+            { description: 'AP Upper' },
+            { description: 'AP|Upper' }
+        ]);
+
+        try {
+            const filePayloads = fixture.entries.map((entry) => ({
+                name: path.basename(entry.path),
+                bytes: Array.from(fs.readFileSync(entry.path))
+            }));
+
+            await installMockDesktop(page);
+            await page.goto(HOME_URL);
+
+            const summary = await page.evaluate(async ({ filePayloads }) => {
+                const files = filePayloads.map((entry) => ({
+                    name: entry.name,
+                    source: {
+                        kind: 'blob',
+                        blob: new Blob([Uint8Array.from(entry.bytes)])
+                    }
+                }));
+
+                const studies = await window.DicomViewerApp.sources.processFilesFromSources(files);
+                const study = Object.values(studies)[0];
+                const seriesEntries = Object.values(study.series).map((series) => ({
+                    uid: series.seriesInstanceUid,
+                    description: series.seriesDescription || '',
+                    sliceCount: series.slices.length
+                })).sort((a, b) => a.uid.localeCompare(b.uid));
+
+                return {
+                    studyCount: Object.keys(studies).length,
+                    seriesEntries
+                };
+            }, { filePayloads });
+
+            expect(summary.studyCount).toBe(1);
+            expect(summary.seriesEntries).toEqual([
+                {
+                    uid: `${fixture.seriesUid}|`,
+                    description: '',
+                    sliceCount: 1
+                },
+                {
+                    uid: `${fixture.seriesUid}|AP Upper`,
+                    description: 'AP Upper',
+                    sliceCount: 1
+                },
+                {
+                    uid: `${fixture.seriesUid}|AP|Upper`,
+                    description: 'AP|Upper',
+                    sliceCount: 1
+                }
+            ]);
+        } finally {
+            removeSyntheticDicomFolder(fixture.folder);
+        }
     });
 
     test('renderDicom selects the requested frame from an uncompressed multi-frame dataset', async ({ page }) => {

--- a/tests/dicom-fixture-helper.js
+++ b/tests/dicom-fixture-helper.js
@@ -1,0 +1,122 @@
+// @ts-check
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const PYTHON_BIN = path.join(REPO_ROOT, 'venv', 'bin', 'python');
+const UID_ROOT = '1.2.826.0.1.3680043.10.54321';
+
+const PYTHON_SCRIPT = `
+import json
+import struct
+import sys
+from pathlib import Path
+
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, SecondaryCaptureImageStorage
+
+payload = json.loads(sys.argv[1])
+folder = Path(payload["folder"])
+folder.mkdir(parents=True, exist_ok=True)
+
+study_uid = payload["studyUid"]
+series_uid = payload["seriesUid"]
+
+for index, entry in enumerate(payload["entries"], start=1):
+    file_path = folder / entry["fileName"]
+    sop_instance_uid = entry.get("sopInstanceUid") or f"{series_uid}.{index}"
+
+    file_meta = FileMetaDataset()
+    file_meta.MediaStorageSOPClassUID = SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = sop_instance_uid
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.ImplementationClassUID = "1.2.826.0.1.3680043.10.54321.1"
+
+    ds = FileDataset(str(file_path), {}, file_meta=file_meta, preamble=b"\\0" * 128)
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+
+    ds.SOPClassUID = SecondaryCaptureImageStorage
+    ds.SOPInstanceUID = sop_instance_uid
+    ds.StudyInstanceUID = study_uid
+    ds.SeriesInstanceUID = series_uid
+    ds.SeriesDescription = entry.get("description") or ""
+    ds.SeriesNumber = int(entry.get("seriesNumber", 1))
+    ds.InstanceNumber = int(entry.get("instanceNumber", index))
+    ds.Modality = entry.get("modality", "DX")
+    ds.PatientName = "Test^SeriesSplit"
+    ds.PatientID = "SERIES-SPLIT"
+    ds.StudyDescription = "Synthetic collision test"
+    ds.StudyDate = "20260320"
+    ds.StudyTime = "120000"
+    ds.ContentDate = "20260320"
+    ds.ContentTime = "120000"
+
+    ds.Rows = 2
+    ds.Columns = 2
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    ds.PixelRepresentation = 0
+    ds.BitsAllocated = 16
+    ds.BitsStored = 16
+    ds.HighBit = 15
+    ds.PixelData = struct.pack("<4H", index, index + 1, index + 2, index + 3)
+
+    ds.save_as(str(file_path), write_like_original=False)
+`;
+
+function makeUid(suffix = '') {
+    const randomPart = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    return `${UID_ROOT}.${randomPart}${suffix}`;
+}
+
+function createSyntheticDicomFolder(entries, options = {}) {
+    if (!fs.existsSync(PYTHON_BIN)) {
+        throw new Error(`Missing test python environment: ${PYTHON_BIN}`);
+    }
+
+    const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'dicom-series-split-'));
+    const studyUid = options.studyUid || makeUid('.1');
+    const seriesUid = options.seriesUid || `${studyUid}.1`;
+    const normalizedEntries = entries.map((entry, index) => ({
+        description: entry.description || '',
+        fileName: entry.fileName || `series-${String(index + 1).padStart(2, '0')}.dcm`,
+        instanceNumber: entry.instanceNumber || index + 1,
+        modality: entry.modality || 'DX',
+        seriesNumber: entry.seriesNumber || 1
+    }));
+
+    const payload = JSON.stringify({
+        folder,
+        studyUid,
+        seriesUid,
+        entries: normalizedEntries
+    });
+
+    execFileSync(PYTHON_BIN, ['-c', PYTHON_SCRIPT, payload], {
+        cwd: REPO_ROOT,
+        stdio: 'pipe'
+    });
+
+    return {
+        folder,
+        studyUid,
+        seriesUid,
+        entries: normalizedEntries.map((entry) => ({
+            ...entry,
+            path: path.join(folder, entry.fileName)
+        }))
+    };
+}
+
+function removeSyntheticDicomFolder(folder) {
+    if (!folder) return;
+    fs.rmSync(folder, { recursive: true, force: true });
+}
+
+module.exports = {
+    createSyntheticDicomFolder,
+    removeSyntheticDicomFolder
+};

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -4,6 +4,10 @@ const { test, expect } = require('@playwright/test');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const {
+    createSyntheticDicomFolder,
+    removeSyntheticDicomFolder
+} = require('./dicom-fixture-helper');
 
 /**
  * Playwright tests for DICOM Viewer - Library View and Navigation
@@ -1352,6 +1356,55 @@ test.describe('Test Suite 24: API Endpoint Health', () => {
             'http://127.0.0.1:5001/api/library/dicom/nonexistent-study-id/nonexistent-series-id/0'
         );
         expect(response.status()).toBe(404);
+    });
+
+    test('library API preserves deterministic collision keys and serves slash-bearing composite series IDs', async ({ page }) => {
+        const fixture = createSyntheticDicomFolder([
+            { description: '' },
+            { description: 'AP/Upper' }
+        ]);
+
+        const configResponse = await page.request.get('http://127.0.0.1:5001/api/library/config');
+        const previousConfig = await configResponse.json();
+
+        try {
+            expect(previousConfig.overridden).toBe(false);
+
+            const saveResponse = await page.request.post('http://127.0.0.1:5001/api/library/config', {
+                data: { folder: fixture.folder }
+            });
+            expect(saveResponse.status()).toBe(200);
+
+            const savePayload = await saveResponse.json();
+            expect(savePayload.available).toBe(true);
+            expect(savePayload.studies).toHaveLength(1);
+
+            const study = savePayload.studies[0];
+            const seriesIds = study.series.map((series) => series.seriesInstanceUid).sort();
+            expect(seriesIds).toEqual([
+                `${fixture.seriesUid}|`,
+                `${fixture.seriesUid}|AP/Upper`
+            ]);
+
+            const slashSeries = study.series.find((series) => series.seriesDescription === 'AP/Upper');
+            expect(slashSeries).toBeDefined();
+
+            const dicomResponse = await page.request.get(
+                `http://127.0.0.1:5001/api/library/dicom/${encodeURIComponent(study.studyInstanceUid)}/${encodeURIComponent(slashSeries.seriesInstanceUid)}/0`
+            );
+            expect(dicomResponse.status()).toBe(200);
+            expect(dicomResponse.headers()['content-type']).toContain('dicom');
+
+            const body = await dicomResponse.body();
+            expect(body.length).toBeGreaterThan(132);
+        } finally {
+            if (previousConfig.folderResolved || previousConfig.folder) {
+                await page.request.post('http://127.0.0.1:5001/api/library/config', {
+                    data: { folder: previousConfig.folderResolved || previousConfig.folder }
+                });
+            }
+            removeSyntheticDicomFolder(fixture.folder);
+        }
     });
 
     test('GET / serves the main application HTML', async ({ page }) => {

--- a/tests/notes-api.spec.js
+++ b/tests/notes-api.spec.js
@@ -352,6 +352,25 @@ test.describe('Test Suite 27: PUT /api/notes/<study_uid>/series/<series_uid>/des
         expect(seriesEntry.description).toBe('FLAIR sequence');
     });
 
+    test('series UIDs containing slashes are accepted by the description route', async ({ request }) => {
+        const studyUid = uniqueStudyUid();
+        const seriesUid = `${uniqueSeriesUid()}/AP Upper`;
+
+        const response = await request.put(
+            `${BASE_URL}/api/notes/${studyUid}/series/${encodeURIComponent(seriesUid)}/description`,
+            { data: { description: 'slash-safe route test' } }
+        );
+        expect(response.status()).toBe(200);
+
+        const body = await response.json();
+        expect(body.seriesUid).toBe(seriesUid);
+
+        const getBody = await (
+            await request.get(`${BASE_URL}/api/notes/?studies=${studyUid}`)
+        ).json();
+        expect(getBody.studies[studyUid].series[seriesUid].description).toBe('slash-safe route test');
+    });
+
     test('two series under one study are stored independently', async ({ request }) => {
         const studyUid = uniqueStudyUid();
         const seriesA = uniqueSeriesUid();


### PR DESCRIPTION
## Summary
- make collision-based series keys deterministic across JS and Python, including empty descriptions
- support slash-bearing composite series IDs in Flask routes and preserve open series panel state without delimiter parsing
- add regression coverage for series description routes with slash-containing IDs

## Verification
- `npx playwright test tests/notes-api.spec.js` (`86 passed`)
- `npx playwright test` (`253 passed`)
- `./venv/bin/python` real-data scan of `/Users/gabriel/Desktop/radiology all discs/2026/3-18-26_XR east river/` -> `1` study, `8` series, `1` slice each