### PR TITLE
tooling: add managed desktop launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,18 @@ For the full beginner explanation of why this workflow exists:
 
 - `docs/AGENT_WORKTREES_EXPLAINER.md`
 - `docs/RESEARCH_POLICY.md`
+
+---
+
+## Desktop Launch
+
+When you need the desktop app in an agent worktree, prefer the managed launcher:
+
+```bash
+npm run desktop:launch
+```
+
+This starts the `docs/` dev server and the desktop binary in one process and is
+more reliable than `npx tauri dev` in this repo. In particular, it can clear a
+stale port `1420` `dev:web` server when no desktop app is running, which avoids
+the repeated `Address already in use` failure mode we have hit in prior sessions.

--- a/README.md
+++ b/README.md
@@ -61,12 +61,20 @@ Open `http://localhost:5001` in Chrome or Edge.
 ### Option 3: Tauri desktop shell (desktop development)
 
 ```bash
-cd dicom-viewer/desktop
-npm install
-npx tauri dev
+cd dicom-viewer
+npm run desktop:launch
 ```
 
-This runs the desktop shell against the current `docs/` source and is the fastest way to verify desktop-only behavior while iterating.
+This is the preferred desktop dev launcher. It starts the static `docs/` server, auto-clears a stale port `1420` dev server when no desktop app is running, launches the Rust desktop binary directly, and cleans up the helper server when the session exits.
+
+If you prefer to run from inside `desktop/`, use:
+
+```bash
+cd dicom-viewer/desktop
+npm run dev:desktop
+```
+
+`npx tauri dev` still works for some workflows, but this repo's managed launcher is more reliable after failed startups because it avoids leaving orphaned `dev:web` listeners behind.
 
 ### Option 4: Build the packaged desktop app
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,6 +5,7 @@
   "description": "Tauri desktop shell for DICOM Viewer",
   "scripts": {
     "build:plain-dmg": "./scripts/build-plain-dmg.sh",
+    "dev:desktop": "./scripts/dev-desktop.sh",
     "dev:web": "python3 -m http.server 1420 --bind 127.0.0.1 --directory ../docs",
     "tauri": "tauri"
   },

--- a/desktop/scripts/dev-desktop.sh
+++ b/desktop/scripts/dev-desktop.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DESKTOP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOCS_DIR="$(cd "${DESKTOP_DIR}/../docs" && pwd)"
+DEV_HOST="${DICOM_DESKTOP_DEV_HOST:-127.0.0.1}"
+DEV_PORT="${DICOM_DESKTOP_DEV_PORT:-1420}"
+DEV_URL="http://${DEV_HOST}:${DEV_PORT}/"
+WEB_SERVER_PID=""
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+listener_pid_for_dev_port() {
+    lsof -tiTCP:"${DEV_PORT}" -sTCP:LISTEN -n -P 2>/dev/null | head -n 1
+}
+
+desktop_binary_running() {
+    pgrep -f "${DESKTOP_DIR}/src-tauri/target/debug/dicom-viewer-desktop" >/dev/null 2>&1
+}
+
+listener_command() {
+    local pid="$1"
+    ps -p "$pid" -o command= 2>/dev/null || true
+}
+
+clear_stale_dev_server_if_needed() {
+    local pid command
+    pid="$(listener_pid_for_dev_port || true)"
+    if [[ -z "$pid" ]]; then
+        return 0
+    fi
+
+    command="$(listener_command "$pid")"
+
+    if desktop_binary_running; then
+        echo "Port ${DEV_PORT} is already in use while the desktop app is running." >&2
+        echo "Reuse the existing session or stop it before starting a new one." >&2
+        exit 1
+    fi
+
+    if [[ "$command" == *"python"* ]] && [[ "$command" == *"http.server ${DEV_PORT}"* ]] && (
+        [[ "$command" == *"--directory ${DOCS_DIR}"* ]] || [[ "$command" == *"--directory ../docs"* ]]
+    ); then
+        echo "Clearing stale desktop dev web server on ${DEV_HOST}:${DEV_PORT}..."
+        kill "$pid"
+        wait_for_port_to_clear
+        return 0
+    fi
+
+    echo "Port ${DEV_PORT} is already in use by another process:" >&2
+    echo "  ${command}" >&2
+    echo "Stop that process or set DICOM_DESKTOP_DEV_PORT to a different port." >&2
+    exit 1
+}
+
+wait_for_port_to_clear() {
+    local attempts=50
+    while [[ $attempts -gt 0 ]]; do
+        if [[ -z "$(listener_pid_for_dev_port || true)" ]]; then
+            return 0
+        fi
+        sleep 0.1
+        attempts=$((attempts - 1))
+    done
+
+    echo "Timed out waiting for port ${DEV_PORT} to clear." >&2
+    exit 1
+}
+
+wait_for_dev_server() {
+    local attempts=50
+    while [[ $attempts -gt 0 ]]; do
+        if curl --silent --fail --output /dev/null "${DEV_URL}"; then
+            return 0
+        fi
+        sleep 0.1
+        attempts=$((attempts - 1))
+    done
+
+    echo "Timed out waiting for desktop dev server at ${DEV_URL}." >&2
+    exit 1
+}
+
+cleanup() {
+    if [[ -n "$WEB_SERVER_PID" ]] && kill -0 "$WEB_SERVER_PID" >/dev/null 2>&1; then
+        kill "$WEB_SERVER_PID" >/dev/null 2>&1 || true
+        wait "$WEB_SERVER_PID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT INT TERM
+
+require_command python3
+require_command cargo
+require_command curl
+require_command lsof
+require_command pgrep
+
+clear_stale_dev_server_if_needed
+
+cd "$DESKTOP_DIR"
+python3 -m http.server "$DEV_PORT" --bind "$DEV_HOST" --directory "$DOCS_DIR" &
+WEB_SERVER_PID="$!"
+
+echo "Serving docs/ at ${DEV_URL}"
+wait_for_dev_server
+
+echo "Launching desktop app..."
+cargo run --manifest-path src-tauri/Cargo.toml --no-default-features --color always -- "$@"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A web-based DICOM medical imaging viewer (CT, MRI, etc.) with client-side processing for privacy. Supports JPEG Lossless, JPEG 2000, and uncompressed formats via browser-based decoders. Built with vanilla JS frontend and Flask backend for static serving. See docs/CLAUDE.md for architecture details.",
   "main": "app.py",
   "scripts": {
+    "desktop:launch": "cd desktop && npm run dev:desktop",
     "test": "npx playwright test",
     "worktree:new": "./scripts/agent-worktree-new.sh",
     "worktree:list": "./scripts/agent-worktree-list.sh",


### PR DESCRIPTION
## Summary
- add a managed desktop dev launcher that starts the docs server and desktop binary together
- clear stale repo-style dev servers on port 1420 when no desktop app is running
- document the preferred launcher path in the README and AGENTS instructions

## Verification
- bash -n desktop/scripts/dev-desktop.sh
- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('desktop/package.json','utf8'));"
- npm run desktop:launch
- confirmed Ctrl-C shuts down the desktop binary and frees port 1420