### PR TITLE
Optimize desktop library scan and gate diagnostics

### DIFF
--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fs,
+    io::Read,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -25,6 +26,7 @@ const DECODE_CACHE_MANIFEST_NAME: &str = "manifest.json";
 const MAX_DECODE_CACHE_ENTRIES: usize = 1000;
 const MAX_DECODE_CACHE_BYTES: u64 = 500 * 1024 * 1024;
 const MAX_DECODE_CACHE_EVICTIONS_PER_WRITE: usize = 20;
+const MAX_SCAN_HEADER_BYTES: usize = 256 * 1024;
 
 type DecodeResult<T> = Result<T, DecodeError>;
 
@@ -205,11 +207,22 @@ pub async fn decode_frame<R: Runtime>(
     frame_index: u32,
     store: State<'_, DecodeStore>,
 ) -> DecodeResult<DecodeFrameMetadata> {
-    let scoped_path = validate_decode_path(&app, &path)?;
+    let scoped_path = validate_scoped_path(&app, &path, "decode", "Decode path")?;
     let cache_paths = resolve_cache_paths(&app)?;
     let decode_result = run_decode_with_timeout(scoped_path, frame_index, cache_paths).await?;
     let decode_id = store.insert(decode_result.pixel_bytes);
     Ok(decode_result.metadata.into_response(decode_id))
+}
+
+#[tauri::command]
+pub fn read_scan_header<R: Runtime>(
+    app: AppHandle<R>,
+    path: String,
+    max_bytes: usize,
+) -> DecodeResult<Response> {
+    let scoped_path = validate_scoped_path(&app, &path, "scan-header", "Scan header path")?;
+    let bytes = read_scan_header_impl(&scoped_path, max_bytes)?;
+    Ok(Response::new(bytes))
 }
 
 #[tauri::command]
@@ -266,36 +279,65 @@ fn resolve_cache_paths<R: Runtime>(app: &AppHandle<R>) -> DecodeResult<DecodeCac
     Ok(cache_paths)
 }
 
