### PR TITLE
Speed up desktop library loading

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -17,7 +17,6 @@
     "fs:allow-remove",
     "fs:allow-write-file",
     "sql:default",
-    "sql:allow-execute",
     {
       "identifier": "fs:scope",
       "allow": [

--- a/desktop/src-tauri/migrations/002_scan_cache.sql
+++ b/desktop/src-tauri/migrations/002_scan_cache.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS desktop_scan_cache (
+    path TEXT PRIMARY KEY,
+    root_path TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    modified_ms INTEGER,
+    scanner_version INTEGER NOT NULL,
+    renderable INTEGER NOT NULL,
+    meta_json TEXT,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_desktop_scan_cache_root_path
+    ON desktop_scan_cache (root_path);

--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -1058,4 +1058,5 @@ mod tests {
 
         let _ = fs::remove_file(&path);
     }
+
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 mod decode;
 mod persistence;
+mod scan;
 
 use tauri::{
     menu::{AboutMetadata, Menu, MenuItemBuilder, SubmenuBuilder},
@@ -78,12 +79,20 @@ fn emit_menu_event<R: Runtime>(app: &AppHandle<R>, event_name: &str) {
 }
 
 fn desktop_db_migrations() -> Vec<Migration> {
-    vec![Migration {
-        version: 1,
-        description: "initial_schema",
-        sql: include_str!("../migrations/001_initial_schema.sql"),
-        kind: MigrationKind::Up,
-    }]
+    vec![
+        Migration {
+            version: 1,
+            description: "initial_schema",
+            sql: include_str!("../migrations/001_initial_schema.sql"),
+            kind: MigrationKind::Up,
+        },
+        Migration {
+            version: 2,
+            description: "scan_cache_compat",
+            sql: include_str!("../migrations/002_scan_cache.sql"),
+            kind: MigrationKind::Up,
+        },
+    ]
 }
 
 fn main() {
@@ -104,8 +113,10 @@ fn main() {
         )
         .invoke_handler(tauri::generate_handler![
             persistence::apply_desktop_migration,
+            persistence::load_legacy_desktop_browser_stores,
             decode::decode_frame,
             decode::read_scan_header,
+            scan::read_scan_manifest,
             decode::take_decoded_frame
         ])
         .on_menu_event(|app, event| match event.id().as_ref() {

--- a/desktop/src-tauri/src/persistence.rs
+++ b/desktop/src-tauri/src/persistence.rs
@@ -1,6 +1,19 @@
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use sqlx::{Connection, Row, SqliteConnection};
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+use tauri::{AppHandle, Manager, State};
 use tauri_plugin_sql::{DbInstances, DbPool};
+
+const CURRENT_STORE_KEY: &str = "dicom-viewer-notes-v3";
+const LIBRARY_CONFIG_KEY: &str = "dicom-viewer-library-config";
+const LEGACY_WEBKIT_PROFILES: &[&str] = &[
+    "health.divergent.dicomviewer",
+    "dicom-viewer-desktop",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -78,6 +91,128 @@ pub struct AppConfigRow {
     pub key: String,
     pub value: String,
     pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyDesktopBrowserStore {
+    pub source_path: String,
+    pub notes_json: Option<String>,
+    pub library_config_json: Option<String>,
+}
+
+fn decode_webkit_localstorage_blob(bytes: &[u8]) -> Option<String> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    if bytes.len() % 2 == 0 {
+        let utf16 = bytes
+            .chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect::<Vec<_>>();
+        let utf16 = match utf16.first() {
+            Some(0xfeff) => &utf16[1..],
+            _ => utf16.as_slice(),
+        };
+        if let Ok(decoded) = String::from_utf16(utf16) {
+            if !decoded.is_empty() {
+                return Some(decoded);
+            }
+        }
+    }
+
+    String::from_utf8(bytes.to_vec())
+        .ok()
+        .filter(|decoded| !decoded.is_empty())
+}
+
+fn collect_localstorage_dbs(root: &Path, found: &mut BTreeSet<PathBuf>) {
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_localstorage_dbs(&path, found);
+            continue;
+        }
+
+        if path.file_name().and_then(|name| name.to_str()) == Some("localstorage.sqlite3") {
+            found.insert(path);
+        }
+    }
+}
+
+fn legacy_webkit_roots(app: &AppHandle) -> Vec<PathBuf> {
+    let home_dir = match app.path().home_dir() {
+        Ok(path) => path,
+        Err(_) => return Vec::new(),
+    };
+
+    let webkit_root = home_dir.join("Library").join("WebKit");
+    LEGACY_WEBKIT_PROFILES
+        .iter()
+        .map(|profile| webkit_root.join(profile))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+async fn read_legacy_browser_store_from_db(path: &Path) -> Option<LegacyDesktopBrowserStore> {
+    let connect_options = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(false)
+        .read_only(true);
+
+    let mut connection = match SqliteConnection::connect_with(&connect_options).await {
+        Ok(connection) => connection,
+        Err(_) => return None,
+    };
+
+    let rows = match sqlx::query("SELECT key, value FROM ItemTable WHERE key IN (?, ?)")
+        .bind(CURRENT_STORE_KEY)
+        .bind(LIBRARY_CONFIG_KEY)
+        .fetch_all(&mut connection)
+        .await
+    {
+        Ok(rows) => rows,
+        Err(_) => return None,
+    };
+
+    let mut notes_json = None;
+    let mut library_config_json = None;
+    for row in rows {
+        let key = match row.try_get::<String, _>("key") {
+            Ok(key) => key,
+            Err(_) => continue,
+        };
+        let value = match row.try_get::<Vec<u8>, _>("value") {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let decoded = match decode_webkit_localstorage_blob(&value) {
+            Some(decoded) => decoded,
+            None => continue,
+        };
+
+        match key.as_str() {
+            CURRENT_STORE_KEY => notes_json = Some(decoded),
+            LIBRARY_CONFIG_KEY => library_config_json = Some(decoded),
+            _ => {}
+        }
+    }
+
+    if notes_json.is_none() && library_config_json.is_none() {
+        return None;
+    }
+
+    Some(LegacyDesktopBrowserStore {
+        source_path: path.to_string_lossy().into_owned(),
+        notes_json,
+        library_config_json,
+    })
 }
 
 #[tauri::command]
@@ -227,4 +362,49 @@ pub async fn apply_desktop_migration(
     })?;
 
     Ok(true)
+}
+
+#[tauri::command]
+pub async fn load_legacy_desktop_browser_stores(
+    app: AppHandle,
+) -> Result<Vec<LegacyDesktopBrowserStore>, PersistenceError> {
+    let mut db_paths = BTreeSet::new();
+    for root in legacy_webkit_roots(&app) {
+        collect_localstorage_dbs(&root, &mut db_paths);
+    }
+
+    let mut stores = Vec::new();
+    for db_path in db_paths {
+        if let Some(store) = read_legacy_browser_store_from_db(&db_path).await {
+            stores.push(store);
+        }
+    }
+
+    Ok(stores)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_webkit_localstorage_blob;
+
+    #[test]
+    fn decodes_utf16le_webkit_localstorage_values() {
+        let bytes = "hello world"
+            .encode_utf16()
+            .flat_map(|unit| unit.to_le_bytes())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            decode_webkit_localstorage_blob(&bytes).as_deref(),
+            Some("hello world")
+        );
+    }
+
+    #[test]
+    fn decodes_utf8_fallback_values() {
+        assert_eq!(
+            decode_webkit_localstorage_blob(br#"{"folder":"/tmp"}"#).as_deref(),
+            Some(r#"{"folder":"/tmp"}"#)
+        );
+    }
 }

--- a/desktop/src-tauri/src/persistence.rs
+++ b/desktop/src-tauri/src/persistence.rs
@@ -4,12 +4,14 @@ use std::{
     collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
+    time::UNIX_EPOCH,
 };
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_sql::{DbInstances, DbPool};
 
 const CURRENT_STORE_KEY: &str = "dicom-viewer-notes-v3";
 const LIBRARY_CONFIG_KEY: &str = "dicom-viewer-library-config";
+const LEGACY_WEBKIT_SCAN_MAX_DEPTH: usize = 12;
 const LEGACY_WEBKIT_PROFILES: &[&str] = &[
     "health.divergent.dicomviewer",
     "dicom-viewer-desktop",
@@ -97,6 +99,7 @@ pub struct AppConfigRow {
 #[serde(rename_all = "camelCase")]
 pub struct LegacyDesktopBrowserStore {
     pub source_path: String,
+    pub modified_ms: Option<i64>,
     pub notes_json: Option<String>,
     pub library_config_json: Option<String>,
 }
@@ -127,7 +130,19 @@ fn decode_webkit_localstorage_blob(bytes: &[u8]) -> Option<String> {
         .filter(|decoded| !decoded.is_empty())
 }
 
-fn collect_localstorage_dbs(root: &Path, found: &mut BTreeSet<PathBuf>) {
+fn modified_ms(path: &Path) -> Option<i64> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+}
+
+fn collect_localstorage_dbs(root: &Path, depth: usize, found: &mut BTreeSet<PathBuf>) {
+    if depth > LEGACY_WEBKIT_SCAN_MAX_DEPTH {
+        return;
+    }
+
     let entries = match fs::read_dir(root) {
         Ok(entries) => entries,
         Err(_) => return,
@@ -135,15 +150,42 @@ fn collect_localstorage_dbs(root: &Path, found: &mut BTreeSet<PathBuf>) {
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_dir() {
-            collect_localstorage_dbs(&path, found);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+        if metadata.file_type().is_symlink() {
             continue;
         }
 
-        if path.file_name().and_then(|name| name.to_str()) == Some("localstorage.sqlite3") {
+        if metadata.is_dir() {
+            if depth < LEGACY_WEBKIT_SCAN_MAX_DEPTH {
+                collect_localstorage_dbs(&path, depth + 1, found);
+            }
+            continue;
+        }
+
+        if metadata.is_file()
+            && path.file_name().and_then(|name| name.to_str()) == Some("localstorage.sqlite3")
+        {
             found.insert(path);
         }
     }
+}
+
+fn sort_localstorage_db_paths(db_paths: BTreeSet<PathBuf>) -> Vec<PathBuf> {
+    let mut ordered = db_paths
+        .into_iter()
+        .map(|path| (modified_ms(&path), path))
+        .collect::<Vec<_>>();
+
+    // Oldest-to-newest preserves deterministic ordering while letting the most
+    // recently written store win when JS upserts later rows over earlier ones.
+    ordered.sort_by(|(modified_a, path_a), (modified_b, path_b)| {
+        modified_a.cmp(modified_b).then_with(|| path_a.cmp(path_b))
+    });
+
+    ordered.into_iter().map(|(_, path)| path).collect()
 }
 
 fn legacy_webkit_roots(app: &AppHandle) -> Vec<PathBuf> {
@@ -210,6 +252,7 @@ async fn read_legacy_browser_store_from_db(path: &Path) -> Option<LegacyDesktopB
 
     Some(LegacyDesktopBrowserStore {
         source_path: path.to_string_lossy().into_owned(),
+        modified_ms: modified_ms(path),
         notes_json,
         library_config_json,
     })
@@ -370,11 +413,18 @@ pub async fn load_legacy_desktop_browser_stores(
 ) -> Result<Vec<LegacyDesktopBrowserStore>, PersistenceError> {
     let mut db_paths = BTreeSet::new();
     for root in legacy_webkit_roots(&app) {
-        collect_localstorage_dbs(&root, &mut db_paths);
+        let metadata = match fs::symlink_metadata(&root) {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            continue;
+        }
+        collect_localstorage_dbs(&root, 0, &mut db_paths);
     }
 
     let mut stores = Vec::new();
-    for db_path in db_paths {
+    for db_path in sort_localstorage_db_paths(db_paths) {
         if let Some(store) = read_legacy_browser_store_from_db(&db_path).await {
             stores.push(store);
         }
@@ -385,7 +435,24 @@ pub async fn load_legacy_desktop_browser_stores(
 
 #[cfg(test)]
 mod tests {
-    use super::decode_webkit_localstorage_blob;
+    use super::{
+        collect_localstorage_dbs, decode_webkit_localstorage_blob, modified_ms,
+        sort_localstorage_db_paths, LEGACY_WEBKIT_SCAN_MAX_DEPTH,
+    };
+    use std::{collections::BTreeSet, fs, path::PathBuf, time::{Duration, SystemTime, UNIX_EPOCH}};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "dicom-viewer-persistence-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be valid")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("temp dir should be creatable");
+        dir
+    }
 
     #[test]
     fn decodes_utf16le_webkit_localstorage_values() {
@@ -406,5 +473,61 @@ mod tests {
             decode_webkit_localstorage_blob(br#"{"folder":"/tmp"}"#).as_deref(),
             Some(r#"{"folder":"/tmp"}"#)
         );
+    }
+
+    #[test]
+    fn collect_localstorage_dbs_respects_depth_cap() {
+        let root = temp_dir("depth-cap");
+        let mut current = root.clone();
+        for index in 0..=LEGACY_WEBKIT_SCAN_MAX_DEPTH {
+            current = current.join(format!("level-{index}"));
+            fs::create_dir_all(&current).expect("nested dirs should be creatable");
+        }
+        let too_deep = current.join("localstorage.sqlite3");
+        fs::write(&too_deep, b"noop").expect("sqlite file should be writable");
+
+        let mut found = BTreeSet::new();
+        collect_localstorage_dbs(&root, 0, &mut found);
+
+        assert!(found.is_empty());
+
+        fs::remove_dir_all(root).expect("temp dir should be removable");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_localstorage_dbs_skips_symlink_loops() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("symlink-loop");
+        let nested = root.join("nested");
+        fs::create_dir_all(&nested).expect("nested dir should be creatable");
+        let sqlite = nested.join("localstorage.sqlite3");
+        fs::write(&sqlite, b"noop").expect("sqlite file should be writable");
+        symlink(&root, nested.join("loop")).expect("symlink should be creatable");
+
+        let mut found = BTreeSet::new();
+        collect_localstorage_dbs(&root, 0, &mut found);
+
+        assert_eq!(found.into_iter().collect::<Vec<_>>(), vec![sqlite]);
+
+        fs::remove_dir_all(root).expect("temp dir should be removable");
+    }
+
+    #[test]
+    fn sort_localstorage_db_paths_prefers_newer_entries_last() {
+        let root = temp_dir("sort");
+        let older = root.join("a.sqlite3");
+        let newer = root.join("b.sqlite3");
+        fs::write(&older, b"older").expect("older file should be writable");
+        std::thread::sleep(Duration::from_millis(5));
+        fs::write(&newer, b"newer").expect("newer file should be writable");
+
+        let ordered = sort_localstorage_db_paths(BTreeSet::from([newer.clone(), older.clone()]));
+
+        assert_eq!(ordered, vec![older.clone(), newer.clone()]);
+        assert!(modified_ms(&newer).unwrap_or_default() >= modified_ms(&older).unwrap_or_default());
+
+        fs::remove_dir_all(root).expect("temp dir should be removable");
     }
 }

--- a/desktop/src-tauri/src/scan.rs
+++ b/desktop/src-tauri/src/scan.rs
@@ -1,0 +1,214 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
+use serde::Serialize;
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_fs::FsExt;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanManifestEntry {
+    pub path: String,
+    pub name: String,
+    pub root_path: String,
+    pub size: u64,
+    pub modified_ms: Option<i64>,
+}
+
+#[tauri::command]
+pub async fn read_scan_manifest<R: Runtime>(
+    app: AppHandle<R>,
+    roots: Vec<String>,
+    max_depth: usize,
+) -> Result<Vec<ScanManifestEntry>, String> {
+    let scoped_roots = roots
+        .iter()
+        .map(|root| validate_scoped_path(&app, root, "scan-manifest"))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    tokio::task::spawn_blocking(move || read_scan_manifest_impl(&scoped_roots, max_depth))
+        .await
+        .map_err(|error| format!("Native scan manifest worker failed to join: {error}"))?
+}
+
+fn validate_scoped_path<R: Runtime>(
+    app: &AppHandle<R>,
+    path: &str,
+    stage: &str,
+) -> Result<PathBuf, String> {
+    let requested_path = PathBuf::from(path);
+    if requested_path.as_os_str().is_empty() {
+        return Err(format!("{stage}: path is empty"));
+    }
+    if !requested_path.is_absolute() {
+        return Err(format!("{stage}: path must be absolute: {path}"));
+    }
+
+    let canonical_path = requested_path
+        .canonicalize()
+        .map_err(|error| format!("{stage}: failed to access {path}: {error}"))?;
+
+    if !app.fs_scope().is_allowed(&canonical_path) {
+        return Err(format!(
+            "{stage}: path is outside the allowed desktop file scope: {}",
+            canonical_path.display()
+        ));
+    }
+
+    Ok(canonical_path)
+}
+
+fn read_scan_manifest_impl(
+    roots: &[PathBuf],
+    max_depth: usize,
+) -> Result<Vec<ScanManifestEntry>, String> {
+    let mut entries = Vec::new();
+    for root_path in roots {
+        let metadata = fs::symlink_metadata(root_path)
+            .map_err(|error| format!("scan-manifest: failed to stat {}: {error}", root_path.display()))?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_file() {
+            entries.push(build_manifest_entry(root_path, root_path, &metadata));
+            continue;
+        }
+        if metadata.is_dir() {
+            collect_directory_entries(root_path, root_path, 0, max_depth, &mut entries)?;
+        }
+    }
+
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(entries)
+}
+
+fn collect_directory_entries(
+    root_path: &Path,
+    current_path: &Path,
+    depth: usize,
+    max_depth: usize,
+    entries: &mut Vec<ScanManifestEntry>,
+) -> Result<(), String> {
+    let dir = fs::read_dir(current_path).map_err(|error| {
+        format!(
+            "scan-manifest: failed to read directory {}: {error}",
+            current_path.display()
+        )
+    })?;
+
+    for dir_entry in dir {
+        let dir_entry = dir_entry.map_err(|error| {
+            format!(
+                "scan-manifest: failed to read directory entry under {}: {error}",
+                current_path.display()
+            )
+        })?;
+        let file_type = dir_entry.file_type().map_err(|error| {
+            format!(
+                "scan-manifest: failed to read entry type under {}: {error}",
+                current_path.display()
+            )
+        })?;
+        if file_type.is_symlink() {
+            continue;
+        }
+
+        let entry_path = dir_entry.path();
+        if file_type.is_dir() {
+            if depth >= max_depth {
+                continue;
+            }
+            collect_directory_entries(root_path, &entry_path, depth + 1, max_depth, entries)?;
+            continue;
+        }
+
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let metadata = dir_entry.metadata().map_err(|error| {
+            format!(
+                "scan-manifest: failed to stat {}: {error}",
+                entry_path.display()
+            )
+        })?;
+        entries.push(build_manifest_entry(root_path, &entry_path, &metadata));
+    }
+
+    Ok(())
+}
+
+fn build_manifest_entry(root_path: &Path, path: &Path, metadata: &fs::Metadata) -> ScanManifestEntry {
+    let modified_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64);
+
+    ScanManifestEntry {
+        path: path.to_string_lossy().to_string(),
+        name: path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| path.display().to_string()),
+        root_path: root_path.to_string_lossy().to_string(),
+        size: metadata.len(),
+        modified_ms,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "dicom-viewer-scan-manifest-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be valid")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("temp dir should be creatable");
+        dir
+    }
+
+    #[test]
+    fn read_scan_manifest_respects_directory_depth() {
+        let root = temp_dir("depth");
+        let nested = root.join("nested");
+        let deep = nested.join("deep");
+        fs::create_dir_all(&deep).expect("nested dirs should be creatable");
+        fs::write(root.join("root.dcm"), [1_u8, 2, 3]).expect("root file should be writable");
+        fs::write(nested.join("nested.dcm"), [4_u8, 5, 6]).expect("nested file should be writable");
+        fs::write(deep.join("deep.dcm"), [7_u8, 8, 9]).expect("deep file should be writable");
+
+        let shallow = read_scan_manifest_impl(std::slice::from_ref(&root), 0)
+            .expect("scan manifest should succeed");
+        let deep_entries = read_scan_manifest_impl(std::slice::from_ref(&root), 2)
+            .expect("scan manifest should succeed");
+
+        let shallow_paths = shallow.iter().map(|entry| entry.path.clone()).collect::<Vec<_>>();
+        let deep_paths = deep_entries
+            .iter()
+            .map(|entry| entry.path.clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(shallow_paths, vec![root.join("root.dcm").to_string_lossy().to_string()]);
+        assert_eq!(
+            deep_paths,
+            vec![
+                root.join("nested").join("deep").join("deep.dcm").to_string_lossy().to_string(),
+                root.join("nested").join("nested.dcm").to_string_lossy().to_string(),
+                root.join("root.dcm").to_string_lossy().to_string(),
+            ]
+        );
+
+        fs::remove_dir_all(&root).expect("temp dir should be removable");
+    }
+}

--- a/docs/js/api.js
+++ b/docs/js/api.js
@@ -227,7 +227,7 @@ const NotesAPI = (() => {
     }
 
     async function waitForDesktopRuntime() {
-        const ready = window.__DICOM_VIEWER_TAURI_READY__;
+        const ready = window.__DICOM_VIEWER_TAURI_STORAGE_READY__ || window.__DICOM_VIEWER_TAURI_READY__;
         if (ready && typeof ready.then === 'function') {
             await ready;
         }

--- a/docs/js/api.js
+++ b/docs/js/api.js
@@ -14,7 +14,10 @@ const NotesAPI = (() => {
     const DESKTOP_DB_URL = 'sqlite:viewer.db';
     const DESKTOP_LIBRARY_CONFIG_KEY = 'desktop_library_config';
     const DESKTOP_LOCALSTORAGE_MIGRATION_KEY = 'localstorage_migrated';
+    const DESKTOP_LEGACY_BROWSER_STORE_MIGRATION_KEY = 'legacy_desktop_browser_store_migrated';
     const DESKTOP_LIBRARY_CONFIG_STORAGE_KEY = 'dicom-viewer-library-config';
+    const DESKTOP_SCAN_CACHE_VERSION = 1;
+    const DESKTOP_SCAN_CACHE_CHUNK_SIZE = 256;
     const LEGACY_STORAGE_KEY = 'dicom-viewer-comments';
     const LEGACY_REPORTS_DB = 'dicom-viewer-reports';
     const LEGACY_REPORTS_STORE = 'reports';
@@ -284,6 +287,86 @@ const NotesAPI = (() => {
         return normalized;
     }
 
+    async function loadDesktopScanCache(rootPaths, scannerVersion = DESKTOP_SCAN_CACHE_VERSION) {
+        const roots = Array.from(new Set(
+            (Array.isArray(rootPaths) ? rootPaths : [rootPaths]).filter(
+                (rootPath) => typeof rootPath === 'string' && rootPath
+            )
+        ));
+        if (!roots.length) return [];
+
+        await initializeDesktopPersistence();
+        const db = await getDesktopDb();
+        const placeholders = roots.map(() => '?').join(', ');
+        return await db.select(
+            `SELECT path, size, modified_ms, renderable, meta_json
+             FROM desktop_scan_cache
+             WHERE root_path IN (${placeholders}) AND scanner_version = ?`,
+            [...roots, scannerVersion]
+        );
+    }
+
+    async function saveDesktopScanCacheEntries(entries, scannerVersion = DESKTOP_SCAN_CACHE_VERSION) {
+        const rows = (Array.isArray(entries) ? entries : []).filter((entry) => {
+            return !!(
+                entry
+                && typeof entry.path === 'string'
+                && entry.path
+                && typeof entry.rootPath === 'string'
+                && entry.rootPath
+            );
+        });
+        if (!rows.length) return 0;
+
+        await initializeDesktopPersistence();
+        const db = await getDesktopDb();
+        let totalRowsAffected = 0;
+
+        for (let index = 0; index < rows.length; index += DESKTOP_SCAN_CACHE_CHUNK_SIZE) {
+            const chunk = rows.slice(index, index + DESKTOP_SCAN_CACHE_CHUNK_SIZE);
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?)').join(', ');
+            const values = [];
+
+            for (const row of chunk) {
+                values.push(
+                    row.path,
+                    row.rootPath,
+                    parseInteger(row.size, 0),
+                    row.modifiedMs ?? null,
+                    scannerVersion,
+                    row.renderable ? 1 : 0,
+                    typeof row.metaJson === 'string' ? row.metaJson : null,
+                    Date.now()
+                );
+            }
+
+            const result = await db.execute(
+                `INSERT INTO desktop_scan_cache (
+                    path,
+                    root_path,
+                    size,
+                    modified_ms,
+                    scanner_version,
+                    renderable,
+                    meta_json,
+                    updated_at
+                ) VALUES ${placeholders}
+                 ON CONFLICT(path) DO UPDATE SET
+                    root_path = excluded.root_path,
+                    size = excluded.size,
+                    modified_ms = excluded.modified_ms,
+                    scanner_version = excluded.scanner_version,
+                    renderable = excluded.renderable,
+                    meta_json = excluded.meta_json,
+                    updated_at = excluded.updated_at`,
+                values
+            );
+            totalRowsAffected += Number(result?.rowsAffected) || chunk.length;
+        }
+
+        return totalRowsAffected;
+    }
+
     function getReportExtension(reportType, file) {
         const explicitType = typeof reportType === 'string' ? reportType.trim().toLowerCase() : '';
         if (REPORT_FILE_EXTENSIONS[explicitType]) {
@@ -520,6 +603,17 @@ const NotesAPI = (() => {
         });
     }
 
+    async function loadLegacyDesktopBrowserStores() {
+        const runtime = await waitForDesktopRuntime();
+        const invoke = runtime?.core?.invoke;
+        if (typeof invoke !== 'function') {
+            throw new Error('Desktop migration runtime is not ready. Quit and reopen the app if this persists.');
+        }
+
+        const stores = await invoke('load_legacy_desktop_browser_stores');
+        return Array.isArray(stores) ? stores : [];
+    }
+
     async function migrateDesktopLocalStorage() {
         const migrated = await getDesktopAppConfigValue(DESKTOP_LOCALSTORAGE_MIGRATION_KEY);
         if (migrated === '1') return false;
@@ -557,12 +651,45 @@ const NotesAPI = (() => {
         return true;
     }
 
+    async function migrateLegacyDesktopBrowserStores() {
+        const migrated = await getDesktopAppConfigValue(DESKTOP_LEGACY_BROWSER_STORE_MIGRATION_KEY);
+        if (migrated === '1') return false;
+
+        const stores = await loadLegacyDesktopBrowserStores();
+        if (!stores.length) {
+            await setDesktopAppConfigValue(DESKTOP_LEGACY_BROWSER_STORE_MIGRATION_KEY, '1');
+            return false;
+        }
+
+        const { fs } = getDesktopTauriApis();
+        const batch = createEmptyDesktopMigrationBatch();
+        for (const store of stores) {
+            const notesStore = safeJsonParse(store?.notesJson, createEmptyStore());
+            const libraryConfig = normalizeDesktopLibraryConfig(
+                safeJsonParse(store?.libraryConfigJson, {})
+            );
+
+            await appendCurrentStoreToDesktopMigration(batch, notesStore, fs);
+            if (libraryConfig.folder || libraryConfig.lastScan) {
+                appendDesktopLibraryConfigToMigration(batch, libraryConfig);
+            }
+        }
+
+        if (hasDesktopMigrationRows(batch)) {
+            await applyDesktopMigrationBatch(batch);
+        }
+
+        await setDesktopAppConfigValue(DESKTOP_LEGACY_BROWSER_STORE_MIGRATION_KEY, '1');
+        return hasDesktopMigrationRows(batch);
+    }
+
     async function initializeDesktopPersistence() {
         if (getBackend() !== 'desktop') return false;
         if (!desktopMigrationPromise) {
             desktopMigrationPromise = (async () => {
                 await getDesktopDb();
                 await migrateDesktopLocalStorage();
+                await migrateLegacyDesktopBrowserStores();
                 return true;
             })().catch((error) => {
                 desktopMigrationPromise = null;
@@ -1354,7 +1481,9 @@ const NotesAPI = (() => {
         getReportFileUrl,
         initializeDesktopStorage,
         loadDesktopLibraryConfig,
-        saveDesktopLibraryConfig
+        saveDesktopLibraryConfig,
+        loadDesktopScanCache,
+        saveDesktopScanCacheEntries
     };
 })();
 

--- a/docs/js/api.js
+++ b/docs/js/api.js
@@ -18,6 +18,7 @@ const NotesAPI = (() => {
     const DESKTOP_LIBRARY_CONFIG_STORAGE_KEY = 'dicom-viewer-library-config';
     const DESKTOP_SCAN_CACHE_VERSION = 1;
     const DESKTOP_SCAN_CACHE_CHUNK_SIZE = 256;
+    const DESKTOP_INIT_RETRY_MS = 5000;
     const LEGACY_STORAGE_KEY = 'dicom-viewer-comments';
     const LEGACY_REPORTS_DB = 'dicom-viewer-reports';
     const LEGACY_REPORTS_STORE = 'reports';
@@ -32,7 +33,11 @@ const NotesAPI = (() => {
     let lastCommentTimestamp = 0;
     let commentCounter = 0;
     let desktopDbPromise = null;
+    let desktopDbFailure = null;
+    let desktopDbRetryAt = 0;
     let desktopMigrationPromise = null;
+    let desktopMigrationFailure = null;
+    let desktopMigrationRetryAt = 0;
     const desktopReportPathCache = new Map();
 
     function createEmptyStore() {
@@ -191,6 +196,19 @@ const NotesAPI = (() => {
         }
     }
 
+    function sortLegacyDesktopStores(stores) {
+        return (Array.isArray(stores) ? stores.slice() : []).sort((left, right) => {
+            const leftModified = Number.isFinite(Number(left?.modifiedMs))
+                ? Number(left.modifiedMs)
+                : (Number.isFinite(Number(left?.modified_ms)) ? Number(left.modified_ms) : -1);
+            const rightModified = Number.isFinite(Number(right?.modifiedMs))
+                ? Number(right.modifiedMs)
+                : (Number.isFinite(Number(right?.modified_ms)) ? Number(right.modified_ms) : -1);
+            return leftModified - rightModified
+                || String(left?.sourcePath || '').localeCompare(String(right?.sourcePath || ''));
+        });
+    }
+
     function hasStudyNotes(entry) {
         if (!entry || typeof entry !== 'object') return false;
         if ((entry.description || '').trim()) return true;
@@ -240,13 +258,25 @@ const NotesAPI = (() => {
         if (!sql?.load) {
             throw new Error('Desktop SQL runtime is not ready. Quit and reopen the app if this persists.');
         }
+        if (desktopDbFailure && Date.now() < desktopDbRetryAt) {
+            throw desktopDbFailure;
+        }
         if (!desktopDbPromise) {
             desktopDbPromise = sql.load(DESKTOP_DB_URL).catch((error) => {
                 desktopDbPromise = null;
+                desktopDbFailure = error;
+                desktopDbRetryAt = Date.now() + DESKTOP_INIT_RETRY_MS;
                 throw error;
             });
         }
-        return desktopDbPromise;
+        try {
+            const db = await desktopDbPromise;
+            desktopDbFailure = null;
+            desktopDbRetryAt = 0;
+            return db;
+        } catch (error) {
+            throw error;
+        }
     }
 
     async function getDesktopAppConfigValue(key) {
@@ -564,11 +594,12 @@ const NotesAPI = (() => {
         });
     }
 
-    async function migrateLegacyReportBlobs(payload) {
+    async function migrateLegacyReportBlobs(payload, db) {
         const commentsBlob = payload?.comments;
-        if (!commentsBlob || typeof commentsBlob !== 'object') return;
+        if (!commentsBlob || typeof commentsBlob !== 'object') return 0;
 
         const legacyDb = await openLegacyReportsDb();
+        let failures = 0;
         try {
             for (const [studyUid, stored] of Object.entries(commentsBlob)) {
                 const reports = stored?.reports || [];
@@ -576,14 +607,23 @@ const NotesAPI = (() => {
                     if (!report?.id) continue;
                     const blob = await getLegacyReportBlob(legacyDb, report.id);
                     if (!blob) continue;
-                    const filename = report.name || 'report';
-                    const file = new File([blob], filename, { type: blob.type || '' });
-                    await storeDesktopReport(studyUid, file, report, { skipInit: true });
+                    try {
+                        const filename = report.name || 'report';
+                        const file = new File([blob], filename, { type: blob.type || '' });
+                        await storeDesktopReportWithDb(db, studyUid, file, report);
+                    } catch (error) {
+                        failures += 1;
+                        console.warn(
+                            `DesktopSqliteBackend: failed to migrate legacy report blob ${report.id} for ${studyUid}:`,
+                            error
+                        );
+                    }
                 }
             }
         } finally {
             if (legacyDb) legacyDb.close();
         }
+        return failures;
     }
 
     async function applyDesktopMigrationBatch(batch) {
@@ -611,7 +651,7 @@ const NotesAPI = (() => {
         }
 
         const stores = await invoke('load_legacy_desktop_browser_stores');
-        return Array.isArray(stores) ? stores : [];
+        return sortLegacyDesktopStores(stores);
     }
 
     async function migrateDesktopLocalStorage() {
@@ -644,7 +684,14 @@ const NotesAPI = (() => {
         await applyDesktopMigrationBatch(batch);
 
         if (hasLegacyStore) {
-            await migrateLegacyReportBlobs(legacyPayload);
+            const db = await getDesktopDb();
+            const blobFailures = await migrateLegacyReportBlobs(legacyPayload, db);
+            if (blobFailures > 0) {
+                console.warn(
+                    `DesktopSqliteBackend: deferred completion of legacy localStorage migration after ${blobFailures} legacy report blob failure(s).`
+                );
+                return true;
+            }
         }
 
         await setDesktopAppConfigValue(DESKTOP_LOCALSTORAGE_MIGRATION_KEY, '1');
@@ -685,27 +732,29 @@ const NotesAPI = (() => {
 
     async function initializeDesktopPersistence() {
         if (getBackend() !== 'desktop') return false;
+        if (desktopMigrationFailure && Date.now() < desktopMigrationRetryAt) {
+            throw desktopMigrationFailure;
+        }
         if (!desktopMigrationPromise) {
             desktopMigrationPromise = (async () => {
                 await getDesktopDb();
                 await migrateDesktopLocalStorage();
                 await migrateLegacyDesktopBrowserStores();
+                desktopMigrationFailure = null;
+                desktopMigrationRetryAt = 0;
                 return true;
             })().catch((error) => {
                 desktopMigrationPromise = null;
+                desktopMigrationFailure = error;
+                desktopMigrationRetryAt = Date.now() + DESKTOP_INIT_RETRY_MS;
                 throw error;
             });
         }
         return desktopMigrationPromise;
     }
 
-    async function storeDesktopReport(studyUid, file, report = {}, options = {}) {
+    async function storeDesktopReportWithDb(db, studyUid, file, report = {}) {
         if (!studyUid || !file || !report?.id) return null;
-
-        if (!options.skipInit) {
-            await initializeDesktopPersistence();
-        }
-        const db = await getDesktopDb();
         const { fs, path } = getDesktopTauriApis();
         if (!fs || !path || typeof fs.writeFile !== 'function' || typeof fs.rename !== 'function') {
             throw new Error('Desktop filesystem runtime is not ready.');
@@ -822,6 +871,13 @@ const NotesAPI = (() => {
             addedAt,
             updatedAt
         };
+    }
+
+    async function storeDesktopReport(studyUid, file, report = {}) {
+        if (!studyUid || !file || !report?.id) return null;
+        await initializeDesktopPersistence();
+        const db = await getDesktopDb();
+        return await storeDesktopReportWithDb(db, studyUid, file, report);
     }
 
     // ---- LocalBackend ----

--- a/docs/js/app/desktop-library.js
+++ b/docs/js/app/desktop-library.js
@@ -4,6 +4,8 @@
 
     const DesktopLibrary = {
         SCAN_TIMING_KEY: 'dicom-viewer-debug-scan-timing',
+        SNAPSHOT_VERSION: 1,
+        SNAPSHOT_FILENAME: 'desktop-library-cache.json',
 
         getRuntime() {
             const tauri = window.__TAURI__;
@@ -60,6 +62,62 @@
             return app.sources.collectPathSources(folderPath);
         },
 
+        async getSnapshotPath() {
+            const tauri = this.getRuntime();
+            const appDataPath = await tauri.path.appDataDir();
+            return await tauri.path.join(appDataPath, this.SNAPSHOT_FILENAME);
+        },
+
+        async loadCachedStudies(folderPath) {
+            if (!folderPath) {
+                return null;
+            }
+
+            const tauri = this.getRuntime();
+            const snapshotPath = await this.getSnapshotPath();
+            let bytes;
+            try {
+                bytes = await tauri.fs.readFile(snapshotPath);
+            } catch {
+                return null;
+            }
+
+            try {
+                const text = new TextDecoder().decode(bytes);
+                const payload = JSON.parse(text);
+                if (payload?.version !== this.SNAPSHOT_VERSION) {
+                    return null;
+                }
+                if (payload?.folder !== folderPath) {
+                    return null;
+                }
+                if (!payload?.studies || typeof payload.studies !== 'object') {
+                    return null;
+                }
+                return payload.studies;
+            } catch (error) {
+                console.warn('DesktopLibrary: failed to read cached library snapshot:', error);
+                return null;
+            }
+        },
+
+        async saveCachedStudies(folderPath, studies) {
+            if (!folderPath) {
+                return;
+            }
+
+            const tauri = this.getRuntime();
+            const snapshotPath = await this.getSnapshotPath();
+            const payload = {
+                version: this.SNAPSHOT_VERSION,
+                folder: folderPath,
+                savedAt: new Date().toISOString(),
+                studies: studies || {}
+            };
+            const bytes = new TextEncoder().encode(`${JSON.stringify(payload)}\n`);
+            await tauri.fs.writeFile(snapshotPath, bytes);
+        },
+
         async writeScanTimingReport(report) {
             const tauri = this.getRuntime();
             const appDataPath = await tauri.path.appDataDir();
@@ -114,6 +172,12 @@
                 } catch (error) {
                     console.warn('DesktopLibrary: failed to write scan timing report:', error);
                 }
+            }
+
+            try {
+                await this.saveCachedStudies(folderPath, studies);
+            } catch (error) {
+                console.warn('DesktopLibrary: failed to save cached library snapshot:', error);
             }
 
             return studies;

--- a/docs/js/app/desktop-library.js
+++ b/docs/js/app/desktop-library.js
@@ -1,6 +1,29 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const notesApi = window.NotesAPI;
+    const LEGACY_LIBRARY_CONFIG_KEY = 'dicom-viewer-library-config';
+
+    function normalizeDesktopConfig(config) {
+        return {
+            folder: typeof config?.folder === 'string' && config.folder ? config.folder : null,
+            lastScan: typeof config?.lastScan === 'string' && config.lastScan ? config.lastScan : null
+        };
+    }
+
+    function loadLegacyDesktopConfig() {
+        try {
+            const raw = localStorage.getItem(LEGACY_LIBRARY_CONFIG_KEY);
+            return normalizeDesktopConfig(raw ? JSON.parse(raw) : null);
+        } catch {
+            return normalizeDesktopConfig(null);
+        }
+    }
+
+    function saveLegacyDesktopConfig(config) {
+        try {
+            localStorage.setItem(LEGACY_LIBRARY_CONFIG_KEY, JSON.stringify(normalizeDesktopConfig(config)));
+        } catch {}
+    }
 
     const DesktopLibrary = {
         SCAN_TIMING_KEY: 'dicom-viewer-debug-scan-timing',
@@ -16,12 +39,28 @@
         },
 
         async getConfig() {
+            let nativeConfig = null;
             try {
-                return await notesApi.loadDesktopLibraryConfig();
+                nativeConfig = normalizeDesktopConfig(await notesApi.loadDesktopLibraryConfig());
+                if (nativeConfig.folder || nativeConfig.lastScan) {
+                    saveLegacyDesktopConfig(nativeConfig);
+                    return nativeConfig;
+                }
             } catch (e) {
                 console.warn('DesktopLibrary: failed to load config:', e);
-                return { folder: null, lastScan: null };
             }
+
+            const legacyConfig = loadLegacyDesktopConfig();
+            if (legacyConfig.folder || legacyConfig.lastScan) {
+                try {
+                    await notesApi.saveDesktopLibraryConfig(legacyConfig);
+                } catch (error) {
+                    console.warn('DesktopLibrary: failed to repair native config from local fallback:', error);
+                }
+                return legacyConfig;
+            }
+
+            return nativeConfig || { folder: null, lastScan: null };
         },
 
         isScanTimingEnabled() {
@@ -41,7 +80,14 @@
         },
 
         async saveConfig(config) {
-            return await notesApi.saveDesktopLibraryConfig(config);
+            const normalized = normalizeDesktopConfig(config);
+            saveLegacyDesktopConfig(normalized);
+            try {
+                return normalizeDesktopConfig(await notesApi.saveDesktopLibraryConfig(normalized));
+            } catch (error) {
+                console.warn('DesktopLibrary: failed to save native config, keeping local fallback:', error);
+                return normalized;
+            }
         },
 
         async setFolder(path) {

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -136,6 +136,146 @@
         return meta;
     }
 
+    function getPathDirectory(path) {
+        const normalized = String(path || '').replace(/\\/g, '/');
+        const lastSeparatorIndex = normalized.lastIndexOf('/');
+        return lastSeparatorIndex > 0 ? normalized.slice(0, lastSeparatorIndex) : '';
+    }
+
+    function resolveDicomDirReferencedPath(dicomDirPath, referencedFileId) {
+        const basePath = getPathDirectory(dicomDirPath);
+        const segments = String(referencedFileId || '')
+            .split(/[\\/]+/)
+            .map((segment) => segment.trim())
+            .filter(Boolean);
+
+        if (!basePath || !segments.length) {
+            return '';
+        }
+
+        return segments.reduce((path, segment) => {
+            return path ? `${path}/${segment}` : segment;
+        }, basePath);
+    }
+
+    async function parseDicomDirectoryDetailed(input, dicomDirPath = '') {
+        try {
+            const byteArray = await toDicomByteArray(input);
+            const dataSet = dicomParser.parseDicom(byteArray);
+            const directoryRecordSequence = dataSet.elements?.x00041220;
+            const recordItems = Array.isArray(directoryRecordSequence?.items)
+                ? directoryRecordSequence.items
+                : [];
+
+            if (!recordItems.length) {
+                return {
+                    entries: [],
+                    indexedPaths: [],
+                    error: new Error('DICOMDIR did not contain a directory record sequence.')
+                };
+            }
+
+            const entries = [];
+            const indexedPaths = [];
+            let currentPatient = null;
+            let currentStudy = null;
+            let currentSeries = null;
+
+            for (const item of recordItems) {
+                const itemDataSet = item?.dataSet;
+                if (!itemDataSet) {
+                    continue;
+                }
+
+                const recordType = getString(itemDataSet, 'x00041430').trim().toUpperCase();
+                switch (recordType) {
+                    case 'PATIENT':
+                        currentPatient = {
+                            patientName: getString(itemDataSet, 'x00100010')
+                        };
+                        currentStudy = null;
+                        currentSeries = null;
+                        break;
+                    case 'STUDY':
+                        currentStudy = {
+                            patientName: currentPatient?.patientName || getString(itemDataSet, 'x00100010'),
+                            studyDate: getString(itemDataSet, 'x00080020'),
+                            studyDescription: getString(itemDataSet, 'x00081030'),
+                            studyInstanceUid: getString(itemDataSet, 'x0020000d'),
+                            modality: ''
+                        };
+                        currentSeries = null;
+                        break;
+                    case 'SERIES':
+                        currentSeries = {
+                            seriesDescription: getString(itemDataSet, 'x0008103e'),
+                            seriesInstanceUid: getString(itemDataSet, 'x0020000e'),
+                            seriesNumber: getString(itemDataSet, 'x00200011'),
+                            modality: getString(itemDataSet, 'x00080060')
+                        };
+                        if (currentStudy && !currentStudy.modality && currentSeries.modality) {
+                            currentStudy.modality = currentSeries.modality;
+                        }
+                        break;
+                    case 'IMAGE': {
+                        const referencedPath = resolveDicomDirReferencedPath(
+                            dicomDirPath,
+                            getString(itemDataSet, 'x00041500')
+                        );
+                        if (
+                            !currentStudy?.studyInstanceUid
+                            || !currentSeries?.seriesInstanceUid
+                            || !referencedPath
+                        ) {
+                            break;
+                        }
+
+                        indexedPaths.push(referencedPath);
+                        entries.push({
+                            source: {
+                                kind: 'path',
+                                path: referencedPath
+                            },
+                            meta: {
+                                patientName: currentStudy.patientName,
+                                studyDate: currentStudy.studyDate,
+                                studyDescription: currentStudy.studyDescription,
+                                studyInstanceUid: currentStudy.studyInstanceUid,
+                                seriesDescription: currentSeries.seriesDescription,
+                                seriesInstanceUid: currentSeries.seriesInstanceUid,
+                                seriesNumber: currentSeries.seriesNumber,
+                                modality: currentSeries.modality || currentStudy.modality,
+                                sopInstanceUid: getString(itemDataSet, 'x00041511') || getString(itemDataSet, 'x00080018'),
+                                instanceNumber: getMetadataNumber(itemDataSet, 'x00200013', 0),
+                                sliceLocation: getMetadataNumber(itemDataSet, 'x00201041', 0)
+                            }
+                        });
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+
+            return {
+                entries,
+                indexedPaths,
+                error: null
+            };
+        } catch (error) {
+            return {
+                entries: [],
+                indexedPaths: [],
+                error
+            };
+        }
+    }
+
+    async function parseDicomDirectory(input, dicomDirPath = '') {
+        const { entries, indexedPaths } = await parseDicomDirectoryDetailed(input, dicomDirPath);
+        return { entries, indexedPaths };
+    }
+
     function isRenderableImageMetadata(meta) {
         return !!(
             meta?.studyInstanceUid &&
@@ -758,6 +898,8 @@
     app.dicom = {
         parseDicomMetadata,
         parseDicomMetadataDetailed,
+        parseDicomDirectory,
+        parseDicomDirectoryDetailed,
         toDicomByteArray,
         getMetadataNumber,
         getNumberOfFrames,

--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -82,7 +82,7 @@
         libraryFolderMessage.style.display = 'block';
     }
 
-    async function applyDesktopLibraryScan(folder, studies) {
+    function applyDesktopLibraryStudies(folder, studies) {
         state.libraryFolder = folder;
         state.libraryFolderResolved = folder;
         state.libraryFolderSource = 'local';
@@ -93,7 +93,10 @@
             folderResolved: folder,
             source: 'local'
         });
+    }
 
+    async function applyDesktopLibraryScan(folder, studies) {
+        applyDesktopLibraryStudies(folder, studies);
         if (Object.keys(studies).length > 0) {
             await app.desktopLibrary.markScanComplete(folder);
             setLibraryFolderMessage('');
@@ -103,6 +106,11 @@
         await app.desktopLibrary.markScanFailed(folder);
         setLibraryFolderMessage(`No DICOM files found in ${folder}.`, 'warning');
         return false;
+    }
+
+    async function applyDesktopLibrarySnapshot(folder, studies) {
+        applyDesktopLibraryStudies(folder, studies);
+        return Object.keys(studies).length > 0;
     }
 
     function applyLibraryConfigPayload(payload, options = {}) {
@@ -670,6 +678,7 @@
 
     app.library = {
         applyDesktopLibraryScan,
+        applyDesktopLibrarySnapshot,
         applyLibraryConfigPayload,
         displayStudies,
         handleSortClick,

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -23,6 +23,7 @@
     const { openHelpViewer, closeHelpViewer } = app.helpViewer;
     const {
         applyDesktopLibraryScan,
+        applyDesktopLibrarySnapshot,
         displayStudies,
         handleSortClick,
         loadLibraryConfig,
@@ -218,6 +219,14 @@
             return await ready;
         }
 
+        const deadline = performance.now() + 5000;
+        while (performance.now() < deadline) {
+            if (window.__TAURI__) {
+                return window.__TAURI__;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
         return window.__TAURI__ || null;
     }
 
@@ -229,16 +238,25 @@
                 return;
             }
 
-            setLibraryFolderMessage('Loading saved library folder...', 'info');
-            await displayStudies();
-
             const runtime = await waitForDesktopRuntime();
             if (!runtime?.fs || !runtime?.path) {
                 throw new Error('Desktop runtime is not ready yet.');
             }
 
+            const cachedStudies = await app.desktopLibrary.loadCachedStudies(state.libraryFolder);
+            if (cachedStudies && Object.keys(cachedStudies).length > 0) {
+                await applyDesktopLibrarySnapshot(state.libraryFolder, cachedStudies);
+                setLibraryFolderMessage('Showing cached library while refreshing...', 'info');
+            } else {
+                setLibraryFolderMessage('Loading saved library folder...', 'info');
+            }
+            await displayStudies();
+
+            const loadLabel = cachedStudies && Object.keys(cachedStudies).length > 0
+                ? 'Refreshing saved library folder...'
+                : 'Loading saved library folder...';
             const studies = await app.desktopLibrary.loadStudies(state.libraryFolder, {
-                onProgress: stats => updateDesktopScanMessage(stats, 'Loading saved library folder...')
+                onProgress: stats => updateDesktopScanMessage(stats, loadLabel)
             });
             await applyDesktopLibraryScan(state.libraryFolder, studies);
         } catch (e) {

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -212,17 +212,24 @@
     }
 
     async function waitForDesktopRuntime() {
-        if (window.__TAURI__) return window.__TAURI__;
+        const runtime = window.__TAURI__;
+        if (runtime?.fs?.readFile && runtime?.path?.appDataDir && runtime?.path?.join) {
+            return runtime;
+        }
 
-        const ready = window.__DICOM_VIEWER_TAURI_READY__;
+        const ready = window.__DICOM_VIEWER_TAURI_STORAGE_READY__ || window.__DICOM_VIEWER_TAURI_READY__;
         if (ready && typeof ready.then === 'function') {
-            return await ready;
+            const resolved = await ready;
+            if (resolved?.fs?.readFile && resolved?.path?.appDataDir && resolved?.path?.join) {
+                return resolved;
+            }
         }
 
         const deadline = performance.now() + 5000;
         while (performance.now() < deadline) {
-            if (window.__TAURI__) {
-                return window.__TAURI__;
+            const current = window.__TAURI__;
+            if (current?.fs?.readFile && current?.path?.appDataDir && current?.path?.join) {
+                return current;
             }
             await new Promise((resolve) => setTimeout(resolve, 50));
         }

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -1,15 +1,73 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { uploadProgress, progressFill, progressText, progressDetail } = app.dom;
-    const { parseDicomMetadata, parseDicomMetadataDetailed, isRenderableImageMetadata } = app.dicom;
+    const {
+        parseDicomMetadata,
+        parseDicomMetadataDetailed,
+        isRenderableImageMetadata
+    } = app.dicom;
     const DESKTOP_MAX_SCAN_DEPTH = 20;
     const DEFAULT_SCAN_CONCURRENCY = 100;
-    const DESKTOP_PATH_SCAN_CONCURRENCY = 4;
-    const DESKTOP_PATH_BATCH_SIZE = 32;
+    const DESKTOP_PATH_SCAN_CONCURRENCY = 10;
+    const DESKTOP_PATH_QUEUE_HIGH_WATER_MARK = 512;
+    const DESKTOP_PATH_QUEUE_LOW_WATER_MARK = 256;
     const DESKTOP_PATH_READ_ATTEMPTS = 3;
     const DESKTOP_PATH_READ_RETRY_DELAY_MS = 50;
     const DESKTOP_SCAN_HEADER_BYTES = 256 * 1024;
+    const DESKTOP_SCAN_HEADER_READ_SIZES = Object.freeze([
+        64 * 1024,
+        DESKTOP_SCAN_HEADER_BYTES
+    ]);
+    const DESKTOP_SCAN_SKIP_EXTENSIONS = new Set([
+        '.bmp',
+        '.chm',
+        '.config',
+        '.css',
+        '.dll',
+        '.dylib',
+        '.eot',
+        '.exe',
+        '.gif',
+        '.h',
+        '.htm',
+        '.html',
+        '.ico',
+        '.icns',
+        '.inf',
+        '.ini',
+        '.jar',
+        '.jpeg',
+        '.jpg',
+        '.js',
+        '.md',
+        '.mht',
+        '.ocx',
+        '.pak',
+        '.pdf',
+        '.plist',
+        '.png',
+        '.properties',
+        '.ttf',
+        '.txt',
+        '.xml',
+        '.xz'
+    ]);
+    // These names recur in exported disc bundles and never represent study content.
+    const DESKTOP_SCAN_SKIP_FILE_NAMES = new Set([
+        '.ds_store',
+        'dicomdir',
+        'thumbs.db'
+    ]);
+    // These are viewer payload directories that show up alongside studies on burned/exported media.
+    const DESKTOP_SCAN_SKIP_DIRECTORY_NAMES = new Set([
+        '__macosx',
+        'catapult',
+        'ddv',
+        'libraries',
+        'reviewer'
+    ]);
     const SCAN_PROGRESS_UPDATE_INTERVAL = 200;
+    const SCAN_YIELD_INTERVAL_MS = 16;
 
     function updateScanProgress(processed, total, valid) {
         if (processed % SCAN_PROGRESS_UPDATE_INTERVAL !== 0 && processed !== total) return;
@@ -244,6 +302,17 @@
         return String(error);
     }
 
+    function hasDicomPreamble(bytes) {
+        return !!(
+            bytes &&
+            bytes.byteLength >= 132 &&
+            bytes[128] === 0x44 &&
+            bytes[129] === 0x49 &&
+            bytes[130] === 0x43 &&
+            bytes[131] === 0x4d
+        );
+    }
+
     // These string matches come from the bundled dicomParser implementation:
     // - parseDicomDataSetExplicit(...) => "buffer overrun"
     // - readFixedString(...) => "attempt to read past end of buffer"
@@ -255,9 +324,29 @@
         'missing required meta header attribute 0002,0010'
     ];
 
-    function shouldRetryDesktopScanWithFullRead(parseResult, headerBytes) {
-        if (parseResult?.meta) return false;
-        if (!headerBytes || headerBytes.byteLength < DESKTOP_SCAN_HEADER_BYTES) return false;
+    function hasLikelyDicomMetadata(meta) {
+        return !!(
+            meta?.transferSyntax ||
+            meta?.studyInstanceUid ||
+            meta?.seriesInstanceUid ||
+            meta?.sopClassUid ||
+            meta?.sopInstanceUid
+        );
+    }
+
+    function shouldExpandDesktopScanHeaderRead(parseResult, headerBytes, requestedBytes) {
+        if (!headerBytes || headerBytes.byteLength < requestedBytes) return false;
+
+        if (parseResult?.meta) {
+            // Small staged reads can parse enough structure to look like DICOM without
+            // reaching rows/cols or the pixel data tag yet. Keep growing the probe until
+            // the metadata is actually sufficient for renderability checks.
+            return hasLikelyDicomMetadata(parseResult.meta) && !isRenderableImageMetadata(parseResult.meta);
+        }
+
+        if (hasDicomPreamble(headerBytes)) {
+            return true;
+        }
 
         const message = getDesktopScanParseErrorMessage(parseResult?.error).toLowerCase();
         return DESKTOP_SCAN_TRUNCATION_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
@@ -265,13 +354,18 @@
 
     async function readDesktopScanMetadata(source, stats) {
         const shouldTimeReads = typeof stats.readFileMs === 'number';
-        const headerReadStartedAt = shouldTimeReads ? performance.now() : 0;
-        const headerBytes = await readDesktopScanHeader(source.path, DESKTOP_SCAN_HEADER_BYTES);
-        const headerReadDeltaMs = shouldTimeReads ? performance.now() - headerReadStartedAt : 0;
-        addDesktopScanTiming(stats, 'readFileMs', headerReadDeltaMs);
-        addDesktopScanTiming(stats, 'headerReadMs', headerReadDeltaMs);
+        for (let stageIndex = 0; stageIndex < DESKTOP_SCAN_HEADER_READ_SIZES.length; stageIndex += 1) {
+            const requestedBytes = DESKTOP_SCAN_HEADER_READ_SIZES[stageIndex];
+            const headerReadStartedAt = shouldTimeReads ? performance.now() : 0;
+            const headerBytes = await readDesktopScanHeader(source.path, requestedBytes);
+            const headerReadDeltaMs = shouldTimeReads ? performance.now() - headerReadStartedAt : 0;
+            addDesktopScanTiming(stats, 'readFileMs', headerReadDeltaMs);
+            addDesktopScanTiming(stats, 'headerReadMs', headerReadDeltaMs);
 
-        if (headerBytes) {
+            if (!headerBytes) {
+                break;
+            }
+
             incrementDesktopScanCounter(stats, 'headerReadCount');
             const headerResult = await parseDesktopScanBuffer(headerBytes, stats);
             if (headerResult.meta) {
@@ -279,17 +373,21 @@
                 return headerResult.meta;
             }
 
-            if (headerBytes.byteLength < DESKTOP_SCAN_HEADER_BYTES) {
+            if (headerBytes.byteLength < requestedBytes) {
                 incrementDesktopScanCounter(stats, 'headerShortCount');
                 return headerResult.meta;
             }
 
-            if (!shouldRetryDesktopScanWithFullRead(headerResult, headerBytes)) {
-                incrementDesktopScanCounter(stats, 'headerRejectedCount');
-                return headerResult.meta;
+            if (shouldExpandDesktopScanHeaderRead(headerResult, headerBytes, requestedBytes)) {
+                if (stageIndex < DESKTOP_SCAN_HEADER_READ_SIZES.length - 1) {
+                    continue;
+                }
+                incrementDesktopScanCounter(stats, 'headerFallbackCount');
+                break;
             }
 
-            incrementDesktopScanCounter(stats, 'headerFallbackCount');
+            incrementDesktopScanCounter(stats, 'headerRejectedCount');
+            return headerResult.meta;
         }
 
         let buffer;
@@ -306,12 +404,198 @@
         return fullResult.meta;
     }
 
+    async function readDesktopScanManifest(paths, maxDepth) {
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (typeof invoke !== 'function') {
+            return null;
+        }
+
+        try {
+            const entries = await invoke('read_scan_manifest', { roots: paths, maxDepth });
+            if (!Array.isArray(entries)) {
+                return null;
+            }
+            return entries
+                .map((entry) => ({
+                    path: typeof entry?.path === 'string' ? entry.path : '',
+                    name: typeof entry?.name === 'string' ? entry.name : getPathName(entry?.path),
+                    rootPath: typeof entry?.rootPath === 'string'
+                        ? entry.rootPath
+                        : (typeof entry?.root_path === 'string' ? entry.root_path : ''),
+                    size: Number.isFinite(Number(entry?.size)) ? Number(entry.size) : null,
+                    modifiedMs: Number.isFinite(Number(entry?.modifiedMs))
+                        ? Number(entry.modifiedMs)
+                        : (Number.isFinite(Number(entry?.modified_ms)) ? Number(entry.modified_ms) : null)
+                }))
+                .filter((entry) => entry.path);
+        } catch (error) {
+            console.warn('Desktop scan manifest unavailable, falling back to fs.readDir walk:', error);
+            return null;
+        }
+    }
+
+    async function loadDesktopScanCache(rootPaths) {
+        const notesApi = window.NotesAPI;
+        if (typeof notesApi?.loadDesktopScanCache !== 'function') {
+            return new Map();
+        }
+
+        try {
+            const rows = await notesApi.loadDesktopScanCache(rootPaths);
+            const cache = new Map();
+            for (const row of rows || []) {
+                if (!row?.path) continue;
+                let meta = null;
+                if (row.renderable && typeof row.meta_json === 'string' && row.meta_json) {
+                    try {
+                        meta = JSON.parse(row.meta_json);
+                    } catch (error) {
+                        console.warn('Desktop scan cache entry contained invalid metadata JSON:', error);
+                        continue;
+                    }
+                }
+                cache.set(row.path, {
+                    size: Number.isFinite(Number(row.size)) ? Number(row.size) : null,
+                    modifiedMs: Number.isFinite(Number(row.modified_ms)) ? Number(row.modified_ms) : null,
+                    renderable: !!row.renderable,
+                    meta
+                });
+            }
+            return cache;
+        } catch (error) {
+            console.warn('Desktop scan cache load failed:', error);
+            return new Map();
+        }
+    }
+
+    async function saveDesktopScanCacheEntries(entries) {
+        const notesApi = window.NotesAPI;
+        if (typeof notesApi?.saveDesktopScanCacheEntries !== 'function') {
+            return;
+        }
+
+        try {
+            await notesApi.saveDesktopScanCacheEntries(entries);
+        } catch (error) {
+            console.warn('Desktop scan cache save failed:', error);
+        }
+    }
+
+    function getDesktopScanCacheHit(cacheByPath, fileEntry) {
+        const path = fileEntry?.source?.path;
+        if (!path || !cacheByPath?.size) {
+            return null;
+        }
+
+        const cached = cacheByPath.get(path);
+        if (!cached) {
+            return null;
+        }
+
+        const size = Number.isFinite(Number(fileEntry.size)) ? Number(fileEntry.size) : null;
+        const modifiedMs = Number.isFinite(Number(fileEntry.modifiedMs)) ? Number(fileEntry.modifiedMs) : null;
+        if (cached.size !== size) {
+            return null;
+        }
+        if (cached.modifiedMs !== modifiedMs) {
+            return null;
+        }
+        return cached;
+    }
+
+    function createDesktopScanCacheEntry(fileEntry, meta, renderable) {
+        if (
+            fileEntry?.source?.kind !== 'path'
+            || !fileEntry.source.path
+            || !fileEntry.rootPath
+            || !Number.isFinite(Number(fileEntry.size))
+        ) {
+            return null;
+        }
+
+        let metaJson = null;
+        if (renderable && meta) {
+            try {
+                metaJson = JSON.stringify(meta);
+            } catch (error) {
+                console.warn('Failed to serialize desktop scan cache metadata:', error);
+            }
+        }
+
+        return {
+            path: fileEntry.source.path,
+            rootPath: fileEntry.rootPath,
+            size: Number(fileEntry.size),
+            modifiedMs: Number.isFinite(Number(fileEntry.modifiedMs)) ? Number(fileEntry.modifiedMs) : null,
+            renderable: !!renderable,
+            metaJson
+        };
+    }
+
     function getPathName(path) {
         return path.split(/[\\/]/).pop() || path;
     }
 
+    function getDesktopScanFileExtension(name) {
+        const lastDot = String(name || '').lastIndexOf('.');
+        if (lastDot <= 0) return '';
+        return String(name).slice(lastDot).toLowerCase();
+    }
+
+    function isDesktopScanDicomDirFileName(name) {
+        return String(name || '').toLowerCase() === 'dicomdir';
+    }
+
+    function shouldSkipDesktopScanPathEntry(name) {
+        const normalizedName = String(name || '').toLowerCase();
+        return (!isDesktopScanDicomDirFileName(normalizedName) && DESKTOP_SCAN_SKIP_FILE_NAMES.has(normalizedName)) ||
+            DESKTOP_SCAN_SKIP_EXTENSIONS.has(getDesktopScanFileExtension(normalizedName));
+    }
+
+    function shouldSkipDesktopScanDirectory(name) {
+        const normalizedName = String(name || '').toLowerCase();
+        return normalizedName.endsWith('.app') ||
+            DESKTOP_SCAN_SKIP_DIRECTORY_NAMES.has(normalizedName);
+    }
+
+    function createDesktopPathScanStats(captureTiming) {
+        const stats = {
+            discovered: 0,
+            processed: 0,
+            valid: 0
+        };
+        if (captureTiming) {
+            Object.assign(stats, {
+                readDirMs: 0,
+                readFileMs: 0,
+                headerReadMs: 0,
+                fullReadMs: 0,
+                parseMs: 0,
+                finalizeMs: 0,
+                headerReadCount: 0,
+                headerHitCount: 0,
+                headerShortCount: 0,
+                headerFallbackCount: 0,
+                headerRejectedCount: 0
+            });
+        }
+        return stats;
+    }
+
     function wait(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function createYieldController(intervalMs = SCAN_YIELD_INTERVAL_MS) {
+        let lastYieldAt = performance.now();
+        return async function yieldIfNeeded(force = false) {
+            const now = performance.now();
+            if (!force && (now - lastYieldAt) < intervalMs) {
+                return;
+            }
+            lastYieldAt = now;
+            await wait(0);
+        };
     }
 
     function getScanConcurrency(files) {
@@ -354,6 +638,7 @@
         const { force = false, currentPath = '', complete = false } = options;
         const shouldEmit = force ||
             stats.discovered === 0 ||
+            stats.processed === 1 ||
             stats.discovered % SCAN_PROGRESS_UPDATE_INTERVAL === 0 ||
             stats.processed % SCAN_PROGRESS_UPDATE_INTERVAL === 0 ||
             stats.processed === stats.discovered;
@@ -415,25 +700,79 @@
         return finalizeStudies(studies);
     }
 
-    async function processDesktopPathFileBatch(files, studies, stats, onProgress) {
-        for (let i = 0; i < files.length; i += DESKTOP_PATH_SCAN_CONCURRENCY) {
-            const batch = files.slice(i, i + DESKTOP_PATH_SCAN_CONCURRENCY);
-            await Promise.all(batch.map(async ({ name, source }) => {
-                try {
-                    const meta = await readDesktopScanMetadata(source, stats);
+    async function processDesktopPathFile(fileEntry, studies, stats, onProgress, cacheUpdates = null) {
+        const { name, source } = fileEntry;
+        let meta = null;
+        let renderable = false;
+        let shouldCache = false;
+        try {
+            if (shouldSkipDesktopScanPathEntry(name)) {
+                return;
+            }
+            meta = await readDesktopScanMetadata(source, stats);
+            shouldCache = true;
+            renderable = isRenderableImageMetadata(meta);
+            if (!renderable) return;
+            stats.valid++;
+            addSliceToStudies(studies, meta, source);
+        } catch (e) {
+            console.warn(`Skipping unreadable DICOM file during scan: ${name}`, e);
+        } finally {
+            const cacheEntry = shouldCache ? createDesktopScanCacheEntry(fileEntry, meta, renderable) : null;
+            if (cacheEntry && Array.isArray(cacheUpdates)) {
+                cacheUpdates.push(cacheEntry);
+            }
+            stats.processed++;
+            safeEmitDesktopPathProgress(onProgress, stats, { currentPath: source?.path || '' });
+        }
+    }
 
-                    if (!isRenderableImageMetadata(meta)) return;
-                    stats.valid++;
-                    addSliceToStudies(studies, meta, source);
-                } catch (e) {
-                    console.warn(`Skipping unreadable DICOM file during scan: ${name}`, e);
-                } finally {
-                    stats.processed++;
-                    safeEmitDesktopPathProgress(onProgress, stats, { currentPath: source?.path || '' });
+    async function processDesktopPathDicomDirFile(
+        fileEntry,
+        studies,
+        indexedFilePaths,
+        stats,
+        onProgress,
+        availablePaths = null
+    ) {
+        const sourcePath = fileEntry?.source?.path || '';
+        const shouldTimeReads = typeof stats.readFileMs === 'number';
+        let indexedCount = 0;
+        try {
+            const readStartedAt = shouldTimeReads ? performance.now() : 0;
+            const bytes = await readSliceBuffer({ source: fileEntry.source }, 'scan');
+            const readDeltaMs = shouldTimeReads ? performance.now() - readStartedAt : 0;
+            addDesktopScanTiming(stats, 'readFileMs', readDeltaMs);
+            addDesktopScanTiming(stats, 'fullReadMs', readDeltaMs);
+
+            const parseStartedAt = shouldTimeReads ? performance.now() : 0;
+            const result = await app.dicom.parseDicomDirectoryDetailed(bytes, sourcePath);
+            if (shouldTimeReads) {
+                addDesktopScanTiming(stats, 'parseMs', performance.now() - parseStartedAt);
+            }
+
+            if (result?.error) {
+                console.warn(`Skipping unreadable DICOMDIR during scan: ${sourcePath}`, result.error);
+                return;
+            }
+
+            for (const entry of result?.entries || []) {
+                if (!entry?.meta || !entry?.source?.path) {
+                    continue;
                 }
-            }));
-
-            await wait(0);
+                if (availablePaths instanceof Set && !availablePaths.has(entry.source.path)) {
+                    continue;
+                }
+                indexedCount += 1;
+                indexedFilePaths.add(entry.source.path);
+                addSliceToStudies(studies, entry.meta, entry.source);
+            }
+            stats.valid += indexedCount;
+        } catch (error) {
+            console.warn(`Skipping unreadable DICOMDIR during scan: ${sourcePath}`, error);
+        } finally {
+            stats.processed += 1;
+            safeEmitDesktopPathProgress(onProgress, stats, { currentPath: sourcePath });
         }
     }
 
@@ -629,6 +968,9 @@
             }
 
             if (entry.isDirectory) {
+                if (shouldSkipDesktopScanDirectory(entry.name)) {
+                    continue;
+                }
                 if (depth >= maxDepth) {
                     console.warn('Skipping path beyond desktop scan depth limit:', entryPath);
                     continue;
@@ -639,6 +981,9 @@
                     visited
                 }));
             } else if (entry.isFile) {
+                if (shouldSkipDesktopScanPathEntry(entry.name)) {
+                    continue;
+                }
                 files.push({
                     name: entry.name,
                     source: { kind: 'path', path: entryPath }
@@ -660,118 +1005,326 @@
             captureTiming = false
         } = options;
 
+        const normalizedPaths = [];
+        for (const path of (Array.isArray(paths) ? paths : [paths]).filter(Boolean)) {
+            normalizedPaths.push(await normalizePath(path));
+        }
+
         const studies = {};
         const pendingFiles = [];
-        const stats = {
-            discovered: 0,
-            processed: 0,
-            valid: 0
-        };
-        if (captureTiming) {
-            Object.assign(stats, {
-                readDirMs: 0,
-                readFileMs: 0,
-                headerReadMs: 0,
-                fullReadMs: 0,
-                parseMs: 0,
-                finalizeMs: 0,
-                headerReadCount: 0,
-                headerHitCount: 0,
-                headerShortCount: 0,
-                headerFallbackCount: 0,
-                headerRejectedCount: 0
-            });
-        }
+        const stats = createDesktopPathScanStats(captureTiming);
+        const cacheUpdates = [];
         const visited = new Set();
+        const queuedFilePaths = new Set();
         const stack = [];
-        for (const path of (Array.isArray(paths) ? paths : [paths]).filter(Boolean)) {
-            stack.push({
-                path: await normalizePath(path),
-                depth: 0
-            });
+        const yieldIfNeeded = createYieldController();
+        let walkingComplete = false;
+        let scanError = null;
+        const queueWaiters = [];
+        const queueDrainedWaiters = [];
+        const indexedFilePaths = new Set();
+        const manifestStartedAt = captureTiming ? performance.now() : 0;
+        const manifestEntries = await readDesktopScanManifest(normalizedPaths, maxDepth);
+        const manifestPathSet = manifestEntries
+            ? new Set(manifestEntries.map((entry) => entry.path).filter(Boolean))
+            : null;
+        if (captureTiming && manifestEntries) {
+            stats.readDirMs += performance.now() - manifestStartedAt;
+        }
+        const cacheByPath = manifestEntries ? await loadDesktopScanCache(normalizedPaths) : new Map();
+        for (const path of normalizedPaths) {
+            stack.push({ path, depth: 0, rootPath: path });
         }
         stack.reverse();
 
-        async function flushPendingFiles(force = false) {
-            while (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE || (force && pendingFiles.length > 0)) {
-                const batchSize = force ? pendingFiles.length : DESKTOP_PATH_BATCH_SIZE;
-                const batch = pendingFiles.splice(0, batchSize);
-                await processDesktopPathFileBatch(batch, studies, stats, onProgress);
+        function wakeQueuedWorkers() {
+            while (queueWaiters.length) {
+                queueWaiters.shift()();
             }
         }
+
+        function wakeQueueDrainWaiters() {
+            if (pendingFiles.length > DESKTOP_PATH_QUEUE_LOW_WATER_MARK) {
+                return;
+            }
+            while (queueDrainedWaiters.length) {
+                queueDrainedWaiters.shift()();
+            }
+        }
+
+        function enqueuePendingFile(fileEntry, currentPath = '') {
+            const filePath = fileEntry.source?.kind === 'path' ? fileEntry.source.path : '';
+            if (filePath) {
+                if (queuedFilePaths.has(filePath)) {
+                    return false;
+                }
+                queuedFilePaths.add(filePath);
+            }
+            pendingFiles.push(fileEntry);
+            stats.discovered++;
+            safeEmitDesktopPathProgress(onProgress, stats, {
+                currentPath: fileEntry.source?.path || currentPath
+            });
+            wakeQueuedWorkers();
+            return true;
+        }
+
+        async function takePendingFile() {
+            while (!pendingFiles.length) {
+                if (walkingComplete || scanError) return null;
+                await new Promise((resolve) => {
+                    queueWaiters.push(resolve);
+                });
+            }
+
+            const fileEntry = pendingFiles.shift();
+            wakeQueueDrainWaiters();
+            return fileEntry;
+        }
+
+        async function waitForQueueCapacity() {
+            while (!scanError && pendingFiles.length >= DESKTOP_PATH_QUEUE_HIGH_WATER_MARK) {
+                await new Promise((resolve) => {
+                    queueDrainedWaiters.push(resolve);
+                });
+            }
+        }
+
+        async function workerLoop() {
+            while (!scanError) {
+                const fileEntry = await takePendingFile();
+                if (!fileEntry) return;
+                await processDesktopPathFile(fileEntry, studies, stats, onProgress, cacheUpdates);
+                await yieldIfNeeded();
+            }
+        }
+
+        const workers = Array.from(
+            { length: DESKTOP_PATH_SCAN_CONCURRENCY },
+            () => workerLoop()
+        );
 
         safeEmitDesktopPathProgress(onProgress, stats, { force: true, complete: false });
 
-        while (stack.length) {
-            const current = stack.pop();
-            const currentPath = current.path;
-
-            if (visited.has(currentPath)) {
-                console.warn('Skipping already-visited desktop scan path:', currentPath);
-                continue;
-            }
-            visited.add(currentPath);
-
-            let entries;
-            const readDirStartedAt = captureTiming ? performance.now() : 0;
+        if (manifestEntries) {
             try {
-                entries = await fs.readDir(currentPath);
-            } catch (readError) {
-                if (captureTiming) {
-                    stats.readDirMs += performance.now() - readDirStartedAt;
-                }
-                const fileEntries = await resolveDesktopPathSource(fs, currentPath, readError);
-                for (const fileEntry of fileEntries) {
-                    pendingFiles.push(fileEntry);
-                    stats.discovered++;
-                    safeEmitDesktopPathProgress(onProgress, stats, { currentPath: fileEntry.source?.path || currentPath });
-                    if (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE) {
-                        await flushPendingFiles();
+                const dicomDirEntries = [];
+                const otherEntries = [];
+                for (const entry of manifestEntries) {
+                    if (isDesktopScanDicomDirFileName(entry?.name)) {
+                        dicomDirEntries.push(entry);
+                    } else {
+                        otherEntries.push(entry);
                     }
                 }
-                continue;
-            }
-            if (captureTiming) {
-                stats.readDirMs += performance.now() - readDirStartedAt;
-            }
 
-            for (const entry of entries) {
-                const entryPath = joinScanPath(currentPath, entry.name);
-                if (entry.isSymlink) {
-                    console.warn('Skipping symlink during desktop scan:', entryPath);
-                    continue;
-                }
-
-                if (entry.isDirectory) {
-                    if (current.depth >= maxDepth) {
-                        console.warn('Skipping path beyond desktop scan depth limit:', entryPath);
+                for (const entry of [...dicomDirEntries, ...otherEntries]) {
+                    const fileEntry = {
+                        name: entry.name,
+                        source: { kind: 'path', path: entry.path },
+                        rootPath: entry.rootPath || normalizedPaths[0] || '',
+                        size: entry.size,
+                        modifiedMs: entry.modifiedMs
+                    };
+                    const currentPath = fileEntry.source.path;
+                    if (currentPath && queuedFilePaths.has(currentPath)) {
                         continue;
                     }
-                    stack.push({
-                        path: entryPath,
-                        depth: current.depth + 1
-                    });
-                    continue;
+
+                    if (isDesktopScanDicomDirFileName(fileEntry.name)) {
+                        if (currentPath) {
+                            queuedFilePaths.add(currentPath);
+                        }
+                        stats.discovered++;
+                        await processDesktopPathDicomDirFile(
+                            fileEntry,
+                            studies,
+                            indexedFilePaths,
+                            stats,
+                            onProgress,
+                            manifestPathSet
+                        );
+                        continue;
+                    }
+
+                    if (currentPath && indexedFilePaths.has(currentPath)) {
+                        queuedFilePaths.add(currentPath);
+                        stats.discovered++;
+                        stats.processed++;
+                        safeEmitDesktopPathProgress(onProgress, stats, { currentPath });
+                        continue;
+                    }
+
+                    if (shouldSkipDesktopScanPathEntry(fileEntry.name)) {
+                        if (currentPath) {
+                            queuedFilePaths.add(currentPath);
+                        }
+                        stats.discovered++;
+                        stats.processed++;
+                        safeEmitDesktopPathProgress(onProgress, stats, { currentPath });
+                        continue;
+                    }
+
+                    const cacheHit = getDesktopScanCacheHit(cacheByPath, fileEntry);
+                    if (cacheHit) {
+                        if (currentPath) {
+                            queuedFilePaths.add(currentPath);
+                        }
+                        stats.discovered++;
+                        if (cacheHit.renderable && cacheHit.meta) {
+                            stats.valid++;
+                            addSliceToStudies(studies, cacheHit.meta, fileEntry.source);
+                        }
+                        stats.processed++;
+                        safeEmitDesktopPathProgress(onProgress, stats, { currentPath });
+                        continue;
+                    }
+
+                    if (enqueuePendingFile(fileEntry, currentPath)) {
+                        await waitForQueueCapacity();
+                    }
                 }
-
-                if (!entry.isFile) continue;
-
-                pendingFiles.push({
-                    name: entry.name,
-                    source: { kind: 'path', path: entryPath }
-                });
-                stats.discovered++;
-                safeEmitDesktopPathProgress(onProgress, stats, { currentPath: entryPath });
-
-                if (pendingFiles.length >= DESKTOP_PATH_BATCH_SIZE) {
-                    await flushPendingFiles();
-                }
+            } catch (error) {
+                scanError = error;
+                wakeQueuedWorkers();
+                wakeQueueDrainWaiters();
+                throw error;
+            } finally {
+                walkingComplete = true;
+                wakeQueuedWorkers();
             }
+        } else {
+            try {
+                while (stack.length) {
+                    const current = stack.pop();
+                    const currentPath = current.path;
 
-            await wait(0);
+                    if (visited.has(currentPath)) {
+                        console.warn('Skipping already-visited desktop scan path:', currentPath);
+                        continue;
+                    }
+                    visited.add(currentPath);
+
+                    let entries;
+                    const readDirStartedAt = captureTiming ? performance.now() : 0;
+                    try {
+                        entries = await fs.readDir(currentPath);
+                    } catch (readError) {
+                        if (captureTiming) {
+                            stats.readDirMs += performance.now() - readDirStartedAt;
+                        }
+                        const fileEntries = await resolveDesktopPathSource(fs, currentPath, readError);
+                        for (const fileEntry of fileEntries) {
+                            if (shouldSkipDesktopScanPathEntry(fileEntry.name)) {
+                                stats.discovered++;
+                                stats.processed++;
+                                safeEmitDesktopPathProgress(onProgress, stats, {
+                                    currentPath: fileEntry.source?.path || currentPath
+                                });
+                                continue;
+                            }
+                            if (enqueuePendingFile({
+                                ...fileEntry,
+                                rootPath: current.rootPath
+                            }, currentPath)) {
+                                await waitForQueueCapacity();
+                            }
+                        }
+                        await yieldIfNeeded();
+                        continue;
+                    }
+                    if (captureTiming) {
+                        stats.readDirMs += performance.now() - readDirStartedAt;
+                    }
+
+                    for (const entry of entries) {
+                        if (!entry.isFile || !isDesktopScanDicomDirFileName(entry.name)) {
+                            continue;
+                        }
+                        const entryPath = joinScanPath(currentPath, entry.name);
+                        if (queuedFilePaths.has(entryPath)) {
+                            continue;
+                        }
+                        queuedFilePaths.add(entryPath);
+                        stats.discovered++;
+                        await processDesktopPathDicomDirFile({
+                            name: entry.name,
+                            source: { kind: 'path', path: entryPath },
+                            rootPath: current.rootPath
+                        }, studies, indexedFilePaths, stats, onProgress);
+                    }
+
+                    for (const entry of entries) {
+                        const entryPath = joinScanPath(currentPath, entry.name);
+                        if (entry.isSymlink) {
+                            console.warn('Skipping symlink during desktop scan:', entryPath);
+                            continue;
+                        }
+
+                        if (entry.isDirectory) {
+                            if (shouldSkipDesktopScanDirectory(entry.name)) {
+                                continue;
+                            }
+                            if (current.depth >= maxDepth) {
+                                console.warn('Skipping path beyond desktop scan depth limit:', entryPath);
+                                continue;
+                            }
+                            stack.push({
+                                path: entryPath,
+                                depth: current.depth + 1,
+                                rootPath: current.rootPath
+                            });
+                            continue;
+                        }
+
+                        if (!entry.isFile) continue;
+                        if (isDesktopScanDicomDirFileName(entry.name)) {
+                            continue;
+                        }
+                        if (indexedFilePaths.has(entryPath)) {
+                            stats.discovered++;
+                            stats.processed++;
+                            safeEmitDesktopPathProgress(onProgress, stats, { currentPath: entryPath });
+                            continue;
+                        }
+                        if (shouldSkipDesktopScanPathEntry(entry.name)) {
+                            stats.discovered++;
+                            stats.processed++;
+                            safeEmitDesktopPathProgress(onProgress, stats, { currentPath: entryPath });
+                            continue;
+                        }
+
+                        if (enqueuePendingFile({
+                            name: entry.name,
+                            source: { kind: 'path', path: entryPath },
+                            rootPath: current.rootPath
+                        }, entryPath)) {
+                            await waitForQueueCapacity();
+                        }
+                    }
+
+                    await yieldIfNeeded();
+                }
+            } catch (error) {
+                scanError = error;
+                wakeQueuedWorkers();
+                wakeQueueDrainWaiters();
+                throw error;
+            } finally {
+                walkingComplete = true;
+                wakeQueuedWorkers();
+            }
         }
 
-        await flushPendingFiles(true);
+        await Promise.all(workers);
+        if (scanError) {
+            throw scanError;
+        }
+
+        if (cacheUpdates.length) {
+            await saveDesktopScanCacheEntries(cacheUpdates);
+        }
+
         const finalizeStartedAt = captureTiming ? performance.now() : 0;
         const finalizedStudies = finalizeStudies(studies);
         if (captureTiming) {

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -17,11 +17,12 @@
     }
 
     function installCompatFromInternals(internals) {
-        if (window.__TAURI__ || !internals?.invoke) {
+        if (!internals?.invoke) {
             return window.__TAURI__ || null;
         }
 
         window.__TAURI_EVENT_PLUGIN_INTERNALS__ = window.__TAURI_EVENT_PLUGIN_INTERNALS__ || {};
+        const tauri = window.__TAURI__ || {};
 
         function invoke(cmd, args, options) {
             return internals.invoke(cmd, args, options);
@@ -178,74 +179,109 @@
             };
         }
 
-        window.__TAURI__ = {
-            core: {
-                convertFileSrc(filePath, protocol) {
-                    return internals.convertFileSrc(filePath, protocol);
-                },
-                invoke(command, args, options) {
-                    return invoke(command, args, options);
-                }
-            },
-            dialog: {
-                async open(options = {}) {
-                    if (typeof options === 'object') {
-                        Object.freeze(options);
-                    }
-                    return invoke('plugin:dialog|open', { options });
-                }
-            },
-            event: {
-                listen
-            },
-            fs: {
-                async exists(path, options) {
-                    return invoke('plugin:fs|exists', { path, options });
-                },
-                async mkdir(path, options) {
-                    return invoke('plugin:fs|mkdir', { path, options });
-                },
-                async readDir(path, options) {
-                    return invoke('plugin:fs|read_dir', { path, options });
-                },
-                readFile,
-                async remove(path, options) {
-                    return invoke('plugin:fs|remove', { path, options });
-                },
-                rename,
-                stat,
-                writeFile
-            },
-            path: {
-                async appDataDir() {
-                    return invoke('plugin:path|resolve_directory', {
-                        directory: APP_DATA_DIRECTORY
-                    });
-                },
-                async join(...paths) {
-                    return invoke('plugin:path|join', { paths });
-                },
-                async normalize(path) {
-                    return invoke('plugin:path|normalize', { path });
-                }
-            },
-            sql: {
-                async load(db) {
-                    await invoke('plugin:sql|load', { db });
-                    return createSqlConnection(db);
-                }
-            },
-            webview: {
-                getCurrentWebview: createCurrentWebview
-            }
-        };
+        tauri.core = tauri.core || {};
+        if (typeof tauri.core.convertFileSrc !== 'function') {
+            tauri.core.convertFileSrc = function convertFileSrc(filePath, protocol) {
+                return internals.convertFileSrc(filePath, protocol);
+            };
+        }
+        if (typeof tauri.core.invoke !== 'function') {
+            tauri.core.invoke = function coreInvoke(command, args, options) {
+                return invoke(command, args, options);
+            };
+        }
 
-        return window.__TAURI__;
+        tauri.dialog = tauri.dialog || {};
+        if (typeof tauri.dialog.open !== 'function') {
+            tauri.dialog.open = async function open(options = {}) {
+                if (typeof options === 'object') {
+                    Object.freeze(options);
+                }
+                return invoke('plugin:dialog|open', { options });
+            };
+        }
+
+        tauri.event = tauri.event || {};
+        if (typeof tauri.event.listen !== 'function') {
+            tauri.event.listen = listen;
+        }
+
+        tauri.fs = tauri.fs || {};
+        if (typeof tauri.fs.exists !== 'function') {
+            tauri.fs.exists = async function exists(path, options) {
+                return invoke('plugin:fs|exists', { path, options });
+            };
+        }
+        if (typeof tauri.fs.mkdir !== 'function') {
+            tauri.fs.mkdir = async function mkdir(path, options) {
+                return invoke('plugin:fs|mkdir', { path, options });
+            };
+        }
+        if (typeof tauri.fs.readDir !== 'function') {
+            tauri.fs.readDir = async function readDir(path, options) {
+                return invoke('plugin:fs|read_dir', { path, options });
+            };
+        }
+        if (typeof tauri.fs.readFile !== 'function') {
+            tauri.fs.readFile = readFile;
+        }
+        if (typeof tauri.fs.remove !== 'function') {
+            tauri.fs.remove = async function remove(path, options) {
+                return invoke('plugin:fs|remove', { path, options });
+            };
+        }
+        if (typeof tauri.fs.rename !== 'function') {
+            tauri.fs.rename = rename;
+        }
+        if (typeof tauri.fs.stat !== 'function') {
+            tauri.fs.stat = stat;
+        }
+        if (typeof tauri.fs.writeFile !== 'function') {
+            tauri.fs.writeFile = writeFile;
+        }
+
+        tauri.path = tauri.path || {};
+        if (typeof tauri.path.appDataDir !== 'function') {
+            tauri.path.appDataDir = async function appDataDir() {
+                return invoke('plugin:path|resolve_directory', {
+                    directory: APP_DATA_DIRECTORY
+                });
+            };
+        }
+        if (typeof tauri.path.join !== 'function') {
+            tauri.path.join = async function join(...paths) {
+                return invoke('plugin:path|join', { paths });
+            };
+        }
+        if (typeof tauri.path.normalize !== 'function') {
+            tauri.path.normalize = async function normalize(path) {
+                return invoke('plugin:path|normalize', { path });
+            };
+        }
+
+        tauri.sql = tauri.sql || {};
+        if (typeof tauri.sql.load !== 'function') {
+            tauri.sql.load = async function load(db) {
+                await invoke('plugin:sql|load', { db });
+                return createSqlConnection(db);
+            };
+        }
+
+        tauri.webview = tauri.webview || {};
+        if (typeof tauri.webview.getCurrentWebview !== 'function') {
+            tauri.webview.getCurrentWebview = createCurrentWebview;
+        }
+
+        window.__TAURI__ = tauri;
+        return tauri;
     }
 
     function resolveDesktopRuntime() {
-        if (window.__TAURI__) return window.__TAURI__;
-        return installCompatFromInternals(getInternals());
+        const internals = getInternals();
+        if (internals?.invoke) {
+            return installCompatFromInternals(internals);
+        }
+        return window.__TAURI__ || null;
     }
 
     window.__DICOM_VIEWER_TAURI_READY__ = window.__DICOM_VIEWER_TAURI_READY__ || new Promise(resolve => {

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -8,7 +8,7 @@
         drop: 'tauri://drag-drop',
         leave: 'tauri://drag-leave'
     };
-    const MAX_ATTEMPTS = 200;
+    const MAX_ATTEMPTS = 1200;
     const RETRY_DELAY_MS = 25;
 
     function getInternals() {

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -11,6 +11,32 @@
     const MAX_ATTEMPTS = 1200;
     const RETRY_DELAY_MS = 25;
 
+    function hasReadyDesktopStorageApis(runtime) {
+        return !!(
+            runtime
+            && typeof runtime.core?.invoke === 'function'
+            && typeof runtime.fs?.exists === 'function'
+            && typeof runtime.fs?.remove === 'function'
+            && typeof runtime.fs?.rename === 'function'
+            && typeof runtime.fs?.writeFile === 'function'
+            && typeof runtime.path?.appDataDir === 'function'
+            && typeof runtime.path?.join === 'function'
+            && typeof runtime.sql?.load === 'function'
+        );
+    }
+
+    function hasReadyDesktopApis(runtime) {
+        return !!(
+            runtime
+            && typeof runtime.core?.invoke === 'function'
+            && typeof runtime.dialog?.open === 'function'
+            && typeof runtime.fs?.readDir === 'function'
+            && typeof runtime.path?.appDataDir === 'function'
+            && typeof runtime.sql?.load === 'function'
+            && typeof runtime.webview?.getCurrentWebview === 'function'
+        );
+    }
+
     function getInternals() {
         const internals = window.__TAURI_INTERNALS__;
         return internals?.invoke ? internals : null;
@@ -276,39 +302,46 @@
         return tauri;
     }
 
-    function resolveDesktopRuntime() {
+    function resolveDesktopRuntime(validator = hasReadyDesktopApis) {
         const internals = getInternals();
         if (internals?.invoke) {
-            return installCompatFromInternals(internals);
+            const runtime = installCompatFromInternals(internals);
+            return validator(runtime) ? runtime : null;
         }
-        return window.__TAURI__ || null;
+        return validator(window.__TAURI__) ? window.__TAURI__ : null;
     }
 
-    window.__DICOM_VIEWER_TAURI_READY__ = window.__DICOM_VIEWER_TAURI_READY__ || new Promise(resolve => {
-        let attempts = 0;
+    function createReadyPromise(validator) {
+        return new Promise(resolve => {
+            let attempts = 0;
 
-        function finish(runtime) {
-            resolve(runtime || null);
-        }
-
-        function tick() {
-            const runtime = resolveDesktopRuntime();
-            if (runtime) {
-                finish(runtime);
-                return;
+            function finish(runtime) {
+                resolve(runtime || null);
             }
 
-            if (attempts >= MAX_ATTEMPTS) {
-                finish(null);
-                return;
+            function tick() {
+                const runtime = resolveDesktopRuntime(validator);
+                if (runtime) {
+                    finish(runtime);
+                    return;
+                }
+
+                if (attempts >= MAX_ATTEMPTS) {
+                    finish(null);
+                    return;
+                }
+
+                attempts += 1;
+                setTimeout(tick, RETRY_DELAY_MS);
             }
 
-            attempts += 1;
-            setTimeout(tick, RETRY_DELAY_MS);
-        }
+            tick();
+        });
+    }
 
-        tick();
-    });
+    window.__DICOM_VIEWER_TAURI_STORAGE_READY__ = window.__DICOM_VIEWER_TAURI_STORAGE_READY__
+        || createReadyPromise(hasReadyDesktopStorageApis);
 
-    resolveDesktopRuntime();
+    window.__DICOM_VIEWER_TAURI_READY__ = window.__DICOM_VIEWER_TAURI_READY__ || createReadyPromise(hasReadyDesktopApis);
+    resolveDesktopRuntime(hasReadyDesktopStorageApis) || resolveDesktopRuntime();
 })();

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -46,6 +46,24 @@ function joinPaths(...parts) {
 async function installMockDesktop(page, options = {}) {
     await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
     await page.addInitScript((options) => {
+        const FILE_STORAGE_PREFIX = 'mock-desktop-fs:';
+
+        function toByteArray(value) {
+            if (Array.isArray(value)) {
+                return value.map((item) => Number(item) || 0);
+            }
+            if (value && typeof value === 'object') {
+                if (typeof value.length === 'number') {
+                    return Array.from(value, (item) => Number(item) || 0);
+                }
+                return Object.keys(value)
+                    .filter((key) => /^\d+$/.test(key))
+                    .sort((a, b) => Number(a) - Number(b))
+                    .map((key) => Number(value[key]) || 0);
+            }
+            return [];
+        }
+
         function normalizePath(input) {
             const text = String(input || '').replace(/\\/g, '/');
             if (!text) return '';
@@ -96,6 +114,13 @@ async function installMockDesktop(page, options = {}) {
             fileBytes[normalizePath(path)] = value;
         }
 
+        for (const [path, value] of Object.entries(options.storedFiles || {})) {
+            localStorage.setItem(
+                `${FILE_STORAGE_PREFIX}${normalizePath(path)}`,
+                JSON.stringify(toByteArray(value))
+            );
+        }
+
         const readFileFailures = {};
         for (const [path, value] of Object.entries(options.readFileFailures || {})) {
             readFileFailures[normalizePath(path)] = Number(value || 0);
@@ -106,6 +131,12 @@ async function installMockDesktop(page, options = {}) {
                 async invoke(cmd, args) {
                     if (cmd === 'apply_desktop_migration') {
                         return window.__applyMockDesktopMigration(args.db, args.batch, options);
+                    }
+                    if (cmd === 'load_legacy_desktop_browser_stores') {
+                        return options.legacyDesktopStores || [];
+                    }
+                    if (cmd === 'read_scan_manifest') {
+                        return options.nativeScanManifest || null;
                     }
                     throw new Error(`Unhandled core invoke: ${cmd}`);
                 }
@@ -136,8 +167,24 @@ async function installMockDesktop(page, options = {}) {
                         readFileFailures[normalized] = remainingFailures - 1;
                         throw new Error(`Transient read failure: ${normalized}`);
                     }
-                    const bytes = fileBytes[normalized] || [0];
+                    const persisted = localStorage.getItem(`${FILE_STORAGE_PREFIX}${normalized}`);
+                    const bytes = fileBytes[normalized]
+                        || (persisted ? JSON.parse(persisted) : null)
+                        || [0];
                     return Uint8Array.from(bytes);
+                },
+                async writeFile(path, bytes) {
+                    const normalized = normalizePath(path);
+                    localStorage.setItem(
+                        `${FILE_STORAGE_PREFIX}${normalized}`,
+                        JSON.stringify(Array.from(bytes))
+                    );
+                },
+                async mkdir() {
+                    return undefined;
+                },
+                async remove(path) {
+                    localStorage.removeItem(`${FILE_STORAGE_PREFIX}${normalizePath(path)}`);
                 },
                 async stat(path) {
                     const normalized = normalizePath(path);
@@ -157,6 +204,9 @@ async function installMockDesktop(page, options = {}) {
                 }
             },
             path: {
+                async appDataDir() {
+                    return normalizePath(options.appDataDir || '/appdata');
+                },
                 async join(...parts) {
                     return joinPaths(...parts);
                 },
@@ -179,6 +229,199 @@ async function installMockDesktop(page, options = {}) {
 }
 
 test.describe('Desktop library scanning', () => {
+    test('desktop path scan prefers the native manifest when available', async ({ page }) => {
+        await installMockDesktop(page, {
+            nativeScanManifest: [
+                {
+                    path: '/library/image.dcm',
+                    name: 'image.dcm',
+                    rootPath: '/library',
+                    size: 4,
+                    modifiedMs: 1234
+                }
+            ]
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+
+            let readFileCount = 0;
+            window.__TAURI__.fs.readFile = async () => {
+                readFileCount += 1;
+                return Uint8Array.from(dicomBytes);
+            };
+
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            return {
+                studyCount: Object.keys(studies).length,
+                readFileCount
+            };
+        });
+
+        expect(result.studyCount).toBeGreaterThan(0);
+        expect(result.readFileCount).toBe(1);
+    });
+
+    test('desktop path scan reuses cached manifest metadata on repeat scans', async ({ page }) => {
+        await installMockDesktop(page, {
+            nativeScanManifest: [
+                {
+                    path: '/library/image.dcm',
+                    name: 'image.dcm',
+                    rootPath: '/library',
+                    size: 4,
+                    modifiedMs: 1234
+                }
+            ]
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+
+            let readFileCount = 0;
+            window.__TAURI__.fs.readFile = async () => {
+                readFileCount += 1;
+                return Uint8Array.from(dicomBytes);
+            };
+
+            const firstStudies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            const readsAfterFirstScan = readFileCount;
+
+            window.__TAURI__.fs.readFile = async () => {
+                readFileCount += 1;
+                throw new Error('cache miss unexpectedly tried to read the file again');
+            };
+
+            const secondStudies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            return {
+                firstStudyCount: Object.keys(firstStudies).length,
+                secondStudyCount: Object.keys(secondStudies).length,
+                readsAfterFirstScan,
+                readsAfterSecondScan: readFileCount
+            };
+        });
+
+        expect(result.firstStudyCount).toBeGreaterThan(0);
+        expect(result.secondStudyCount).toBe(result.firstStudyCount);
+        expect(result.readsAfterFirstScan).toBe(1);
+        expect(result.readsAfterSecondScan).toBe(1);
+    });
+
+    test('desktop path scan uses DICOMDIR records to skip indexed image header reads', async ({ page }) => {
+        await installMockDesktop(page, {
+            nativeScanManifest: [
+                {
+                    path: '/library/DICOMDIR',
+                    name: 'DICOMDIR',
+                    rootPath: '/library',
+                    size: 128,
+                    modifiedMs: 111
+                },
+                {
+                    path: '/library/images/IMG00001.dcm',
+                    name: 'IMG00001.dcm',
+                    rootPath: '/library',
+                    size: 512,
+                    modifiedMs: 222
+                },
+                {
+                    path: '/library/images/IMG00002.dcm',
+                    name: 'IMG00002.dcm',
+                    rootPath: '/library',
+                    size: 512,
+                    modifiedMs: 333
+                }
+            ]
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const readsByPath = {};
+            window.DicomViewerApp.dicom.parseDicomDirectoryDetailed = async () => ({
+                entries: [
+                    {
+                        source: { kind: 'path', path: '/library/images/IMG00001.dcm' },
+                        meta: {
+                            patientName: 'Patient^Example',
+                            studyDate: '20260322',
+                            studyDescription: 'Indexed Study',
+                            studyInstanceUid: 'study-1',
+                            seriesDescription: 'Series A',
+                            seriesInstanceUid: 'series-1',
+                            seriesNumber: '1',
+                            modality: 'DX',
+                            sopInstanceUid: 'sop-1',
+                            instanceNumber: 1,
+                            sliceLocation: 0
+                        }
+                    },
+                    {
+                        source: { kind: 'path', path: '/library/images/IMG00002.dcm' },
+                        meta: {
+                            patientName: 'Patient^Example',
+                            studyDate: '20260322',
+                            studyDescription: 'Indexed Study',
+                            studyInstanceUid: 'study-1',
+                            seriesDescription: 'Series A',
+                            seriesInstanceUid: 'series-1',
+                            seriesNumber: '1',
+                            modality: 'DX',
+                            sopInstanceUid: 'sop-2',
+                            instanceNumber: 2,
+                            sliceLocation: 0
+                        }
+                    }
+                ],
+                indexedPaths: [
+                    '/library/images/IMG00001.dcm',
+                    '/library/images/IMG00002.dcm'
+                ],
+                error: null
+            });
+
+            window.__TAURI__.fs.readFile = async (path) => {
+                readsByPath[path] = (readsByPath[path] || 0) + 1;
+                return Uint8Array.from([0, 1, 2, 3]);
+            };
+
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            const study = studies['study-1'];
+            return {
+                studyCount: Object.keys(studies).length,
+                imageCount: study?.imageCount || 0,
+                readKeys: Object.keys(readsByPath).sort(),
+                readsByPath
+            };
+        });
+
+        expect(result.studyCount).toBe(1);
+        expect(result.imageCount).toBe(2);
+        expect(result.readKeys).toEqual(['/library/DICOMDIR']);
+        expect(result.readsByPath['/library/DICOMDIR']).toBe(1);
+    });
+
     test('desktop path study scan starts processing before the full tree is materialized', async ({ page }) => {
         const rootEntries = [];
         const nestedEntries = [];
@@ -199,6 +442,7 @@ test.describe('Desktop library scanning', () => {
         rootEntries.push({ name: 'nested', isDirectory: true, isFile: false, isSymlink: false });
 
         await installMockDesktop(page, {
+            readDirDelayMs: 250,
             dirs: {
                 '/library': rootEntries,
                 '/library/nested': nestedEntries
@@ -228,7 +472,7 @@ test.describe('Desktop library scanning', () => {
         });
 
         expect(summary.studyCount).toBe(0);
-        expect(summary.progress.some((entry) => entry.discovered === 128 && entry.processed === 128)).toBe(true);
+        expect(summary.progress.some((entry) => entry.discovered < 130 && entry.processed > 0)).toBe(true);
         expect(summary.progress.at(-1)).toMatchObject({
             discovered: 130,
             processed: 130,
@@ -400,10 +644,10 @@ test.describe('Desktop library scanning', () => {
         const summary = await page.evaluate(async () => {
             const studiesResponse = await fetch('/api/test-data/studies');
             const studiesPayload = await studiesResponse.json();
-            const study = studiesPayload[0];
-            const series = study.series[0];
+            const fixtureStudy = studiesPayload[0];
+            const series = fixtureStudy.series[0];
             const dicomResponse = await fetch(
-                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+                `/api/test-data/dicom/${fixtureStudy.studyInstanceUid}/${series.seriesInstanceUid}/0`
             );
             const blob = await dicomResponse.blob();
 
@@ -1786,6 +2030,117 @@ test.describe('Desktop library scanning', () => {
         await expect(page.locator('#libraryFolderMessage')).toContainText('Loading saved library folder...');
     });
 
+    test('desktop auto-load shows a cached library snapshot while refresh is in flight', async ({ page }) => {
+        const cachedStudies = {
+            '1.2.840.cached.study': {
+                patientName: 'Cached Patient',
+                studyDate: '20260320',
+                studyDescription: 'Cached Study',
+                studyInstanceUid: '1.2.840.cached.study',
+                modality: 'CT',
+                seriesCount: 1,
+                imageCount: 1,
+                comments: [],
+                reports: [],
+                series: {
+                    '1.2.840.cached.series': {
+                        seriesInstanceUid: '1.2.840.cached.series',
+                        seriesDescription: 'Cached Series',
+                        seriesNumber: 1,
+                        modality: 'CT',
+                        comments: [],
+                        slices: [
+                            {
+                                instanceNumber: 1,
+                                sliceLocation: 0,
+                                source: { kind: 'path', path: '/slow-library/image.dcm' }
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+        const snapshotBytes = new TextEncoder().encode(JSON.stringify({
+            version: 1,
+            folder: '/slow-library',
+            savedAt: '2026-03-22T00:00:00.000Z',
+            studies: cachedStudies
+        }));
+
+        await installMockDesktop(page, {
+            initialConfig: {
+                folder: '/slow-library',
+                lastScan: '2026-03-07T12:00:00.000Z'
+            },
+            dirs: {
+                '/slow-library': []
+            },
+            readDirDelayMs: 3000,
+            storedFiles: {
+                '/appdata/desktop-library-cache.json': snapshotBytes
+            }
+        });
+
+        await page.goto(AUTOLOAD_URL);
+        await expect(page.locator('#libraryFolderConfig')).toBeVisible();
+        await expect(page.locator('#libraryFolderInput')).toHaveValue('/slow-library');
+        await expect(page.locator('#studiesBody')).toContainText('Cached Patient');
+    });
+
+    test('desktop library cache round-trips through app data', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studies = {
+                '1.2.840.cached.study': {
+                    patientName: 'Roundtrip Patient',
+                    studyDate: '20260322',
+                    studyDescription: 'Roundtrip Study',
+                    studyInstanceUid: '1.2.840.cached.study',
+                    modality: 'MR',
+                    seriesCount: 1,
+                    imageCount: 1,
+                    comments: [],
+                    reports: [],
+                    series: {
+                        '1.2.840.cached.series': {
+                            seriesInstanceUid: '1.2.840.cached.series',
+                            seriesDescription: 'Roundtrip Series',
+                            seriesNumber: 1,
+                            modality: 'MR',
+                            comments: [],
+                            slices: [
+                                {
+                                    instanceNumber: 1,
+                                    sliceLocation: 0,
+                                    source: { kind: 'path', path: '/library/image.dcm' }
+                                }
+                            ]
+                        }
+                    }
+                }
+            };
+
+            await window.DicomViewerApp.desktopLibrary.saveCachedStudies('/library', studies);
+            const raw = localStorage.getItem('mock-desktop-fs:/appdata/desktop-library-cache.json');
+            return {
+                loaded: await window.DicomViewerApp.desktopLibrary.loadCachedStudies('/library'),
+                mismatch: await window.DicomViewerApp.desktopLibrary.loadCachedStudies('/other-library'),
+                rawText: raw ? new TextDecoder().decode(Uint8Array.from(JSON.parse(raw))) : ''
+            };
+        });
+
+        expect(result.loaded).toEqual(expect.objectContaining({
+            '1.2.840.cached.study': expect.objectContaining({
+                patientName: 'Roundtrip Patient'
+            })
+        }));
+        expect(result.mismatch).toBeNull();
+        expect(result.rawText).toContain('"folder":"/library"');
+    });
+
     test('desktop auto-load does not mark empty folders as a successful scan', async ({ page }) => {
         await installMockDesktop(page, {
             dirs: {
@@ -1884,8 +2239,11 @@ test.describe('Desktop library scanning', () => {
         expect(result.mkdirCalls).toEqual([
             { path: '/appdata/reports', options: { recursive: true } }
         ]);
-        expect(result.writes).toHaveLength(1);
-        expect(result.writes[0].path).toBe('/appdata/reports/scan-timing.json');
+        expect(result.writes).toHaveLength(2);
+        expect(result.writes.map((entry) => entry.path)).toEqual([
+            '/appdata/reports/scan-timing.json',
+            '/appdata/desktop-library-cache.json'
+        ]);
 
         const report = JSON.parse(result.writes[0].text);
         expect(report).toMatchObject({
@@ -1956,7 +2314,8 @@ test.describe('Desktop library scanning', () => {
         expect(result.progress.fullReadMs).toBeUndefined();
         expect(result.progress.parseMs).toBeUndefined();
         expect(result.progress.finalizeMs).toBeUndefined();
-        expect(result.writes).toHaveLength(0);
+        expect(result.writes).toHaveLength(1);
+        expect(result.writes[0].path).toBe('/appdata/desktop-library-cache.json');
     });
 
     test('desktop loadStudies ignores timing report write failures', async ({ page }) => {
@@ -2049,7 +2408,66 @@ test.describe('Desktop library scanning', () => {
         expect(result.fullReads).toBe(0);
     });
 
-    test('desktop path scan falls back to a full read when the header chunk is insufficient', async ({ page }) => {
+    test('desktop path scan falls back for DICM-preamble header misses', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'image.dcm', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studiesResponse = await fetch('/api/test-data/studies');
+            const studiesPayload = await studiesResponse.json();
+            const study = studiesPayload[0];
+            const series = study.series[0];
+            const dicomResponse = await fetch(
+                `/api/test-data/dicom/${study.studyInstanceUid}/${series.seriesInstanceUid}/0`
+            );
+            const dicomBytes = new Uint8Array(await dicomResponse.arrayBuffer());
+            const dicmHeader = new Uint8Array(256 * 1024);
+            dicmHeader[128] = 0x44;
+            dicmHeader[129] = 0x49;
+            dicmHeader[130] = 0x43;
+            dicmHeader[131] = 0x4d;
+
+            let headerReads = 0;
+            let fullReads = 0;
+            window.__TAURI__.core = {
+                async invoke(command, args) {
+                    if (command !== 'read_scan_header') {
+                        throw new Error(`Unexpected command: ${command}`);
+                    }
+                    headerReads++;
+                    return dicmHeader;
+                }
+            };
+            window.__TAURI__.fs.readFile = async () => {
+                fullReads++;
+                return Uint8Array.from(dicomBytes);
+            };
+
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            const firstStudy = Object.values(studies)[0];
+            return {
+                studyCount: Object.keys(studies).length,
+                imageCount: firstStudy?.imageCount || 0,
+                headerReads,
+                fullReads
+            };
+        });
+
+        expect(result.studyCount).toBe(1);
+        expect(result.imageCount).toBe(1);
+        expect(result.headerReads).toBe(2);
+        expect(result.fullReads).toBe(1);
+    });
+
+    test('desktop path scan falls back to a full read after exhausting staged header reads', async ({ page }) => {
         await installMockDesktop(page, {
             dirs: {
                 '/library': [
@@ -2098,7 +2516,7 @@ test.describe('Desktop library scanning', () => {
         });
 
         expect(result.studyCount).toBeGreaterThan(0);
-        expect(result.headerReads).toBe(1);
+        expect(result.headerReads).toBe(2);
         expect(result.fullReads).toBe(1);
     });
 
@@ -2142,6 +2560,103 @@ test.describe('Desktop library scanning', () => {
         expect(result.studyCount).toBe(0);
         expect(result.headerReads).toBe(1);
         expect(result.fullReads).toBe(0);
+    });
+
+    test('desktop path scan skips obvious junk extensions before any header read', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'notes.txt', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            let headerReads = 0;
+            let fullReads = 0;
+
+            window.__TAURI__.core.invoke = async (command) => {
+                if (command === 'read_scan_header') {
+                    headerReads++;
+                    return new Uint8Array(256);
+                }
+                throw new Error(`Unexpected command: ${command}`);
+            };
+            window.__TAURI__.fs.readFile = async () => {
+                fullReads++;
+                return new Uint8Array(256);
+            };
+
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library']);
+            return {
+                studyCount: Object.keys(studies).length,
+                headerReads,
+                fullReads
+            };
+        });
+
+        expect(result.studyCount).toBe(0);
+        expect(result.headerReads).toBe(0);
+        expect(result.fullReads).toBe(0);
+    });
+
+    test('desktop path scan skips known viewer payload directories', async ({ page }) => {
+        await installMockDesktop(page, {
+            dirs: {
+                '/library': [
+                    { name: 'viewer.app', isDirectory: true, isFile: false, isSymlink: false },
+                    { name: 'Libraries', isDirectory: true, isFile: false, isSymlink: false },
+                    { name: 'Reviewer', isDirectory: true, isFile: false, isSymlink: false },
+                    { name: 'Catapult', isDirectory: true, isFile: false, isSymlink: false },
+                    { name: 'ddv', isDirectory: true, isFile: false, isSymlink: false },
+                    { name: 'image.dcm', isDirectory: false, isFile: true, isSymlink: false }
+                ]
+            },
+            fileBytes: {
+                '/library/image.dcm': [1, 2, 3, 4]
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            let headerReads = 0;
+
+            window.__TAURI__.core.invoke = async (command) => {
+                if (command === 'read_scan_header') {
+                    headerReads++;
+                    return new Uint8Array(256);
+                }
+                throw new Error(`Unexpected command: ${command}`);
+            };
+
+            const progress = [];
+            const studies = await window.DicomViewerApp.sources.loadStudiesFromDesktopPaths(['/library'], {
+                onProgress: (stats) => {
+                    progress.push({
+                        discovered: stats.discovered,
+                        processed: stats.processed
+                    });
+                }
+            });
+
+            return {
+                studyCount: Object.keys(studies).length,
+                headerReads,
+                finalProgress: progress.at(-1)
+            };
+        });
+
+        expect(result.studyCount).toBe(0);
+        expect(result.headerReads).toBe(1);
+        expect(result.finalProgress).toEqual({
+            discovered: 1,
+            processed: 1
+        });
     });
 
     test('collectPathSources caps recursion depth and skips symlink paths', async ({ page }) => {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -2030,6 +2030,25 @@ test.describe('Desktop library scanning', () => {
         await expect(page.locator('#libraryFolderMessage')).toContainText('Loading saved library folder...');
     });
 
+    test('desktop library config falls back to the mirrored local config when native storage is unavailable', async ({ page }) => {
+        await installMockDesktop(page, {
+            initialConfig: {
+                folder: '/slow-library',
+                lastScan: '2026-03-07T12:00:00.000Z'
+            },
+            dirs: {
+                '/slow-library': []
+            },
+            readDirDelayMs: 500,
+            sqlLoadError: 'mock desktop sqlite unavailable'
+        });
+
+        await page.goto(AUTOLOAD_URL);
+        await expect(page.locator('#libraryFolderConfig')).toBeVisible();
+        await expect(page.locator('#libraryFolderInput')).toHaveValue('/slow-library');
+        await expect(page.locator('#libraryFolderMessage')).toContainText('Loading saved library folder...');
+    });
+
     test('desktop auto-load shows a cached library snapshot while refresh is in flight', async ({ page }) => {
         const cachedStudies = {
             '1.2.840.cached.study': {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -147,6 +147,13 @@ async function installMockDesktop(page, options = {}) {
                 }
             },
             fs: {
+                async exists(path) {
+                    const normalized = normalizePath(path);
+                    return (
+                        Object.prototype.hasOwnProperty.call(fileBytes, normalized)
+                        || localStorage.getItem(`${FILE_STORAGE_PREFIX}${normalized}`) !== null
+                    );
+                },
                 async readDir(path) {
                     if (readDirDelayMs > 0) {
                         await new Promise((resolve) => setTimeout(resolve, readDirDelayMs));

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -38,6 +38,9 @@ async function installMockTauri(page, options = {}) {
                     if (cmd === 'apply_desktop_migration') {
                         return window.__applyMockDesktopMigration(args.db, args.batch, options);
                     }
+                    if (cmd === 'load_legacy_desktop_browser_stores') {
+                        return options.legacyDesktopStores || [];
+                    }
                     throw new Error(`Unhandled core invoke: ${cmd}`);
                 }
             },
@@ -253,6 +256,87 @@ test.describe('Desktop report persistence', () => {
         expect(persisted.sqlStore.series_notes).toHaveLength(1);
         expect(persisted.sqlStore.comments).toHaveLength(2);
         expect(persisted.sqlStore.reports).toHaveLength(1);
+    });
+
+    test('desktop storage repairs migration from legacy packaged browser stores', async ({ page }) => {
+        const studyUid = '1.2.840.desktop.packaged-legacy.study';
+        const reportId = 'desktop-packaged-legacy-report';
+        const reportPath = `/mock/appdata/reports/${studyUid}/${reportId}.pdf`;
+        const libraryConfig = {
+            folder: '/Users/gabriel/Desktop/radiology all discs',
+            lastScan: '2026-03-20T14:51:37.855Z'
+        };
+
+        await installMockTauri(page, {
+            initialState: {
+                'sqlite:viewer.db': {
+                    study_notes: [],
+                    series_notes: [],
+                    comments: [],
+                    reports: [],
+                    app_config: [
+                        { key: 'desktop_library_config', value: JSON.stringify(libraryConfig), updated_at: 1 },
+                        { key: 'localstorage_migrated', value: '1', updated_at: 1 }
+                    ],
+                    meta: { lastCommentId: 0 }
+                }
+            },
+            legacyDesktopStores: [
+                {
+                    sourcePath: '/Users/gabriel/Library/WebKit/health.divergent.dicomviewer/.../localstorage.sqlite3',
+                    notesJson: JSON.stringify({
+                        studies: {
+                            [studyUid]: {
+                                description: '',
+                                comments: [],
+                                series: {},
+                                reports: [
+                                    {
+                                        id: reportId,
+                                        name: 'Migrated report.pdf',
+                                        type: 'pdf',
+                                        size: 123,
+                                        filePath: reportPath,
+                                        addedAt: 303,
+                                        updatedAt: 404
+                                    }
+                                ]
+                            }
+                        }
+                    }),
+                    libraryConfigJson: JSON.stringify(libraryConfig)
+                }
+            ]
+        });
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const repaired = await page.evaluate(async ({ studyUid, reportId, reportPath }) => {
+            const bytes = new TextEncoder().encode('%PDF-1.4\n%%EOF');
+            localStorage.setItem(`mock-tauri-fs:${reportPath}`, JSON.stringify(Array.from(bytes)));
+
+            await window.NotesAPI.initializeDesktopStorage();
+
+            const notes = await window.NotesAPI.loadNotes([studyUid]);
+            const sqlStore = JSON.parse(localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}');
+
+            return {
+                notes,
+                reportUrl: window.NotesAPI.getReportFileUrl(reportId),
+                sqlStore
+            };
+        }, { studyUid, reportId, reportPath });
+
+        expect(repaired.notes.studies[studyUid].reports).toHaveLength(1);
+        expect(repaired.notes.studies[studyUid].reports[0].filePath).toBe(reportPath);
+        expect(repaired.reportUrl).toBe(`asset://local/${encodeURIComponent(reportPath)}`);
+        expect(repaired.sqlStore.reports).toHaveLength(1);
+        expect(repaired.sqlStore.app_config).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ key: 'localstorage_migrated', value: '1' }),
+                expect.objectContaining({ key: 'legacy_desktop_browser_store_migrated', value: '1' })
+            ])
+        );
     });
 
     test('desktop backend persists report files and metadata across reloads', async ({ page }) => {

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -11,6 +11,7 @@ async function installMockTauri(page, options = {}) {
     await page.addInitScript((options) => {
         const FILE_STORAGE_PREFIX = 'mock-tauri-fs:';
         const failRemoveAll = !!options.failRemoveAll;
+        const failWritePatterns = Array.isArray(options.failWritePatterns) ? options.failWritePatterns : [];
 
         function joinPaths(...parts) {
             const cleaned = parts
@@ -66,6 +67,9 @@ async function installMockTauri(page, options = {}) {
                     localStorage.removeItem(`${FILE_STORAGE_PREFIX}${fromPath}`);
                 },
                 async writeFile(filePath, bytes) {
+                    if (failWritePatterns.some((pattern) => String(filePath).includes(String(pattern)))) {
+                        throw new Error(`Mock write failure for ${filePath}`);
+                    }
                     localStorage.setItem(
                         `${FILE_STORAGE_PREFIX}${filePath}`,
                         JSON.stringify(Array.from(bytes))
@@ -337,6 +341,147 @@ test.describe('Desktop report persistence', () => {
                 expect.objectContaining({ key: 'legacy_desktop_browser_store_migrated', value: '1' })
             ])
         );
+    });
+
+    test('desktop legacy blob migration continues after an individual report import fails', async ({ page }) => {
+        const studyUid = '1.2.840.desktop.legacy-blob-failure.study';
+        const failedReportId = 'desktop-legacy-report-fail';
+        const goodReportId = 'desktop-legacy-report-good';
+
+        await installMockTauri(page, {
+            failWritePatterns: [failedReportId]
+        });
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async ({ studyUid, failedReportId, goodReportId }) => {
+            const failedBytes = new TextEncoder().encode('%PDF-1.4\nfailed');
+            const goodBytes = new TextEncoder().encode('%PDF-1.4\ngood');
+
+            localStorage.setItem('dicom-viewer-comments', JSON.stringify({
+                version: 2,
+                comments: {
+                    [studyUid]: {
+                        reports: [
+                            { id: failedReportId, name: 'failed.pdf', type: 'pdf', size: failedBytes.length },
+                            { id: goodReportId, name: 'good.pdf', type: 'pdf', size: goodBytes.length }
+                        ]
+                    }
+                }
+            }));
+
+            const request = indexedDB.open('dicom-viewer-reports', 1);
+            await new Promise((resolve, reject) => {
+                request.onupgradeneeded = () => {
+                    request.result.createObjectStore('reports', { keyPath: 'id' });
+                };
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => resolve();
+            });
+            const db = request.result;
+            await new Promise((resolve, reject) => {
+                const tx = db.transaction('reports', 'readwrite');
+                const store = tx.objectStore('reports');
+                store.put({ id: failedReportId, blob: new Blob([failedBytes], { type: 'application/pdf' }) });
+                store.put({ id: goodReportId, blob: new Blob([goodBytes], { type: 'application/pdf' }) });
+                tx.oncomplete = () => resolve();
+                tx.onerror = () => reject(tx.error);
+                tx.onabort = () => reject(tx.error);
+            });
+            db.close();
+
+            await window.NotesAPI.initializeDesktopStorage();
+
+            const notes = await window.NotesAPI.loadNotes([studyUid]);
+            const sqlStore = JSON.parse(localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}');
+            return {
+                notes,
+                sqlStore
+            };
+        }, { studyUid, failedReportId, goodReportId });
+
+        expect(result.notes.studies[studyUid].reports.map((entry) => entry.id)).toEqual([goodReportId]);
+        expect(result.sqlStore.reports.map((entry) => entry.id)).toEqual([goodReportId]);
+        expect(result.sqlStore.app_config).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ key: 'localstorage_migrated', value: '1' })
+            ])
+        );
+    });
+
+    test('desktop legacy packaged store migration prefers the newest browser profile data', async ({ page }) => {
+        const olderConfig = {
+            folder: '/Users/gabriel/Desktop/older-library',
+            lastScan: '2026-03-20T14:51:37.855Z'
+        };
+        const newerConfig = {
+            folder: '/Users/gabriel/Desktop/radiology all discs',
+            lastScan: '2026-03-22T10:00:00.000Z'
+        };
+
+        await installMockTauri(page, {
+            legacyDesktopStores: [
+                {
+                    sourcePath: '/Users/gabriel/Library/WebKit/zzz/localstorage.sqlite3',
+                    modifiedMs: 10,
+                    notesJson: JSON.stringify({ studies: {} }),
+                    libraryConfigJson: JSON.stringify(olderConfig)
+                },
+                {
+                    sourcePath: '/Users/gabriel/Library/WebKit/aaa/localstorage.sqlite3',
+                    modifiedMs: 20,
+                    notesJson: JSON.stringify({ studies: {} }),
+                    libraryConfigJson: JSON.stringify(newerConfig)
+                }
+            ]
+        });
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const migratedConfig = await page.evaluate(async () => {
+            await window.NotesAPI.initializeDesktopStorage();
+            return await window.NotesAPI.loadDesktopLibraryConfig();
+        });
+
+        expect(migratedConfig).toEqual(newerConfig);
+    });
+
+    test('desktop sqlite init backs off repeated failures before retrying', async ({ page }) => {
+        await installMockTauri(page, {
+            sqlLoadError: 'mock desktop sqlite unavailable'
+        });
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const loadCalls = await page.evaluate(async () => {
+            const key = 'mock-tauri-sql-load-calls:sqlite:viewer.db';
+            const initial = Number(localStorage.getItem(key) || '0');
+            const realNow = Date.now;
+            let now = realNow();
+            Date.now = () => now;
+
+            try {
+                for (let index = 0; index < 3; index += 1) {
+                    try {
+                        await window.NotesAPI.initializeDesktopStorage();
+                    } catch {}
+                }
+                const withinBackoff = Number(localStorage.getItem(key) || '0') - initial;
+
+                now += 6000;
+                try {
+                    await window.NotesAPI.initializeDesktopStorage();
+                } catch {}
+                const afterRetry = Number(localStorage.getItem(key) || '0') - initial;
+
+                return { withinBackoff, afterRetry };
+            } finally {
+                Date.now = realNow;
+            }
+        });
+
+        expect(loadCalls.withinBackoff).toBe(1);
+        expect(loadCalls.afterRetry).toBe(2);
     });
 
     test('desktop backend persists report files and metadata across reloads', async ({ page }) => {

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -98,6 +98,8 @@ async function installMockTauriInternals(page) {
                         return window.__handleMockTauriSqlCommand(cmd, args);
                     case 'apply_desktop_migration':
                         return window.__applyMockDesktopMigration(args.db, args.batch);
+                    case 'load_legacy_desktop_browser_stores':
+                        return [];
                     default:
                         throw new Error(`Unhandled command: ${cmd}`);
                 }
@@ -248,6 +250,8 @@ test('tauri runtime shim installs when internals arrive after the script loads',
                             return window.__handleMockTauriSqlCommand(cmd, args);
                         case 'apply_desktop_migration':
                             return window.__applyMockDesktopMigration(args.db, args.batch);
+                        case 'load_legacy_desktop_browser_stores':
+                            return [];
                         default:
                             throw new Error(`Unhandled command: ${cmd}`);
                     }

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -389,6 +389,132 @@ test('desktop runtime shim augments a partial global Tauri object', async ({ pag
     expect(result.hasSqlApi).toBe(true);
 });
 
+test('desktop runtime ready promise waits for a partial global Tauri object to finish initializing', async ({ page }) => {
+    await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
+    await page.addInitScript(() => {
+        window.__TAURI__ = {
+            core: {
+                invoke() {
+                    return Promise.resolve('native-invoke');
+                }
+            }
+        };
+
+        setTimeout(() => {
+            window.__TAURI__.dialog = {
+                async open() {
+                    return null;
+                }
+            };
+            window.__TAURI__.fs = {
+                async readDir() {
+                    return [];
+                }
+            };
+            window.__TAURI__.path = {
+                async appDataDir() {
+                    return '/mock/appdata';
+                }
+            };
+            window.__TAURI__.sql = window.__createMockTauriSql();
+            window.__TAURI__.webview = {
+                getCurrentWebview() {
+                    return {
+                        onDragDropEvent() {
+                            return Promise.resolve(() => {});
+                        }
+                    };
+                }
+            };
+        }, 150);
+    });
+
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const settledEarly = await Promise.race([
+            window.__DICOM_VIEWER_TAURI_READY__.then(() => true),
+            new Promise((resolve) => setTimeout(() => resolve(false), 25))
+        ]);
+        const runtime = await window.__DICOM_VIEWER_TAURI_READY__;
+        return {
+            settledEarly,
+            hasDialogApi: typeof runtime?.dialog?.open === 'function',
+            hasFsApi: typeof runtime?.fs?.readDir === 'function',
+            hasPathApi: typeof runtime?.path?.appDataDir === 'function',
+            hasSqlApi: typeof runtime?.sql?.load === 'function'
+        };
+    });
+
+    expect(result.settledEarly).toBe(false);
+    expect(result.hasDialogApi).toBe(true);
+    expect(result.hasFsApi).toBe(true);
+    expect(result.hasPathApi).toBe(true);
+    expect(result.hasSqlApi).toBe(true);
+});
+
+test('desktop storage ready promise resolves before the full desktop shell is available', async ({ page }) => {
+    await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
+    await page.addInitScript(() => {
+        window.__TAURI__ = {
+            core: {
+                invoke() {
+                    return Promise.resolve('native-invoke');
+                }
+            },
+            fs: {
+                async exists() {
+                    return false;
+                },
+                async remove() {
+                    return null;
+                },
+                async rename() {
+                    return null;
+                },
+                async writeFile() {
+                    return null;
+                }
+            },
+            path: {
+                async appDataDir() {
+                    return '/mock/appdata';
+                },
+                async join(...parts) {
+                    return parts.join('/');
+                }
+            },
+            sql: window.__createMockTauriSql()
+        };
+    });
+
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const storageRuntime = await window.__DICOM_VIEWER_TAURI_STORAGE_READY__;
+        const fullSettledEarly = await Promise.race([
+            window.__DICOM_VIEWER_TAURI_READY__.then(() => true),
+            new Promise((resolve) => setTimeout(() => resolve(false), 25))
+        ]);
+
+        return {
+            hasStorageReadyPromise: typeof window.__DICOM_VIEWER_TAURI_STORAGE_READY__?.then === 'function',
+            hasCoreInvoke: typeof storageRuntime?.core?.invoke === 'function',
+            hasFsWriteFile: typeof storageRuntime?.fs?.writeFile === 'function',
+            hasPathJoin: typeof storageRuntime?.path?.join === 'function',
+            hasSqlApi: typeof storageRuntime?.sql?.load === 'function',
+            fullSettledEarly
+        };
+    });
+
+    expect(result.hasStorageReadyPromise).toBe(true);
+    expect(result.hasCoreInvoke).toBe(true);
+    expect(result.hasFsWriteFile).toBe(true);
+    expect(result.hasPathJoin).toBe(true);
+    expect(result.hasSqlApi).toBe(true);
+    expect(result.fullSettledEarly).toBe(false);
+});
+
 test('OpenJPEG asset URL resolves when the decoder bundle is worker-loaded', async ({ page }) => {
     await page.goto('http://127.0.0.1:5001/?nolib');
 

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -284,6 +284,111 @@ test('tauri runtime shim installs when internals arrive after the script loads',
     expect(result.hasFsApi).toBe(true);
 });
 
+test('desktop runtime shim augments a partial global Tauri object', async ({ page }) => {
+    await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
+    await page.addInitScript(() => {
+        window.__TAURI__ = {
+            core: {
+                invoke() {
+                    return Promise.resolve('native-invoke');
+                }
+            }
+        };
+
+        window.__TAURI_INTERNALS__ = {
+            metadata: {
+                currentWindow: { label: 'main' },
+                currentWebview: { label: 'main', windowLabel: 'main' }
+            },
+            convertFileSrc(filePath, protocol = 'asset') {
+                return `${protocol}://localhost/${encodeURIComponent(filePath)}`;
+            },
+            transformCallback(callback) {
+                return callback;
+            },
+            unregisterCallback() {},
+            async invoke(cmd, args) {
+                switch (cmd) {
+                    case 'plugin:dialog|open':
+                        return null;
+                    case 'plugin:event|listen':
+                    case 'plugin:event|unlisten':
+                        return null;
+                    case 'plugin:fs|exists':
+                        return false;
+                    case 'plugin:fs|mkdir':
+                    case 'plugin:fs|rename':
+                    case 'plugin:fs|remove':
+                        return null;
+                    case 'plugin:fs|read_dir':
+                        return [];
+                    case 'plugin:fs|read_file':
+                        return new Uint8Array([0]);
+                    case 'plugin:fs|stat':
+                        return {
+                            isFile: false,
+                            isDirectory: true,
+                            isSymlink: false,
+                            size: 0,
+                            mtime: null,
+                            atime: null,
+                            birthtime: null,
+                            readonly: false,
+                            fileAttributes: null,
+                            dev: null,
+                            ino: null,
+                            mode: null,
+                            nlink: null,
+                            uid: null,
+                            gid: null,
+                            rdev: null,
+                            blksize: null,
+                            blocks: null
+                        };
+                    case 'plugin:fs|write_file':
+                        return null;
+                    case 'plugin:path|resolve_directory':
+                        return '/mock/appdata';
+                    case 'plugin:path|join':
+                        return args.paths.join('/');
+                    case 'plugin:path|normalize':
+                        return args.path;
+                    case 'plugin:sql|load':
+                    case 'plugin:sql|select':
+                    case 'plugin:sql|execute':
+                    case 'plugin:sql|close':
+                        return window.__handleMockTauriSqlCommand(cmd, args);
+                    case 'apply_desktop_migration':
+                        return window.__applyMockDesktopMigration(args.db, args.batch);
+                    case 'load_legacy_desktop_browser_stores':
+                        return [];
+                    default:
+                        throw new Error(`Unhandled command: ${cmd}`);
+                }
+            }
+        };
+    });
+
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const runtime = await window.__DICOM_VIEWER_TAURI_READY__;
+        return {
+            preservedCoreInvoke: await runtime.core.invoke('ignored'),
+            hasDialogApi: typeof runtime?.dialog?.open === 'function',
+            hasFsApi: typeof runtime?.fs?.readDir === 'function',
+            hasPathApi: typeof runtime?.path?.appDataDir === 'function',
+            hasSqlApi: typeof runtime?.sql?.load === 'function'
+        };
+    });
+
+    expect(result.preservedCoreInvoke).toBe('native-invoke');
+    expect(result.hasDialogApi).toBe(true);
+    expect(result.hasFsApi).toBe(true);
+    expect(result.hasPathApi).toBe(true);
+    expect(result.hasSqlApi).toBe(true);
+});
+
 test('OpenJPEG asset URL resolves when the decoder bundle is worker-loaded', async ({ page }) => {
     await page.goto('http://127.0.0.1:5001/?nolib');
 

--- a/tests/mock-tauri-sql-init.js
+++ b/tests/mock-tauri-sql-init.js
@@ -452,6 +452,9 @@
     window.__createMockTauriSql = function createMockTauriSql(options = {}) {
         return {
             async load(db) {
+                if (options.sqlLoadError) {
+                    throw new Error(options.sqlLoadError);
+                }
                 loadState(db, options);
                 return makeConnection(db, options);
             }

--- a/tests/mock-tauri-sql-init.js
+++ b/tests/mock-tauri-sql-init.js
@@ -16,6 +16,7 @@
             comments: [],
             reports: [],
             app_config: [],
+            desktop_scan_cache: [],
             meta: {
                 lastCommentId: 0
             }
@@ -30,12 +31,29 @@
         const storageKey = createStorageKey(db);
         const raw = localStorage.getItem(storageKey);
         if (raw) {
-            return safeParse(raw, createEmptyDbState());
+            return hydrateState(safeParse(raw, createEmptyDbState()));
         }
         const initial = options?.initialState?.[db];
-        const state = initial ? clone(initial) : createEmptyDbState();
+        const state = hydrateState(initial ? clone(initial) : createEmptyDbState());
         persistState(db, state);
         return state;
+    }
+
+    function hydrateState(state) {
+        const normalized = state && typeof state === 'object' ? state : createEmptyDbState();
+        if (!Array.isArray(normalized.study_notes)) normalized.study_notes = [];
+        if (!Array.isArray(normalized.series_notes)) normalized.series_notes = [];
+        if (!Array.isArray(normalized.comments)) normalized.comments = [];
+        if (!Array.isArray(normalized.reports)) normalized.reports = [];
+        if (!Array.isArray(normalized.app_config)) normalized.app_config = [];
+        if (!Array.isArray(normalized.desktop_scan_cache)) normalized.desktop_scan_cache = [];
+        if (!normalized.meta || typeof normalized.meta !== 'object') {
+            normalized.meta = { lastCommentId: 0 };
+        }
+        if (!Number.isFinite(Number(normalized.meta.lastCommentId))) {
+            normalized.meta.lastCommentId = 0;
+        }
+        return normalized;
     }
 
     function persistState(db, state) {
@@ -237,6 +255,45 @@
                     return { rowsAffected: 1, lastInsertId: null };
                 }
 
+                if (normalized.startsWith('insert into desktop_scan_cache')) {
+                    const stride = 8;
+                    for (let index = 0; index < values.length; index += stride) {
+                        const [
+                            path,
+                            rootPath,
+                            size,
+                            modifiedMs,
+                            scannerVersion,
+                            renderable,
+                            metaJson,
+                            updatedAt
+                        ] = values.slice(index, index + stride);
+                        const existing = state.desktop_scan_cache.find((row) => row.path === path);
+                        if (existing) {
+                            existing.root_path = rootPath;
+                            existing.size = size;
+                            existing.modified_ms = modifiedMs;
+                            existing.scanner_version = scannerVersion;
+                            existing.renderable = renderable;
+                            existing.meta_json = metaJson;
+                            existing.updated_at = updatedAt;
+                        } else {
+                            state.desktop_scan_cache.push({
+                                path,
+                                root_path: rootPath,
+                                size,
+                                modified_ms: modifiedMs,
+                                scanner_version: scannerVersion,
+                                renderable,
+                                meta_json: metaJson,
+                                updated_at: updatedAt
+                            });
+                        }
+                    }
+                    persistState(db, state);
+                    return { rowsAffected: values.length / stride, lastInsertId: null };
+                }
+
                 throw new Error(`Unhandled mock SQL execute: ${query}`);
             },
 
@@ -309,6 +366,20 @@
                         (entry) => String(entry.id) === String(id) && entry.study_uid === studyUid
                     );
                     return row ? [{ file_path: row.file_path }] : [];
+                }
+
+                if (normalized.startsWith('select path, size, modified_ms, renderable, meta_json from desktop_scan_cache where root_path in')) {
+                    const scannerVersion = Number(values[values.length - 1]);
+                    const roots = new Set(values.slice(0, -1));
+                    return state.desktop_scan_cache
+                        .filter((row) => roots.has(row.root_path) && Number(row.scanner_version) === scannerVersion)
+                        .map((row) => ({
+                            path: row.path,
+                            size: row.size,
+                            modified_ms: row.modified_ms,
+                            renderable: row.renderable,
+                            meta_json: row.meta_json
+                        }));
                 }
 
                 throw new Error(`Unhandled mock SQL select: ${query}`);

--- a/tests/mock-tauri-sql-init.js
+++ b/tests/mock-tauri-sql-init.js
@@ -18,7 +18,8 @@
             app_config: [],
             desktop_scan_cache: [],
             meta: {
-                lastCommentId: 0
+                lastCommentId: 0,
+                loadCalls: 0
             }
         };
     }
@@ -48,10 +49,13 @@
         if (!Array.isArray(normalized.app_config)) normalized.app_config = [];
         if (!Array.isArray(normalized.desktop_scan_cache)) normalized.desktop_scan_cache = [];
         if (!normalized.meta || typeof normalized.meta !== 'object') {
-            normalized.meta = { lastCommentId: 0 };
+            normalized.meta = { lastCommentId: 0, loadCalls: 0 };
         }
         if (!Number.isFinite(Number(normalized.meta.lastCommentId))) {
             normalized.meta.lastCommentId = 0;
+        }
+        if (!Number.isFinite(Number(normalized.meta.loadCalls))) {
+            normalized.meta.loadCalls = 0;
         }
         return normalized;
     }
@@ -452,10 +456,15 @@
     window.__createMockTauriSql = function createMockTauriSql(options = {}) {
         return {
             async load(db) {
+                const loadKey = `mock-tauri-sql-load-calls:${db}`;
+                const previousCalls = Number(localStorage.getItem(loadKey) || '0');
+                localStorage.setItem(loadKey, String(previousCalls + 1));
                 if (options.sqlLoadError) {
                     throw new Error(options.sqlLoadError);
                 }
-                loadState(db, options);
+                const state = loadState(db, options);
+                state.meta.loadCalls += 1;
+                persistState(db, state);
                 return makeConnection(db, options);
             }
         };


### PR DESCRIPTION
## Summary
- speed up desktop library scans with a native recursive manifest reader and persisted scan cache reuse
- render cached desktop library snapshots before refresh and keep diagnostics/report persistence compatible with the native desktop store
- add a DICOMDIR-first scan path so indexed media can build studies without per-file header reads

## Verification
- cargo test --manifest-path desktop/src-tauri/Cargo.toml scan::tests::
- cargo test --manifest-path desktop/src-tauri/Cargo.toml read_scan_header_impl
- npx playwright test tests/desktop-library.spec.js tests/desktop-runtime-compat.spec.js tests/desktop-report-persistence.spec.js