### PR TITLE
Fix phantom study creation for report tombstones

### DIFF
--- a/docs/js/app/sync-engine.js
+++ b/docs/js/app/sync-engine.js
@@ -577,21 +577,30 @@ const _SyncEngine = (() => {
                 const studyUid = data.study_uid;
                 if (!studyUid) return;
                 const deletedAt = data.deletedAt || data.deleted_at || null;
-
-                const studyEntry = ensureStudy(store, studyUid);
                 const { normalizeReportId } = window._NotesInternals;
                 const targetId = normalizeReportId(recordKey);
+
+                if (deletedAt) {
+                    // Remote tombstone -- only act if study and report exist locally
+                    const existingStudy = store.studies[studyUid];
+                    if (!existingStudy) return;
+                    const idx = existingStudy.reports.findIndex(
+                        r => normalizeReportId(r?.id) === targetId
+                    );
+                    if (idx !== -1) {
+                        existingStudy.reports[idx].deletedAt = deletedAt;
+                        existingStudy.reports[idx].sync_version = syncVersion;
+                        saveStore(store);
+                    }
+                    return;
+                }
+
+                const studyEntry = ensureStudy(store, studyUid);
                 const existingIdx = studyEntry.reports.findIndex(
                     r => normalizeReportId(r?.id) === targetId
                 );
 
-                if (deletedAt) {
-                    // Remote tombstone
-                    if (existingIdx !== -1) {
-                        studyEntry.reports[existingIdx].deletedAt = deletedAt;
-                        studyEntry.reports[existingIdx].sync_version = syncVersion;
-                    }
-                } else if (existingIdx !== -1) {
+                if (existingIdx !== -1) {
                     // Update existing report metadata
                     const report = studyEntry.reports[existingIdx];
                     if (data.name !== undefined) report.name = data.name;


### PR DESCRIPTION
## Summary

- Remote tombstone for a report on an unknown study no longer creates a phantom empty study entry
- Mirrors the same guard already applied to comments tombstones in PR #42

## Root cause

`_applyRemoteData` in the reports branch called `ensureStudy(store, studyUid)` unconditionally before checking `deletedAt`. A remote tombstone for an unknown study created an empty study entry via `ensureStudy` + `saveStore`.

## Fix

Check `store.studies[studyUid]` exists before acting on tombstones. If the study doesn't exist locally, return early. `ensureStudy` is only called for non-tombstone operations (updates and inserts).

## Test plan

- [ ] `npx playwright test` -- full suite, no exclusions
- [ ] Verify no phantom studies created when processing remote report tombstones for unknown studies

Generated with [Claude Code](https://claude.com/claude-code)