-fn validate_decode_path<R: Runtime>(app: &AppHandle<R>, path: &str) -> DecodeResult<PathBuf> {
+fn validate_scoped_path<R: Runtime>(
+    app: &AppHandle<R>,
+    path: &str,
+    stage: &str,
+    path_label: &str,
+) -> DecodeResult<PathBuf> {
     let requested_path = PathBuf::from(path);
     if requested_path.as_os_str().is_empty() {
-        return Err(DecodeError::new("decode", "Decode path is empty."));
+        return Err(DecodeError::new(stage, format!("{path_label} is empty.")));
     }
     if !requested_path.is_absolute() {
         return Err(DecodeError::new(
-            "decode",
-            format!("Decode path must be absolute: {path}"),
+            stage,
+            format!("{path_label} must be absolute: {path}"),
         ));
     }
 
     let canonical_path = requested_path.canonicalize().map_err(|error| {
         DecodeError::new(
-            "decode",
-            format!("Failed to open DICOM file {path}: {error}"),
+            stage,
+            format!("Failed to access scoped file {path}: {error}"),
         )
     })?;
 
     if !app.fs_scope().is_allowed(&canonical_path) {
         return Err(DecodeError::new(
-            "decode",
+            stage,
             format!(
-                "Decode path is outside the allowed desktop file scope: {}",
+                "{path_label} is outside the allowed desktop file scope: {}",
                 canonical_path.display()
             ),
         ));
     }
 
     Ok(canonical_path)
+}
+
+fn read_scan_header_impl(path: &Path, max_bytes: usize) -> DecodeResult<Vec<u8>> {
+    let capped_max_bytes = max_bytes.min(MAX_SCAN_HEADER_BYTES);
+    if capped_max_bytes == 0 {
+        return Ok(Vec::new());
+    }
+
+    let file = fs::File::open(path).map_err(|error| {
+        DecodeError::new(
+            "scan-header",
+            format!("Failed to open DICOM file {}: {error}", path.display()),
+        )
+    })?;
+    let mut bytes = Vec::with_capacity(capped_max_bytes);
+    file.take(capped_max_bytes as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            DecodeError::new(
+                "scan-header",
+                format!("Failed to read scan header from {}: {error}", path.display()),
+            )
+        })?;
+    Ok(bytes)
 }
 
 fn decode_frame_impl_with_cache(
@@ -980,5 +1022,33 @@ mod tests {
         assert_eq!(decoded.metadata.photometric_interpretation, "MONOCHROME2");
         assert_eq!(decoded.metadata.pixel_data_length, 1024 * 1024 * 2);
         assert_eq!(decoded.pixel_bytes.len(), decoded.metadata.pixel_data_length);
+    }
+
+    #[test]
+    fn read_scan_header_impl_returns_only_the_requested_prefix() {
+        let unique = format!("scan-header-{}-{}", std::process::id(), current_time_ms());
+        let path = std::env::temp_dir().join(unique);
+        fs::write(&path, [1, 2, 3, 4, 5, 6]).expect("scan header fixture should be written");
+
+        let bytes = read_scan_header_impl(&path, 4).expect("partial header read should succeed");
+
+        assert_eq!(bytes, vec![1, 2, 3, 4]);
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_scan_header_impl_caps_reads_to_the_maximum_header_size() {
+        let unique = format!("scan-header-cap-{}-{}", std::process::id(), current_time_ms());
+        let path = std::env::temp_dir().join(unique);
+        let bytes = vec![9; MAX_SCAN_HEADER_BYTES + 128];
+        fs::write(&path, &bytes).expect("scan header cap fixture should be written");
+
+        let read = read_scan_header_impl(&path, MAX_SCAN_HEADER_BYTES + 64)
+            .expect("capped header read should succeed");
+
+        assert_eq!(read.len(), MAX_SCAN_HEADER_BYTES);
+
+        let _ = fs::remove_file(&path);
     }
 }

--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -215,13 +215,20 @@ pub async fn decode_frame<R: Runtime>(
 }
 
 #[tauri::command]
-pub fn read_scan_header<R: Runtime>(
+pub async fn read_scan_header<R: Runtime>(
     app: AppHandle<R>,
     path: String,
     max_bytes: usize,
 ) -> DecodeResult<Response> {
     let scoped_path = validate_scoped_path(&app, &path, "scan-header", "Scan header path")?;
-    let bytes = read_scan_header_impl(&scoped_path, max_bytes)?;
+    let bytes = tokio::task::spawn_blocking(move || read_scan_header_impl(&scoped_path, max_bytes))
+        .await
+        .map_err(|error| {
+            DecodeError::new(
+                "scan-header",
+                format!("Native scan header worker ended before producing a result: {error}"),
+            )
+        })??;
     Ok(Response::new(bytes))
 }
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -87,6 +87,7 @@ fn main() {
         .plugin(tauri_plugin_persisted_scope::init())
         .invoke_handler(tauri::generate_handler![
             decode::decode_frame,
+            decode::read_scan_header,
             decode::take_decoded_frame
         ])
         .on_menu_event(|app, event| match event.id().as_ref() {

--- a/docs/decisions/003-tauri-desktop-shell-with-shared-web-core.md
+++ b/docs/decisions/003-tauri-desktop-shell-with-shared-web-core.md
@@ -84,6 +84,10 @@ The shared core should not depend directly on:
 
 Rust commands should be added only where Tauri plugins or frontend code are insufficient. The default should be to keep viewer logic in the shared web core, not move application logic into Rust prematurely.
 
+Operational note:
+
+- Desktop library scan timing is intentionally debug-only. The optimized header-first scan path is always on, but timing/report writing must be explicitly enabled. See [Desktop Library Diagnostics](../desktop-library-diagnostics.md) for the current toggle and report workflow.
+
 #### Cloud adapter
 
 - Authenticated study listing and slice retrieval
@@ -111,6 +115,7 @@ The initial Tauri v2 validation spike passed the required bootstrap and 2D imagi
 - Relative sample loading worked inside Tauri via `fetch('sample/manifest.json')`
 - A JPEG 2000 dataset rendered successfully in the desktop shell, confirming the OpenJPEG WASM decode path works in WKWebView
 - A follow-up render using a changed window/level override also succeeded, confirming the shared 2D render path survives desktop execution
+- A later desktop scan optimization pass replaced full-file metadata reads with native header reads plus selective fallback, cutting one real macOS library scan from `192744 ms` to `99361 ms` while leaving timing/reporting behind a debug toggle
 
 Implementation note:
 

--- a/docs/desktop-library-diagnostics.md
+++ b/docs/desktop-library-diagnostics.md
@@ -1,0 +1,157 @@
+# Desktop Library Diagnostics
+
+This note is the quick reference for rerunning desktop library scan diagnostics without turning them into normal app behavior.
+
+## Default Behavior
+
+The desktop app always uses the optimized header-first scan path.
+
+Scan timing and report writing are **off by default**:
+
+- normal desktop scans do not write `scan-timing.json`
+- normal progress callbacks do not include timing fields
+- diagnostics are enabled only when explicitly requested
+
+## When To Use This
+
+Turn diagnostics on when you need to:
+
+- profile a slow real-world library scan
+- compare performance before and after a scan-path change
+- verify whether a regression is coming from directory walk time, file reads, parse time, or header fallback behavior
+
+## Enable Diagnostics
+
+Use either of these methods.
+
+### Option 1: Query Parameter
+
+Add `?scanTiming=1` to the desktop app URL.
+
+For a one-off Tauri dev run, the simplest path is to temporarily change `build.devUrl` in [tauri.conf.json](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/desktop/src-tauri/tauri.conf.json) from:
+
+```json
+"devUrl": "http://127.0.0.1:1420"
+```
+
+to:
+
+```json
+"devUrl": "http://127.0.0.1:1420/?scanTiming=1"
+```
+
+Then launch:
+
+```bash
+cd desktop
+npm run tauri -- dev
+```
+
+Revert `devUrl` after the diagnostic run.
+
+### Option 2: localStorage Flag
+
+From the desktop window devtools console:
+
+```js
+localStorage.setItem('dicom-viewer-debug-scan-timing', '1');
+location.reload();
+```
+
+This keeps diagnostics enabled across reloads until removed.
+
+To turn it back off:
+
+```js
+localStorage.removeItem('dicom-viewer-debug-scan-timing');
+location.reload();
+```
+
+### Explicit Disable
+
+If the localStorage flag is set but you want one launch without diagnostics, use `?scanTiming=0`.
+
+## Running A Diagnostic Scan
+
+1. Enable diagnostics.
+2. Launch the desktop app.
+3. Let the configured desktop library auto-load, or choose/refresh the folder from the desktop library UI.
+4. Wait for the scan to finish.
+5. Read the timing report from app data.
+
+If you need startup determinism during testing, `?nolib` still disables library auto-load.
+
+## Report Location
+
+The report is written to Tauri app data as:
+
+```text
+$APPDATA/reports/scan-timing.json
+```
+
+On macOS that is currently:
+
+```text
+~/Library/Application Support/health.divergent.dicomviewer/reports/scan-timing.json
+```
+
+Example:
+
+```bash
+cat ~/Library/Application\ Support/health.divergent.dicomviewer/reports/scan-timing.json
+```
+
+## Report Fields
+
+Typical report shape:
+
+```json
+{
+  "totalMs": 99361,
+  "readDirMs": 17792,
+  "readFileMs": 183524,
+  "parseMs": 5406,
+  "finalizeMs": 6,
+  "headerReadCount": 75653,
+  "headerHitCount": 52545,
+  "headerShortCount": 20719,
+  "headerFallbackCount": 1076,
+  "headerRejectedCount": 1313,
+  "discovered": 75725,
+  "valid": 53265
+}
+```
+
+Field meanings:
+
+- `totalMs`: wall-clock scan time seen by the user
+- `readDirMs`: cumulative time spent in directory listing calls
+- `readFileMs`: cumulative time spent reading header chunks and any fallback full-file reads
+- `parseMs`: cumulative metadata parse time
+- `finalizeMs`: time spent sorting and finalizing the studies map after scanning
+- `headerReadCount`: files that used the native header-read command
+- `headerHitCount`: files whose metadata was fully resolved from the header read alone
+- `headerShortCount`: files smaller than the scan header size, so no full-read fallback was needed
+- `headerFallbackCount`: files that needed a full-file retry after a truncation-like header parse failure
+- `headerRejectedCount`: large files rejected after header parse failure without paying for a second full read
+- `discovered`: total files seen during the walk
+- `valid`: renderable image DICOM objects admitted into the library
+
+## Reading The Numbers
+
+Two important interpretation rules:
+
+- `totalMs` is wall-clock latency. That is the number to optimize for user experience.
+- `readFileMs` and `parseMs` are cumulative across concurrent work, so they can exceed `totalMs`.
+
+If `readFileMs` dominates, focus on file I/O shape and fallback behavior.
+
+If `headerFallbackCount` spikes after a scan-path change, the header-read heuristic is too aggressive or the retry rule is too broad.
+
+If `readDirMs` becomes large relative to `totalMs`, inspect directory walk behavior and hot-loop path operations.
+
+## Related Files
+
+- [desktop-library.js](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/docs/js/app/desktop-library.js)
+- [sources.js](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/docs/js/app/sources.js)
+- [decode.rs](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/desktop/src-tauri/src/decode.rs)

--- a/docs/desktop-library-diagnostics.md
+++ b/docs/desktop-library-diagnostics.md
@@ -28,7 +28,7 @@ Use either of these methods.
 
 Add `?scanTiming=1` to the desktop app URL.
 
-For a one-off Tauri dev run, the simplest path is to temporarily change `build.devUrl` in [tauri.conf.json](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/desktop/src-tauri/tauri.conf.json) from:
+For a one-off Tauri dev run, the simplest path is to temporarily change `build.devUrl` in [`desktop/src-tauri/tauri.conf.json`](../desktop/src-tauri/tauri.conf.json) from:
 
 ```json
 "devUrl": "http://127.0.0.1:1420"
@@ -110,6 +110,8 @@ Typical report shape:
   "totalMs": 99361,
   "readDirMs": 17792,
   "readFileMs": 183524,
+  "headerReadMs": 24163,
+  "fullReadMs": 159361,
   "parseMs": 5406,
   "finalizeMs": 6,
   "headerReadCount": 75653,
@@ -127,6 +129,8 @@ Field meanings:
 - `totalMs`: wall-clock scan time seen by the user
 - `readDirMs`: cumulative time spent in directory listing calls
 - `readFileMs`: cumulative time spent reading header chunks and any fallback full-file reads
+- `headerReadMs`: cumulative time spent in native header-prefix reads
+- `fullReadMs`: cumulative time spent in fallback full-file reads
 - `parseMs`: cumulative metadata parse time
 - `finalizeMs`: time spent sorting and finalizing the studies map after scanning
 - `headerReadCount`: files that used the native header-read command
@@ -144,7 +148,9 @@ Two important interpretation rules:
 - `totalMs` is wall-clock latency. That is the number to optimize for user experience.
 - `readFileMs` and `parseMs` are cumulative across concurrent work, so they can exceed `totalMs`.
 
-If `readFileMs` dominates, focus on file I/O shape and fallback behavior.
+If `fullReadMs` dominates, focus on fallback behavior and whether the header-read heuristic is too conservative.
+
+If `headerReadMs` dominates while `fullReadMs` stays low, the scan is already mostly header-only and the next bottleneck is directory walk or path overhead.
 
 If `headerFallbackCount` spikes after a scan-path change, the header-read heuristic is too aggressive or the retry rule is too broad.
 
@@ -152,6 +158,6 @@ If `readDirMs` becomes large relative to `totalMs`, inspect directory walk behav
 
 ## Related Files
 
-- [desktop-library.js](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/docs/js/app/desktop-library.js)
-- [sources.js](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/docs/js/app/sources.js)
-- [decode.rs](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-scan-timing/desktop/src-tauri/src/decode.rs)
+- [`docs/js/app/desktop-library.js`](./js/app/desktop-library.js)
+- [`docs/js/app/sources.js`](./js/app/sources.js)
+- [`desktop/src-tauri/src/decode.rs`](../desktop/src-tauri/src/decode.rs)

--- a/docs/js/app/desktop-library.js
+++ b/docs/js/app/desktop-library.js
@@ -3,6 +3,7 @@
 
     const DesktopLibrary = {
         CONFIG_KEY: 'dicom-viewer-library-config',
+        SCAN_TIMING_KEY: 'dicom-viewer-debug-scan-timing',
 
         getRuntime() {
             const tauri = window.__TAURI__;
@@ -30,6 +31,22 @@
             }
         },
 
+        isScanTimingEnabled() {
+            try {
+                const queryValue = new URLSearchParams(window.location.search).get('scanTiming');
+                if (queryValue !== null) {
+                    return !['0', 'false', 'off', 'no'].includes(queryValue.toLowerCase());
+                }
+            } catch {}
+
+            try {
+                const saved = localStorage.getItem(this.SCAN_TIMING_KEY);
+                return saved === '1' || saved === 'true';
+            } catch {
+                return false;
+            }
+        },
+
         saveConfig(config) {
             localStorage.setItem(this.CONFIG_KEY, JSON.stringify(config));
             return config;
@@ -53,9 +70,61 @@
             return app.sources.collectPathSources(folderPath);
         },
 
-        loadStudies(folderPath, options = {}) {
+        async writeScanTimingReport(report) {
+            const tauri = this.getRuntime();
+            const appDataPath = await tauri.path.appDataDir();
+            const reportsDir = await tauri.path.join(appDataPath, 'reports');
+            await tauri.fs.mkdir(reportsDir, { recursive: true });
+
+            const filePath = await tauri.path.join(reportsDir, 'scan-timing.json');
+            const bytes = new TextEncoder().encode(`${JSON.stringify(report, null, 2)}\n`);
+            await tauri.fs.writeFile(filePath, bytes);
+        },
+
+        async loadStudies(folderPath, options = {}) {
             this.getRuntime();
-            return app.sources.loadStudiesFromDesktopPaths([folderPath], options);
+
+            const { onProgress, ...restOptions } = options;
+            const captureTiming = this.isScanTimingEnabled();
+            let lastProgress = null;
+            const startedAt = captureTiming ? performance.now() : 0;
+            const studies = await app.sources.loadStudiesFromDesktopPaths([folderPath], {
+                ...restOptions,
+                captureTiming,
+                onProgress: (stats) => {
+                    if (captureTiming) {
+                        lastProgress = stats;
+                    }
+                    if (typeof onProgress === 'function') {
+                        onProgress(stats);
+                    }
+                }
+            });
+
+            if (captureTiming && lastProgress) {
+                const report = {
+                    totalMs: Math.round(performance.now() - startedAt),
+                    readDirMs: Math.round(lastProgress.readDirMs || 0),
+                    readFileMs: Math.round(lastProgress.readFileMs || 0),
+                    parseMs: Math.round(lastProgress.parseMs || 0),
+                    finalizeMs: Math.round(lastProgress.finalizeMs || 0),
+                    headerReadCount: lastProgress.headerReadCount || 0,
+                    headerHitCount: lastProgress.headerHitCount || 0,
+                    headerShortCount: lastProgress.headerShortCount || 0,
+                    headerFallbackCount: lastProgress.headerFallbackCount || 0,
+                    headerRejectedCount: lastProgress.headerRejectedCount || 0,
+                    discovered: lastProgress.discovered || 0,
+                    valid: lastProgress.valid || 0
+                };
+
+                try {
+                    await this.writeScanTimingReport(report);
+                } catch (error) {
+                    console.warn('DesktopLibrary: failed to write scan timing report:', error);
+                }
+            }
+
+            return studies;
         },
 
         markScanComplete(folderPath) {

--- a/docs/js/app/desktop-library.js
+++ b/docs/js/app/desktop-library.js
@@ -106,6 +106,8 @@
                     totalMs: Math.round(performance.now() - startedAt),
                     readDirMs: Math.round(lastProgress.readDirMs || 0),
                     readFileMs: Math.round(lastProgress.readFileMs || 0),
+                    headerReadMs: Math.round(lastProgress.headerReadMs || 0),
+                    fullReadMs: Math.round(lastProgress.fullReadMs || 0),
                     parseMs: Math.round(lastProgress.parseMs || 0),
                     finalizeMs: Math.round(lastProgress.finalizeMs || 0),
                     headerReadCount: lastProgress.headerReadCount || 0,

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -95,7 +95,7 @@
      * @param {File|Blob|ArrayBuffer|Uint8Array} input - Source bytes or file-like object
      * @returns {Promise<Object|null>} Metadata object or null if not valid DICOM
      */
-    async function parseDicomMetadata(input) {
+    async function parseDicomMetadataDetailed(input) {
         try {
             const byteArray = await toDicomByteArray(input);
             const dataSet = dicomParser.parseDicom(byteArray, { untilTag: 'x7fe00010' });
@@ -105,25 +105,35 @@
             const pixelDataElement = dataSet.elements?.x7fe00010;
             const numberOfFrames = getNumberOfFrames(dataSet);
             return {
-                patientName: getString(dataSet, 'x00100010'),
-                studyDate: getString(dataSet, 'x00080020'),
-                studyDescription: getString(dataSet, 'x00081030'),
-                studyInstanceUid: getString(dataSet, 'x0020000d'),
-                seriesDescription: getString(dataSet, 'x0008103e'),
-                seriesInstanceUid: getString(dataSet, 'x0020000e'),
-                seriesNumber: getString(dataSet, 'x00200011'),
-                modality: getString(dataSet, 'x00080060'),
-                sopInstanceUid: getString(dataSet, 'x00080018'),
-                instanceNumber: getMetadataNumber(dataSet, 'x00200013', 0),
-                sliceLocation: getMetadataNumber(dataSet, 'x00201041', 0),
-                transferSyntax: transferSyntax,
-                sopClassUid: getString(dataSet, 'x00080016'),
-                rows,
-                cols,
-                numberOfFrames,
-                hasPixelData: !!pixelDataElement && rows > 0 && cols > 0
+                meta: {
+                    patientName: getString(dataSet, 'x00100010'),
+                    studyDate: getString(dataSet, 'x00080020'),
+                    studyDescription: getString(dataSet, 'x00081030'),
+                    studyInstanceUid: getString(dataSet, 'x0020000d'),
+                    seriesDescription: getString(dataSet, 'x0008103e'),
+                    seriesInstanceUid: getString(dataSet, 'x0020000e'),
+                    seriesNumber: getString(dataSet, 'x00200011'),
+                    modality: getString(dataSet, 'x00080060'),
+                    sopInstanceUid: getString(dataSet, 'x00080018'),
+                    instanceNumber: getMetadataNumber(dataSet, 'x00200013', 0),
+                    sliceLocation: getMetadataNumber(dataSet, 'x00201041', 0),
+                    transferSyntax: transferSyntax,
+                    sopClassUid: getString(dataSet, 'x00080016'),
+                    rows,
+                    cols,
+                    numberOfFrames,
+                    hasPixelData: !!pixelDataElement && rows > 0 && cols > 0
+                },
+                error: null
             };
-        } catch { return null; }
+        } catch (error) {
+            return { meta: null, error };
+        }
+    }
+
+    async function parseDicomMetadata(input) {
+        const { meta } = await parseDicomMetadataDetailed(input);
+        return meta;
     }
 
     function isRenderableImageMetadata(meta) {
@@ -747,6 +757,7 @@
 
     app.dicom = {
         parseDicomMetadata,
+        parseDicomMetadataDetailed,
         toDicomByteArray,
         getMetadataNumber,
         getNumberOfFrames,

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -151,14 +151,18 @@
         }
     }
 
+    function joinPathSegments(parent, child) {
+        const separator = parent.includes('\\') ? '\\' : '/';
+        return parent.endsWith(separator) ? `${parent}${child}` : `${parent}${separator}${child}`;
+    }
+
     async function joinPath(parent, child) {
         const pathApi = window.__TAURI__?.path;
         if (pathApi?.join) {
             return pathApi.join(parent, child);
         }
 
-        const separator = parent.includes('\\') ? '\\' : '/';
-        return parent.endsWith(separator) ? `${parent}${child}` : `${parent}${separator}${child}`;
+        return joinPathSegments(parent, child);
     }
 
     async function normalizePath(path) {
@@ -174,8 +178,9 @@
     }
 
     function joinScanPath(parent, child) {
-        const separator = parent.includes('\\') ? '\\' : '/';
-        return parent.endsWith(separator) ? `${parent}${child}` : `${parent}${separator}${child}`;
+        // Desktop scan roots are normalized once up front, and readDir() only yields basenames.
+        // Reusing the shared string join avoids hot-loop path IPC without introducing a second fallback shape.
+        return joinPathSegments(parent, child);
     }
 
     function normalizeBinaryResponse(bytes) {
@@ -217,10 +222,18 @@
         try {
             return await parseDicomMetadataDetailed(buffer);
         } finally {
-            if (shouldTimeParse) {
-                stats.parseMs += performance.now() - parseStartedAt;
-            }
+            addDesktopScanTiming(stats, 'parseMs', shouldTimeParse ? performance.now() - parseStartedAt : 0);
         }
+    }
+
+    function addDesktopScanTiming(stats, key, deltaMs) {
+        if (typeof stats[key] !== 'number' || !Number.isFinite(deltaMs)) return;
+        stats[key] += deltaMs;
+    }
+
+    function incrementDesktopScanCounter(stats, key, delta = 1) {
+        if (typeof stats[key] !== 'number') return;
+        stats[key] += delta;
     }
 
     function getDesktopScanParseErrorMessage(error) {
@@ -231,55 +244,52 @@
         return String(error);
     }
 
+    // These string matches come from the bundled dicomParser implementation:
+    // - parseDicomDataSetExplicit(...) => "buffer overrun"
+    // - readFixedString(...) => "attempt to read past end of buffer"
+    // - parseDicom(...) => "missing required meta header attribute 0002,0010"
+    // If dicomParser changes these messages, update this heuristic and its scan fallback tests together.
+    const DESKTOP_SCAN_TRUNCATION_ERROR_PATTERNS = [
+        'buffer overrun',
+        'attempt to read past end of buffer',
+        'missing required meta header attribute 0002,0010'
+    ];
+
     function shouldRetryDesktopScanWithFullRead(parseResult, headerBytes) {
         if (parseResult?.meta) return false;
         if (!headerBytes || headerBytes.byteLength < DESKTOP_SCAN_HEADER_BYTES) return false;
 
         const message = getDesktopScanParseErrorMessage(parseResult?.error).toLowerCase();
-        return (
-            message.includes('buffer overrun') ||
-            message.includes('attempt to read past end of buffer') ||
-            message.includes('missing required meta header attribute 0002,0010')
-        );
+        return DESKTOP_SCAN_TRUNCATION_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
     }
 
     async function readDesktopScanMetadata(source, stats) {
         const shouldTimeReads = typeof stats.readFileMs === 'number';
         const headerReadStartedAt = shouldTimeReads ? performance.now() : 0;
         const headerBytes = await readDesktopScanHeader(source.path, DESKTOP_SCAN_HEADER_BYTES);
-        if (shouldTimeReads) {
-            stats.readFileMs += performance.now() - headerReadStartedAt;
-        }
+        const headerReadDeltaMs = shouldTimeReads ? performance.now() - headerReadStartedAt : 0;
+        addDesktopScanTiming(stats, 'readFileMs', headerReadDeltaMs);
+        addDesktopScanTiming(stats, 'headerReadMs', headerReadDeltaMs);
 
         if (headerBytes) {
-            if (typeof stats.headerReadCount === 'number') {
-                stats.headerReadCount++;
-            }
+            incrementDesktopScanCounter(stats, 'headerReadCount');
             const headerResult = await parseDesktopScanBuffer(headerBytes, stats);
             if (headerResult.meta) {
-                if (typeof stats.headerHitCount === 'number') {
-                    stats.headerHitCount++;
-                }
+                incrementDesktopScanCounter(stats, 'headerHitCount');
                 return headerResult.meta;
             }
 
             if (headerBytes.byteLength < DESKTOP_SCAN_HEADER_BYTES) {
-                if (typeof stats.headerShortCount === 'number') {
-                    stats.headerShortCount++;
-                }
+                incrementDesktopScanCounter(stats, 'headerShortCount');
                 return headerResult.meta;
             }
 
             if (!shouldRetryDesktopScanWithFullRead(headerResult, headerBytes)) {
-                if (typeof stats.headerRejectedCount === 'number') {
-                    stats.headerRejectedCount++;
-                }
+                incrementDesktopScanCounter(stats, 'headerRejectedCount');
                 return headerResult.meta;
             }
 
-            if (typeof stats.headerFallbackCount === 'number') {
-                stats.headerFallbackCount++;
-            }
+            incrementDesktopScanCounter(stats, 'headerFallbackCount');
         }
 
         let buffer;
@@ -287,9 +297,9 @@
         try {
             buffer = await readSliceBuffer({ source }, 'scan');
         } finally {
-            if (shouldTimeReads) {
-                stats.readFileMs += performance.now() - fullReadStartedAt;
-            }
+            const fullReadDeltaMs = shouldTimeReads ? performance.now() - fullReadStartedAt : 0;
+            addDesktopScanTiming(stats, 'readFileMs', fullReadDeltaMs);
+            addDesktopScanTiming(stats, 'fullReadMs', fullReadDeltaMs);
         }
 
         const fullResult = await parseDesktopScanBuffer(buffer, stats);
@@ -661,6 +671,8 @@
             Object.assign(stats, {
                 readDirMs: 0,
                 readFileMs: 0,
+                headerReadMs: 0,
+                fullReadMs: 0,
                 parseMs: 0,
                 finalizeMs: 0,
                 headerReadCount: 0,

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -1,13 +1,14 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { uploadProgress, progressFill, progressText, progressDetail } = app.dom;
-    const { parseDicomMetadata, isRenderableImageMetadata } = app.dicom;
+    const { parseDicomMetadata, parseDicomMetadataDetailed, isRenderableImageMetadata } = app.dicom;
     const DESKTOP_MAX_SCAN_DEPTH = 20;
     const DEFAULT_SCAN_CONCURRENCY = 100;
     const DESKTOP_PATH_SCAN_CONCURRENCY = 4;
     const DESKTOP_PATH_BATCH_SIZE = 32;
     const DESKTOP_PATH_READ_ATTEMPTS = 3;
     const DESKTOP_PATH_READ_RETRY_DELAY_MS = 50;
+    const DESKTOP_SCAN_HEADER_BYTES = 256 * 1024;
     const SCAN_PROGRESS_UPDATE_INTERVAL = 200;
 
     function updateScanProgress(processed, total, valid) {
@@ -172,6 +173,129 @@
         return path;
     }
 
+    function joinScanPath(parent, child) {
+        const separator = parent.includes('\\') ? '\\' : '/';
+        return parent.endsWith(separator) ? `${parent}${child}` : `${parent}${separator}${child}`;
+    }
+
+    function normalizeBinaryResponse(bytes) {
+        if (bytes instanceof Uint8Array) {
+            return bytes;
+        }
+        if (bytes instanceof ArrayBuffer) {
+            return new Uint8Array(bytes);
+        }
+        if (bytes?.buffer instanceof ArrayBuffer && typeof bytes.byteLength === 'number') {
+            return new Uint8Array(bytes.buffer, bytes.byteOffset || 0, bytes.byteLength);
+        }
+        if (Array.isArray(bytes)) {
+            return Uint8Array.from(bytes);
+        }
+        if (bytes && Object.prototype.hasOwnProperty.call(bytes, 'data')) {
+            return normalizeBinaryResponse(bytes.data);
+        }
+        return null;
+    }
+
+    async function readDesktopScanHeader(path, maxBytes = DESKTOP_SCAN_HEADER_BYTES) {
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (typeof invoke !== 'function') {
+            return null;
+        }
+
+        try {
+            const bytes = await invoke('read_scan_header', { path, maxBytes });
+            return normalizeBinaryResponse(bytes);
+        } catch {
+            return null;
+        }
+    }
+
+    async function parseDesktopScanBuffer(buffer, stats) {
+        const shouldTimeParse = typeof stats.parseMs === 'number';
+        const parseStartedAt = shouldTimeParse ? performance.now() : 0;
+        try {
+            return await parseDicomMetadataDetailed(buffer);
+        } finally {
+            if (shouldTimeParse) {
+                stats.parseMs += performance.now() - parseStartedAt;
+            }
+        }
+    }
+
+    function getDesktopScanParseErrorMessage(error) {
+        if (!error) return '';
+        if (typeof error === 'string') return error;
+        if (typeof error.message === 'string' && error.message) return error.message;
+        if (typeof error.exception === 'string' && error.exception) return error.exception;
+        return String(error);
+    }
+
+    function shouldRetryDesktopScanWithFullRead(parseResult, headerBytes) {
+        if (parseResult?.meta) return false;
+        if (!headerBytes || headerBytes.byteLength < DESKTOP_SCAN_HEADER_BYTES) return false;
+
+        const message = getDesktopScanParseErrorMessage(parseResult?.error).toLowerCase();
+        return (
+            message.includes('buffer overrun') ||
+            message.includes('attempt to read past end of buffer') ||
+            message.includes('missing required meta header attribute 0002,0010')
+        );
+    }
+
+    async function readDesktopScanMetadata(source, stats) {
+        const shouldTimeReads = typeof stats.readFileMs === 'number';
+        const headerReadStartedAt = shouldTimeReads ? performance.now() : 0;
+        const headerBytes = await readDesktopScanHeader(source.path, DESKTOP_SCAN_HEADER_BYTES);
+        if (shouldTimeReads) {
+            stats.readFileMs += performance.now() - headerReadStartedAt;
+        }
+
+        if (headerBytes) {
+            if (typeof stats.headerReadCount === 'number') {
+                stats.headerReadCount++;
+            }
+            const headerResult = await parseDesktopScanBuffer(headerBytes, stats);
+            if (headerResult.meta) {
+                if (typeof stats.headerHitCount === 'number') {
+                    stats.headerHitCount++;
+                }
+                return headerResult.meta;
+            }
+
+            if (headerBytes.byteLength < DESKTOP_SCAN_HEADER_BYTES) {
+                if (typeof stats.headerShortCount === 'number') {
+                    stats.headerShortCount++;
+                }
+                return headerResult.meta;
+            }
+
+            if (!shouldRetryDesktopScanWithFullRead(headerResult, headerBytes)) {
+                if (typeof stats.headerRejectedCount === 'number') {
+                    stats.headerRejectedCount++;
+                }
+                return headerResult.meta;
+            }
+
+            if (typeof stats.headerFallbackCount === 'number') {
+                stats.headerFallbackCount++;
+            }
+        }
+
+        let buffer;
+        const fullReadStartedAt = shouldTimeReads ? performance.now() : 0;
+        try {
+            buffer = await readSliceBuffer({ source }, 'scan');
+        } finally {
+            if (shouldTimeReads) {
+                stats.readFileMs += performance.now() - fullReadStartedAt;
+            }
+        }
+
+        const fullResult = await parseDesktopScanBuffer(buffer, stats);
+        return fullResult.meta;
+    }
+
     function getPathName(path) {
         return path.split(/[\\/]/).pop() || path;
     }
@@ -227,13 +351,7 @@
         if (!shouldEmit) return;
 
         try {
-            onProgress({
-                discovered: stats.discovered,
-                processed: stats.processed,
-                valid: stats.valid,
-                currentPath,
-                complete
-            });
+            onProgress({ ...stats, currentPath, complete });
         } catch (error) {
             console.warn('Desktop path scan progress callback failed:', error);
         }
@@ -292,8 +410,8 @@
             const batch = files.slice(i, i + DESKTOP_PATH_SCAN_CONCURRENCY);
             await Promise.all(batch.map(async ({ name, source }) => {
                 try {
-                    const buffer = await readSliceBuffer({ source }, 'scan');
-                    const meta = await parseDicomMetadata(buffer);
+                    const meta = await readDesktopScanMetadata(source, stats);
+
                     if (!isRenderableImageMetadata(meta)) return;
                     stats.valid++;
                     addSliceToStudies(studies, meta, source);
@@ -528,17 +646,39 @@
 
         const {
             maxDepth = DESKTOP_MAX_SCAN_DEPTH,
-            onProgress = null
+            onProgress = null,
+            captureTiming = false
         } = options;
 
         const studies = {};
         const pendingFiles = [];
-        const stats = { discovered: 0, processed: 0, valid: 0 };
+        const stats = {
+            discovered: 0,
+            processed: 0,
+            valid: 0
+        };
+        if (captureTiming) {
+            Object.assign(stats, {
+                readDirMs: 0,
+                readFileMs: 0,
+                parseMs: 0,
+                finalizeMs: 0,
+                headerReadCount: 0,
+                headerHitCount: 0,
+                headerShortCount: 0,
+                headerFallbackCount: 0,
+                headerRejectedCount: 0
+            });
+        }
         const visited = new Set();
-        const stack = (Array.isArray(paths) ? paths : [paths])
-            .filter(Boolean)
-            .map(path => ({ path, depth: 0 }))
-            .reverse();
+        const stack = [];
+        for (const path of (Array.isArray(paths) ? paths : [paths]).filter(Boolean)) {
+            stack.push({
+                path: await normalizePath(path),
+                depth: 0
+            });
+        }
+        stack.reverse();
 
         async function flushPendingFiles(force = false) {
             while (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE || (force && pendingFiles.length > 0)) {
@@ -552,32 +692,39 @@
 
         while (stack.length) {
             const current = stack.pop();
-            const normalizedPath = await normalizePath(current.path);
+            const currentPath = current.path;
 
-            if (visited.has(normalizedPath)) {
-                console.warn('Skipping already-visited desktop scan path:', normalizedPath);
+            if (visited.has(currentPath)) {
+                console.warn('Skipping already-visited desktop scan path:', currentPath);
                 continue;
             }
-            visited.add(normalizedPath);
+            visited.add(currentPath);
 
             let entries;
+            const readDirStartedAt = captureTiming ? performance.now() : 0;
             try {
-                entries = await fs.readDir(normalizedPath);
+                entries = await fs.readDir(currentPath);
             } catch (readError) {
-                const fileEntries = await resolveDesktopPathSource(fs, normalizedPath, readError);
+                if (captureTiming) {
+                    stats.readDirMs += performance.now() - readDirStartedAt;
+                }
+                const fileEntries = await resolveDesktopPathSource(fs, currentPath, readError);
                 for (const fileEntry of fileEntries) {
                     pendingFiles.push(fileEntry);
                     stats.discovered++;
-                    safeEmitDesktopPathProgress(onProgress, stats, { currentPath: fileEntry.source?.path || normalizedPath });
+                    safeEmitDesktopPathProgress(onProgress, stats, { currentPath: fileEntry.source?.path || currentPath });
                     if (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE) {
                         await flushPendingFiles();
                     }
                 }
                 continue;
             }
+            if (captureTiming) {
+                stats.readDirMs += performance.now() - readDirStartedAt;
+            }
 
             for (const entry of entries) {
-                const entryPath = await joinPath(normalizedPath, entry.name);
+                const entryPath = joinScanPath(currentPath, entry.name);
                 if (entry.isSymlink) {
                     console.warn('Skipping symlink during desktop scan:', entryPath);
                     continue;
@@ -613,8 +760,13 @@
         }
 
         await flushPendingFiles(true);
+        const finalizeStartedAt = captureTiming ? performance.now() : 0;
+        const finalizedStudies = finalizeStudies(studies);
+        if (captureTiming) {
+            stats.finalizeMs += performance.now() - finalizeStartedAt;
+        }
         safeEmitDesktopPathProgress(onProgress, stats, { force: true, complete: true });
-        return finalizeStudies(studies);
+        return finalizedStudies;
     }
 
     async function loadDroppedPaths(paths) {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -1794,6 +1794,330 @@ test.describe('Desktop library scanning', () => {
         expect(config.lastScan).toBeNull();
     });
 
+    test('desktop loadStudies writes a timing report with final scan metrics', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'image.dcm', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            },
+            readDirDelayMs: 15
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+
+            const mkdirCalls = [];
+            const writes = [];
+            localStorage.setItem('dicom-viewer-debug-scan-timing', '1');
+            window.__TAURI__.path.appDataDir = async () => '/appdata';
+            window.__TAURI__.fs.readFile = async () => {
+                await new Promise(resolve => setTimeout(resolve, 5));
+                return Uint8Array.from(dicomBytes);
+            };
+            window.__TAURI__.fs.mkdir = async (path, options) => {
+                mkdirCalls.push({ path, options });
+            };
+            window.__TAURI__.fs.writeFile = async (path, data) => {
+                writes.push({
+                    path,
+                    text: new TextDecoder().decode(data)
+                });
+            };
+
+            const progress = [];
+            const studies = await window.DicomViewerApp.desktopLibrary.loadStudies('/library', {
+                onProgress: (stats) => progress.push(stats)
+            });
+
+            return {
+                studyCount: Object.keys(studies).length,
+                progress: progress.at(-1),
+                mkdirCalls,
+                writes
+            };
+        });
+
+        expect(result.studyCount).toBeGreaterThan(0);
+        expect(result.progress).toMatchObject({
+            discovered: 1,
+            processed: 1,
+            valid: 1,
+            complete: true
+        });
+        expect(result.progress.readDirMs).toBeGreaterThan(0);
+        expect(result.progress.readFileMs).toBeGreaterThan(0);
+        expect(result.progress.parseMs).toBeGreaterThan(0);
+        expect(result.progress.finalizeMs).toBeGreaterThanOrEqual(0);
+        expect(result.mkdirCalls).toEqual([
+            { path: '/appdata/reports', options: { recursive: true } }
+        ]);
+        expect(result.writes).toHaveLength(1);
+        expect(result.writes[0].path).toBe('/appdata/reports/scan-timing.json');
+
+        const report = JSON.parse(result.writes[0].text);
+        expect(report).toMatchObject({
+            discovered: 1,
+            valid: 1,
+            readDirMs: Math.round(result.progress.readDirMs),
+            readFileMs: Math.round(result.progress.readFileMs),
+            parseMs: Math.round(result.progress.parseMs),
+            finalizeMs: Math.round(result.progress.finalizeMs)
+        });
+        expect(report.totalMs).toBeGreaterThan(0);
+    });
+
+    test('desktop loadStudies does not write a timing report by default', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'image.dcm', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+
+            const writes = [];
+            window.__TAURI__.path.appDataDir = async () => '/appdata';
+            window.__TAURI__.fs.readFile = async () => Uint8Array.from(dicomBytes);
+            window.__TAURI__.fs.mkdir = async () => {};
+            window.__TAURI__.fs.writeFile = async (path, data) => {
+                writes.push({ path, size: data.length });
+            };
+
+            const progress = [];
+            const studies = await window.DicomViewerApp.desktopLibrary.loadStudies('/library', {
+                onProgress: (stats) => progress.push(stats)
+            });
+
+            return {
+                studyCount: Object.keys(studies).length,
+                progress: progress.at(-1),
+                writes
+            };
+        });
+
+        expect(result.studyCount).toBeGreaterThan(0);
+        expect(result.progress).toMatchObject({
+            discovered: 1,
+            processed: 1,
+            valid: 1,
+            complete: true
+        });
+        expect(result.progress.readDirMs).toBeUndefined();
+        expect(result.progress.readFileMs).toBeUndefined();
+        expect(result.progress.parseMs).toBeUndefined();
+        expect(result.progress.finalizeMs).toBeUndefined();
+        expect(result.writes).toHaveLength(0);
+    });
+
+    test('desktop loadStudies ignores timing report write failures', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'image.dcm', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+
+            localStorage.setItem('dicom-viewer-debug-scan-timing', '1');
+            window.__TAURI__.path.appDataDir = async () => '/appdata';
+            window.__TAURI__.fs.readFile = async () => Uint8Array.from(dicomBytes);
+            window.__TAURI__.fs.mkdir = async () => {};
+            window.__TAURI__.fs.writeFile = async () => {
+                throw new Error('disk full');
+            };
+
+            const studies = await window.DicomViewerApp.desktopLibrary.loadStudies('/library');
+            return {
+                studyCount: Object.keys(studies).length
+            };
+        });
+
+        expect(result.studyCount).toBeGreaterThan(0);
+    });
+
+    test('desktop path scan uses native header reads when the header chunk is sufficient', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'image.dcm', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+
+            let headerReads = 0;
+            let fullReads = 0;
+            window.__TAURI__.core = {
+                async invoke(command, args) {
+                    if (command !== 'read_scan_header') {
+                        throw new Error(`Unexpected command: ${command}`);
+                    }
+                    headerReads++;
+                    return dicomBytes;
+                }
+            };
+            window.__TAURI__.fs.readFile = async () => {
+                fullReads++;
+                return Uint8Array.from(dicomBytes);
+            };
+
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            return {
+                studyCount: Object.keys(studies).length,
+                headerReads,
+                fullReads
+            };
+        });
+
+        expect(result.studyCount).toBeGreaterThan(0);
+        expect(result.headerReads).toBe(1);
+        expect(result.fullReads).toBe(0);
+    });
+
+    test('desktop path scan falls back to a full read when the header chunk is insufficient', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'image.dcm', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+            const truncatedHeader = new Uint8Array(256 * 1024);
+            truncatedHeader.set(dicomBytes.slice(0, Math.min(1024, dicomBytes.length)));
+
+            let headerReads = 0;
+            let fullReads = 0;
+            window.__TAURI__.core = {
+                async invoke(command, args) {
+                    if (command !== 'read_scan_header') {
+                        throw new Error(`Unexpected command: ${command}`);
+                    }
+                    headerReads++;
+                    return truncatedHeader;
+                }
+            };
+            window.__TAURI__.fs.readFile = async () => {
+                fullReads++;
+                return Uint8Array.from(dicomBytes);
+            };
+
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            return {
+                studyCount: Object.keys(studies).length,
+                headerReads,
+                fullReads
+            };
+        });
+
+        expect(result.studyCount).toBeGreaterThan(0);
+        expect(result.headerReads).toBe(1);
+        expect(result.fullReads).toBe(1);
+    });
+
+    test('desktop path scan skips a full read for obvious non-DICOM header misses', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'not-dicom.bin', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            let headerReads = 0;
+            let fullReads = 0;
+            window.__TAURI__.core = {
+                async invoke(command, args) {
+                    if (command !== 'read_scan_header') {
+                        throw new Error(`Unexpected command: ${command}`);
+                    }
+                    headerReads++;
+                    return new Uint8Array(256 * 1024);
+                }
+            };
+            window.__TAURI__.fs.readFile = async () => {
+                fullReads++;
+                return new Uint8Array(512 * 1024);
+            };
+
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            return {
+                studyCount: Object.keys(studies).length,
+                headerReads,
+                fullReads
+            };
+        });
+
+        expect(result.studyCount).toBe(0);
+        expect(result.headerReads).toBe(1);
+        expect(result.fullReads).toBe(0);
+    });
+
     test('collectPathSources caps recursion depth and skips symlink paths', async ({ page }) => {
         const dirs = {
             '/root': [

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -1857,6 +1857,8 @@ test.describe('Desktop library scanning', () => {
         });
         expect(result.progress.readDirMs).toBeGreaterThan(0);
         expect(result.progress.readFileMs).toBeGreaterThan(0);
+        expect(result.progress.headerReadMs).toBeGreaterThanOrEqual(0);
+        expect(result.progress.fullReadMs).toBeGreaterThan(0);
         expect(result.progress.parseMs).toBeGreaterThan(0);
         expect(result.progress.finalizeMs).toBeGreaterThanOrEqual(0);
         expect(result.mkdirCalls).toEqual([
@@ -1871,6 +1873,8 @@ test.describe('Desktop library scanning', () => {
             valid: 1,
             readDirMs: Math.round(result.progress.readDirMs),
             readFileMs: Math.round(result.progress.readFileMs),
+            headerReadMs: Math.round(result.progress.headerReadMs || 0),
+            fullReadMs: Math.round(result.progress.fullReadMs || 0),
             parseMs: Math.round(result.progress.parseMs),
             finalizeMs: Math.round(result.progress.finalizeMs)
         });
@@ -1928,6 +1932,8 @@ test.describe('Desktop library scanning', () => {
         });
         expect(result.progress.readDirMs).toBeUndefined();
         expect(result.progress.readFileMs).toBeUndefined();
+        expect(result.progress.headerReadMs).toBeUndefined();
+        expect(result.progress.fullReadMs).toBeUndefined();
         expect(result.progress.parseMs).toBeUndefined();
         expect(result.progress.finalizeMs).toBeUndefined();
         expect(result.writes).toHaveLength(0);


### PR DESCRIPTION
## Summary
- add a native scan-header read command and switch desktop library scanning to header-first metadata reads with selective full-read fallback
- remove hot-loop Tauri path IPC during desktop scans and keep scan timing/report writing behind an explicit debug toggle instead of core app behavior
- add desktop scan diagnostics docs and regression coverage for header hits, fallback reads, and default-off timing reports

## Real-world result
- reran the desktop scan against `/Users/gabriel/Desktop/radiology all discs`
- wall-clock scan time dropped from `192744 ms` to `99361 ms` with the same `53265` valid DICOM images

## Testing
- `cargo test read_scan_header_impl --manifest-path desktop/src-tauri/Cargo.toml`
- `npx playwright test tests/desktop-library.spec.js -g "desktop loadStudies writes a timing report|desktop loadStudies does not write a timing report by default|desktop loadStudies ignores timing report write failures|desktop path scan uses native header reads|desktop path scan falls back to a full read|desktop path scan skips a full read"`