### PR TITLE
docs: ADR 007, research, and Divergent Central Guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,18 @@ Tauri Desktop Shell (desktop/src-tauri/)
 └── Shared web core loaded from docs/
 ```
 
+## Domain Separation: Imaging vs. Annotations
+
+The system has two fundamentally different data domains. They share infrastructure where convenient, but they are not the same thing and must not be coupled.
+
+**Imaging** -- DICOM files, pixel data, study/series/slice organization, transfer syntaxes, decoders, rendering. This is the core viewer pipeline. It deals with large, immutable binary objects that are read-heavy and write-once.
+
+**Annotations** -- notes, comments, reports, measurements, labels. These are lightweight, mutable, user-generated metadata layered on top of imaging. They are keyed by DICOM UIDs but have their own lifecycle (created, edited, deleted, synced).
+
+These two domains have different storage characteristics, different sync requirements, different performance profiles, and different compliance implications. In a company context, they would be owned by different engineering teams. Design decisions, APIs, persistence layers, and sync protocols should respect this boundary. Shared infrastructure (SQLite, content hashing, UID-based identity) is fine, but the domains should not depend on each other's internals or assume they will always be co-located.
+
+When in doubt, ask: "Is this about the imaging pipeline or the annotation layer?" and keep the answer in its own lane.
+
 ## Key Files
 
 - `docs/index.html` - Main SPA with all client-side logic

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dicom-viewer-desktop"
 version = "0.1.0"
 description = "Tauri desktop shell for DICOM Viewer"
-authors = ["Gabriel Casalduc <rgc@alumni.stanford.edu>"]
+authors = ["Gabriel Casalduc <gabriel@divergent.health>"]
 license = "MIT"
 edition = "2021"
 rust-version = "1.77.2"

--- a/docs/DIVERGENT_CENTRAL_GUIDE.md
+++ b/docs/DIVERGENT_CENTRAL_GUIDE.md
@@ -1,0 +1,228 @@
+<!--
+  Divergent Central Guide
+  The canonical document for Divergent Health Technologies.
+  Product vision, architecture, history, and roadmap.
+
+  Copyright (c) 2026 Divergent Health Technologies
+  https://divergent.health/
+-->
+
+# Divergent Central Guide
+
+This is the central reference document for Divergent Health Technologies and its product, the DICOM Medical Imaging Viewer. It ties together product vision, technical architecture, history, and roadmap. Everything else -- ADRs, research docs, planning files -- branches off from here.
+
+For navigating project documentation, see [INDEX.md](INDEX.md).
+For architecture decision records, see [docs/decisions/](decisions/).
+
+---
+
+## What We're Building
+
+A medical imaging viewer that works like a photo library. Users collect their imaging -- CT scans, MRIs, X-rays -- from hospitals, CDs, downloads, wherever it comes from, into one place. View it, annotate it, keep it. Eventually, sync it across devices and access it from anywhere.
+
+The product starts as a desktop app and grows into a cloud platform.
+
+### Who It's For
+
+Today: individuals who want to view and organize their own medical imaging. Patients who get CDs from hospitals. Physicians reviewing outside studies. Researchers working with DICOM datasets.
+
+Tomorrow: the same people, plus teams who need to share and collaborate on imaging. The cloud platform enables this.
+
+### What Makes It Different
+
+- **You own your data.** Imaging stays on your machine (desktop) or in your account (cloud). No vendor lock-in on the data itself.
+- **It works offline.** The desktop app is fully functional without an internet connection. Cloud sync is additive, not required.
+- **It's a library, not just a viewer.** Import once, always there. Organized by study and series. Notes and reports attached.
+
+---
+
+## Product Philosophy
+
+### Two Data Domains
+
+The system has two fundamentally different data domains. They share infrastructure where convenient, but they are not the same thing and must not be coupled.
+
+**Imaging** -- DICOM files, pixel data, study/series/slice organization, transfer syntaxes, decoders, rendering. Large, immutable binary objects. Read-heavy, write-once. The core viewer pipeline.
+
+**Annotations** -- notes, comments, reports, measurements, labels. Lightweight, mutable, user-generated metadata layered on top of imaging. Keyed by DICOM UIDs but with their own lifecycle (created, edited, deleted, synced).
+
+These domains have different storage characteristics, different sync requirements, different performance profiles, and different compliance implications. In a company context, they would be owned by different engineering teams. Design decisions, APIs, persistence layers, and sync protocols should respect this boundary.
+
+When in doubt, ask: "Is this about the imaging pipeline or the annotation layer?" and keep the answer in its own lane.
+
+### Local-First, Cloud-Second
+
+The desktop app is the primary product today. It must be fully functional without any server or internet connection. Cloud sync is a layer on top, not a dependency underneath.
+
+This means:
+- All writes go to local storage first. The UI reads from local storage.
+- Cloud is a replication target, not a primary store.
+- If the network disappears, the app keeps working. Changes queue locally and sync when connectivity returns.
+
+### Copy-on-Import
+
+When a user drops a folder of DICOM files, the app copies them into a managed library folder (not reference-in-place). The managed folder is self-contained: everything the app needs is in one location. No external path dependencies, no offline drive problems, no scattered source folders.
+
+This model was chosen because:
+- It eliminates complexity around multi-source path management, offline drives, and path canonicalization.
+- The managed folder becomes a local cache of the cloud state. On a new device, it starts empty and fills as studies are pulled. The sync engine only talks to one well-known location.
+- Selective sync is natural: each device materializes only what it needs.
+- It matches proven patterns (Horos, Google Photos).
+
+See [ADR 007](decisions/007-multi-source-library.md) for the full decision record.
+
+### Privacy by Default
+
+Medical imaging is sensitive data. The architecture reflects this:
+- Client-side DICOM processing -- pixel data is decoded in the browser/app, not on a server.
+- No telemetry, no analytics, no third-party tracking.
+- Demo site is stateless -- no data persists between visits.
+- Cloud platform (future) will require explicit account creation and consent.
+
+---
+
+## Architecture
+
+### Stack
+
+- **Frontend**: Vanilla JavaScript, single-page application
+- **Desktop shell**: Tauri (Rust) for native macOS packaging, filesystem access, SQLite persistence
+- **Backend**: Flask (Python) for local development server and test APIs
+- **Rendering**: Canvas 2D, with vtk.js planned for 3D volume rendering
+- **Decoders**: DICOM parser (JS), JPEG Lossless (JS), OpenJPEG WASM (JPEG 2000)
+- **Persistence**: SQLite (desktop, via Tauri), localStorage (browser fallback)
+
+### Shared Web Core
+
+All web assets live in `docs/`. This single source of truth serves every deployment mode:
+- GitHub Pages serves `docs/` for the demo site
+- Flask serves `docs/` for local development
+- Tauri loads `docs/` for the desktop app
+- Cloud platform will serve `docs/` with additional server-side APIs
+
+### Deployment Modes
+
+The same codebase adapts to four contexts:
+
+| Mode | Context | Persistence | Audience |
+|------|---------|-------------|----------|
+| **Demo** | GitHub Pages | None (stateless) | Public visitors trying it out |
+| **Personal** | localhost Flask | Flask API + localStorage | Individual users |
+| **Desktop** | Tauri shell | SQLite + managed library folder | Individual users (primary product) |
+| **Cloud** | app.divergent.health (future) | Server-side + local cache | Logged-in users |
+
+Detection is via Tauri first, then hostname. Feature flags route through `CONFIG.deploymentMode`.
+
+### Storage Architecture
+
+**Desktop (current):**
+```
+~/Library/Application Support/com.divergent.health.dicom-viewer/
+  library/                    # Managed DICOM files (copy-on-import)
+    <StudyInstanceUID>/
+      <SeriesInstanceUID>/
+        <SOPInstanceUID>.dcm
+  database.sqlite             # SQLite: notes, reports, config, scan cache
+  reports/                    # Attached report files (PDFs, images)
+```
+
+**Cloud (future):**
+The managed library folder becomes a local cache of the cloud state. The sync engine uploads from and downloads into this folder. Each device materializes only the studies it needs. See [ADR 006](decisions/006-cloud-sync-storage-architecture.md) and the [managed folder principle](planning/PRINCIPLE-managed-folder-as-local-cache.md).
+
+---
+
+## History and Key Decisions
+
+The product started as a browser-based DICOM viewer and evolved into a desktop application with a path to cloud.
+
+**January 2026 -- Browser viewer.**
+Initial release. Web-based DICOM viewer with drag-and-drop folder loading, slice navigation, and basic windowing. Chose vanilla JS over React/Vue for simplicity. Client-side processing for privacy. Dark theme for radiologist viewing environment. Added sample CT and MRI scans, viewing tools (W/L, Pan, Zoom), measurement tool, and automated Playwright test suite.
+
+**February 2026 -- Persistent library.**
+Added persistent local DICOM library so users don't re-import on every visit. Flask backend scans a configured folder on startup and serves results via API. Introduced `DicomFolderSource` abstraction. ([ADR 002](decisions/002-persistent-local-library.md))
+
+**March 2026 -- Desktop app.**
+Moved to Tauri desktop shell. The shared web core stays in `docs/`, but Tauri provides native macOS packaging, filesystem access, menus, and SQLite persistence. This was the shift from "web viewer" to "desktop application." ([ADR 003](decisions/003-tauri-desktop-shell-with-shared-web-core.md))
+
+**March 2026 -- Native persistence.**
+SQLite database in Tauri app data for notes, reports, library config, and scan cache. Replaced localStorage with a durable, queryable store. Rust IPC bridge for database operations. ([ADR 005](decisions/005-native-desktop-persistence.md))
+
+**March 2026 -- Cloud sync design.**
+Designed the sync protocol for notes, comments, and reports. Local-first with outbox-based replication. Server-issued delta cursors, tombstones for deletions, content hashing for dedup. DICOM file sync deferred to later. ([ADR 006](decisions/006-cloud-sync-storage-architecture.md))
+
+**March 2026 -- Copy-on-import library.**
+Pivoted from reference-in-place to copy-on-import after exploring multi-folder references and discovering compounding complexity (offline drives, path canonicalization, cross-source merge safety). The managed library folder is the single source of truth locally and the natural upload source for cloud sync. Benchmarked against Horos and Google Photos. ([ADR 007](decisions/007-multi-source-library.md))
+
+**Other key decisions:**
+- Client-side rendering for the cloud platform, not server-side ([ADR 004](decisions/004-cloud-platform-rendering-architecture.md))
+- macOS launch.command for double-click startup ([ADR 001](decisions/001-launch-command.md))
+- vtk.js for 3D volume rendering (industry standard, Kitware-backed)
+
+---
+
+## Roadmap
+
+### Now: Desktop App (Local-First)
+
+The desktop app is the current focus. It must be a complete, polished, standalone product before cloud work begins.
+
+**Completed:**
+- DICOM viewing (CT, MRI, multi-modality)
+- Multiple compression formats (Uncompressed, JPEG Lossless, JPEG Baseline/Extended, JPEG 2000)
+- Persistent library with study/series organization
+- Notes and reports system
+- Measurement tool
+- Native macOS desktop shell (Tauri)
+- SQLite persistence
+
+**In progress / next:**
+- Copy-on-import library (ADR 007) -- additive folder drop, managed library folder
+- 3D volume rendering (vtk.js) -- volume rendering, MIP, transfer functions
+- Signed and notarized macOS release
+
+### Next: Cloud Sync (Annotations First)
+
+Sync notes, comments, and reports across devices. The desktop app remains fully functional offline. Cloud is additive.
+
+- User accounts and authentication
+- Sync engine: outbox-based replication, delta cursors, tombstones
+- Server infrastructure (Flask or separate service, TBD)
+- DICOM file sync deferred to after annotation sync is stable
+
+See [ADR 006](decisions/006-cloud-sync-storage-architecture.md) and [Sync Contract v1](planning/SYNC-CONTRACT-V1.md).
+
+### Later: Cloud Platform
+
+The full hosted service at app.divergent.health.
+
+- DICOM file sync (managed folder as upload source, selective sync per device)
+- Sharing and collaboration
+- Server-side search and organization
+- Multi-platform (Windows, Linux desktop; mobile TBD)
+
+### Future: Advanced Imaging
+
+- 3D volume rendering with medical presets (CT soft tissue, bone, lung; MRI brain, spine)
+- Multi-planar reconstruction (MPR)
+- Hanging protocols
+- AI-assisted analysis (integration points, not building our own models)
+
+---
+
+## Where to Find Things
+
+| What | Where |
+|------|-------|
+| Full documentation index | [INDEX.md](INDEX.md) |
+| Architecture decisions | [docs/decisions/](decisions/) |
+| Research and benchmarks | [docs/planning/RESEARCH-*.md](planning/) |
+| Implementation plans | [docs/planning/PLANS.md](planning/PLANS.md) |
+| Bug tracking | [BUGS.md](BUGS.md) |
+| Code review findings | [CODE_REVIEWS.md](CODE_REVIEWS.md) |
+| Test documentation | [TESTING.md](TESTING.md) |
+| AI agent instructions | [CLAUDE.md](../CLAUDE.md) (not for humans -- see this guide instead) |
+
+---
+
+*Divergent Health Technologies -- divergent.health*
+*Last updated: 2026-03-28*

--- a/docs/PARALLEL_EXECUTION.md
+++ b/docs/PARALLEL_EXECUTION.md
@@ -148,7 +148,7 @@ Expected: {what passing looks like}
 
 ## When done
 Commit with descriptive message.
-Git author: Gabriel Casalduc <rgc@alumni.stanford.edu>
+Git author: Gabriel Casalduc <gabriel@divergent.health>
 ```
 
 ### Orchestrating running agents

--- a/docs/decisions/007-multi-source-library.md
+++ b/docs/decisions/007-multi-source-library.md
@@ -1,0 +1,251 @@
+# ADR 007: Copy-on-Import Library
+
+## Status
+Proposed
+
+## Context
+
+The desktop app (Tauri shell, ADR 003) currently supports a single library folder. The config stores one path (`{ folder, lastScan }`), and dropping a new folder replaces the entire library. There is no way to collect imaging from multiple sources into one library.
+
+This is at odds with the app's core purpose: being a library where users collect all their imaging. Real-world DICOM data lives in multiple places -- hospital CDs, external drives, download folders, organized archives. Users should be able to drop a new folder and have its contents merge into their existing library, not replace it.
+
+### The reference-in-place problem
+
+The current architecture (ADR 002) references DICOM files in place via path strings. Extending this to multiple source folders was the initial approach explored for this ADR. That exploration revealed compounding complexity:
+
+- **Config complexity**: An array of source folders with per-folder scan state, overlapping root detection, and canonical path resolution.
+- **Offline drives**: External drives unmounting between sessions, requiring graceful degradation, cached-study visibility for unreachable roots, and per-source availability indicators.
+- **Path canonicalization**: The Rust scan manifest canonicalizes paths, but the JS layer only normalizes. Symlinks and aliases of the same folder could appear as duplicate sources.
+- **Cross-source merge safety**: Files from different folders with the same Study Instance UID merge into one study row. This is correct for well-formed DICOM data but dangerous with anonymized datasets that may have colliding UIDs -- silently mixing slices from different patients into one study.
+- **Cache consistency**: `desktop_scan_cache` uses `path` as primary key with `root_path` as a non-unique column. A file can only retain one `root_path`, making overlapping sources (`/A` and `/A/B`) ambiguous for removal.
+- **Cloud sync friction**: The sync engine would need to know about N scattered source folders, check which are mounted, track which files from which folders have been uploaded, and handle partial availability.
+
+Every one of these problems disappears with copy-on-import.
+
+### Benchmarks
+
+**Horos** (macOS DICOM viewer, fork of OsiriX): Copies files into a managed `DATABASE.noindex/` folder on import, indexes in Core Data/SQLite, three-level UID dedup (Study -> Series -> SOP Instance). Drop is always additive. This is the established model in medical imaging. See [Horos research](../planning/RESEARCH-horos-library-model-prompt_2026-03-27_2021.md).
+
+**Google Photos**: Copies files to cloud on upload. Cloud is the source of truth. Each device's local storage is a partial, disposable cache of the cloud state. SHA-256 content hashing for dedup at upload time. Complete metadata stored locally in SQLite (< 1KB per photo); image bytes on demand. Selective sync is natural: each device materializes only what it needs. See [Google Photos research](../planning/RESEARCH-google-photos-library-model-prompt_2026-03-28_0849.md).
+
+Both systems validate the same pattern: import into a managed location, index it, sync from there.
+
+### Relationship to cloud sync
+
+ADR 006 defines cloud sync for notes, comments, and reports. DICOM file sync is out of scope for v1 but will follow. The storage model chosen here determines how hard that extension is:
+
+- **Reference-in-place**: The sync engine must discover files across N folders, check drive availability, and handle partial uploads. Each device has a different filesystem layout. Complex.
+- **Copy-on-import**: The managed folder is the upload source. Each device's managed folder is a local materialization of the cloud state. On a new device, it starts empty and fills as studies are pulled. The sync engine talks to one well-known location. Simple.
+
+Selective sync becomes natural: the cloud tracks what exists, each device's managed folder contains only what's been pulled. No phantom references to files that don't exist locally.
+
+## Decision
+
+Adopt copy-on-import for the desktop library. When the user drops a folder, the app copies all valid DICOM files into a managed library folder, indexes them, and discards the reference to the source location. The managed folder is the single source of truth for imaging data on this device.
+
+### Core principles
+
+1. **Import copies all valid DICOM files.** Dropping a folder copies every valid DICOM instance into the managed library folder -- not just renderable images. SEG, SR, PR, and other non-image DICOM objects are preserved. Renderability is a UI concern (which files to display), not an import filter. The originals are untouched. The app never references external paths after import.
+
+2. **The managed folder is self-contained.** Everything the app needs is in one location. No external dependencies, no offline drive problems, no path resolution issues. The library folder can be backed up, moved, or synced as a unit.
+
+3. **The managed folder is a local cache of the cloud.** When cloud sync ships, the managed folder becomes the local materialization of the cloud library. Upload from here, download into here. The sync engine never needs to know the user's filesystem layout.
+
+4. **UID-based dedup at import time.** Before copying a file, check whether its SOP Instance UID already exists in the library. Skip duplicates. Report what was added and what was skipped.
+
+5. **Additive import, explicit removal.** Import always adds. Removing a study from the library is a separate, explicit action (delete from managed folder + remove from index). Never conflate "import" with "replace."
+
+## Alternatives Considered
+
+- **Multi-folder reference-in-place**: Track an array of source folder paths, scan all on launch, merge results. This was the initial direction explored in this ADR. Rejected after analysis revealed compounding complexity: overlapping roots, path canonicalization, offline drives, cross-source merge safety, cache consistency, and cloud sync friction. Every problem stems from the app not owning the files. See Context section for details.
+
+- **Reference-in-place with collision guard**: Merge unconditionally across sources but flag studies where Patient Name differs across source roots (targeted heuristic for UID collisions from anonymized data). Recommended by hardener review. Rejected: the guard catches the symptom (metadata mismatch) but not the root cause (the app doesn't control the files). Copy-on-import eliminates the collision surface by deduplicating at import time before files enter the library.
+
+- **Hybrid (reference for local, copy for external)**: Reference files on the main drive, copy files from external/removable drives. Rejected: two code paths, ambiguous behavior, and the user has to understand which mode applies. Simplicity wins.
+
+- **Single-folder reference (status quo)**: Keep the current single-folder model. Rejected: doesn't serve the core product goal of collecting imaging from multiple sources.
+
+## Design Details
+
+### Managed library folder
+
+Location: Tauri app data directory, under a `library/` subfolder.
+
+```
+~/Library/Application Support/com.divergent.health.dicom-viewer/
+  library/                    # Managed DICOM files
+    <StudyInstanceUID>/
+      <SeriesInstanceUID>/
+        <SOPInstanceUID>.dcm
+  database.sqlite             # Existing SQLite database (ADR 005)
+  reports/                    # Existing report storage (ADR 005)
+```
+
+Files are organized by DICOM UID hierarchy. This structure is:
+- Deterministic (same file always goes to the same path)
+- Human-navigable (a user can find a specific study in Finder)
+- Dedup-friendly (existence check = file path check)
+- Flat enough for filesystem performance (three levels max)
+
+### Import pipeline
+
+When the user drops a folder:
+
+1. **Walk the source folder** recursively, collecting all files.
+2. **Parse DICOM metadata** for each file. Any file with a valid DICOM preamble and a SOP Instance UID is a candidate for import -- not just renderable images. SEG, SR, PR, and other non-image DICOM objects are included. Non-DICOM files (JPEGs, PDFs, text) are silently skipped.
+3. **Dedup check**: Does `<library>/<StudyUID>/<SeriesUID>/<SOPUID>.dcm` already exist? If yes, compare file size. If size matches, skip (true duplicate). If size differs, this is a UID collision -- flag it for the user rather than silently dropping the incoming file.
+4. **Copy the file** into the managed folder at the deterministic path.
+5. **Index metadata**: Store parsed metadata in the persistent index for fast launch (see Metadata Index section below).
+6. **Mark renderability**: Flag files that pass `isRenderableImageMetadata()` (Study UID, pixel data, non-zero dimensions). The library UI displays only renderable files, but all DICOM instances are preserved for future features.
+7. **Report results**: "Imported N files (M studies, K series). Skipped P duplicates."
+
+Progress UI throughout -- reuse existing scan progress infrastructure.
+
+### Import is not a scan
+
+The current scan pipeline (`loadStudiesFromDesktopPaths`) reads metadata from files and holds path references. The import pipeline is different: it reads metadata, copies the file, then indexes the copy. The scan pipeline is reused for re-indexing the managed folder on launch, but the import pipeline is new code.
+
+### Metadata index
+
+The ADR uses "indexed in SQLite" to mean a persistent metadata store that survives app restarts without re-parsing files. The existing `desktop_scan_cache` table (migration 002) stores per-file metadata keyed by path, with size/mtime invalidation. This is sufficient as the persistent index for the managed folder -- same table, single root path.
+
+`addSliceToStudies()` in `sources.js` is the in-memory assembler that builds the `state.studies` map from cached or freshly-parsed metadata. It is not itself a persistent index. The flow is: persistent index (SQLite) -> in-memory assembly (`addSliceToStudies`) -> UI display.
+
+No new SQLite table is needed for v1. If the scan cache proves insufficient (e.g., for storing non-renderable DICOM metadata that the current schema doesn't capture), a dedicated `library_files` table can be added as a migration. But start with the existing table.
+
+### Config schema (v1 -> v2)
+
+```javascript
+// v1 (current):
+{ "folder": "/path/to/dicom", "lastScan": "2026-03-27T..." }
+
+// v2 (proposed):
+{
+    "version": 2,
+    "libraryPath": "<app-data>/library",
+    "lastScan": "2026-03-28T..."
+}
+```
+
+- `version: 2` enables migration detection.
+- `libraryPath` points to the managed folder. Defaults to `<app-data>/library`. Configurable for users who want the library on a specific drive.
+- `lastScan` tracks when the library was last indexed.
+
+Migration from v1 requires care. A user with a large library folder could face a long copy operation and a significant disk-space increase. The migration must not happen automatically.
+
+**Migration flow:**
+
+1. On first launch with a v1 config, the app detects the old `folder` value and shows a migration prompt -- not an auto-import.
+2. **Preflight check**: Calculate total size of DICOM files in the old folder. Show the user: "Your library at [path] contains N files (X GB). Importing will copy these into the app's managed folder, using approximately X GB of additional disk space. Available disk: Y GB."
+3. **User confirms** before any copying begins. If they decline, the app continues with the old reference-in-place behavior until they're ready.
+4. **Resumable import**: If the import is interrupted (crash, quit, power loss), it picks up where it left off on next launch. Files already copied are detected by the dedup check.
+5. After successful import, the v2 config is persisted. The old folder is untouched -- the user can delete it manually if they want to reclaim space.
+
+### Dedup strategy
+
+**At import time**: Check file existence at the deterministic path (`<library>/<StudyUID>/<SeriesUID>/<SOPUID>.dcm`). If the file exists, compare file size against the incoming file. If sizes match, treat as a true duplicate and skip. If sizes differ, this is a UID collision -- two distinct files claiming the same SOP Instance UID. The import should flag the collision for the user rather than silently dropping the incoming file or overwriting the existing one. The collision notice should include both file sizes and source paths so the user can investigate.
+
+Copy-on-import reduces the UID collision surface compared to reference-in-place (no cross-source merge ambiguity), but it does not eliminate it. The size check catches the most common collision case (anonymization tools generating identical UIDs for different files of different sizes). For byte-identical files with colliding UIDs, the collision is undetectable at import time -- but also harmless, since the content is the same.
+
+**For cloud sync (future)**: SHA-256 content hash computed at import time and stored in the index. Upload skips files the cloud already has (by hash). This is the Google Photos model. Already planned in ADR 006.
+
+### Duplicate notice
+
+After import completes:
+
+- All new: "Imported N files (M studies) from [folder name]"
+- Mixed: "Imported N new files (M studies, K series). Skipped P duplicates already in your library."
+- All existing: "All files in [folder name] are already in your library."
+
+### Deletion semantics
+
+"Remove from library" means: delete the file from the managed folder, remove from the SQLite index. The original file (wherever the user imported it from) is untouched -- the app doesn't track or modify source locations.
+
+This avoids the Google Photos confusion where "delete" means different things in different contexts. Our model: import is a copy in, remove is a delete from the managed folder. No ambiguity.
+
+### Launch behavior
+
+1. Read `libraryPath` from config.
+2. Scan the managed folder (reuse existing scan pipeline with the managed folder as the single root).
+3. Use `desktop_scan_cache` for fast re-indexing (unchanged files skip parsing).
+4. Display the library.
+
+No multi-root complexity. One folder, one scan, one index.
+
+### Disk usage
+
+Medical imaging datasets for a personal viewer are typically a few hundred MB to a few GB per study. A large personal library might be 50-100 GB. On modern hardware with hundreds of GB to multiple TB of storage, this is manageable.
+
+Users who want to minimize duplication can delete the original source after confirming import. The app does not do this automatically.
+
+For cloud sync (future), selective sync means devices only pull what they need. A laptop with limited storage can keep recent studies locally and access older ones on demand.
+
+### Phased implementation
+
+1. **Managed folder setup**: Create the `library/` directory structure in app data. Update config schema to v2.
+2. **Import pipeline**: New code path for copy + index on drop. Dedup by file path existence. Progress UI.
+3. **Migration**: On first launch with v1 config, import existing library folder contents into managed folder.
+4. **Remove from library**: UI action to delete a study/series from the managed folder and index.
+5. **Cache cleanup**: Remove `desktop-library-cache.json` dependency.
+
+### Files impacted
+
+| File | Change | Phase |
+|------|--------|-------|
+| `docs/js/persistence/desktop.js` | v2 config schema, managed folder path | 1 |
+| `docs/js/app/desktop-library.js` | Import pipeline, managed folder setup, kill snapshot methods | 1-5 |
+| `docs/js/app/main.js` | `handleTauriDrop()` calls import instead of scan | 2 |
+| `docs/js/app/library.js` | Import progress UI, remove-from-library action | 2-4 |
+| `docs/js/app/sources.js` | No changes for scan; import pipeline is new code alongside | 2 |
+| `desktop/src-tauri/src/` | Rust commands for file copy, managed folder operations | 2 |
+
+## Consequences
+
+Positive:
+
+- Users can collect imaging from multiple sources into one library. This is the core value proposition of the app.
+- Offline drive problems are minimized -- files are always local after import. (Note: if `libraryPath` is configured to an external drive, that drive must be mounted. This is a simpler and rarer scenario than multi-root reference-in-place, but not impossible.)
+- No cross-source merge ambiguity -- dedup happens at import time by SOP Instance UID, before files enter the library.
+- No path canonicalization issues -- the app owns the file paths in the managed folder.
+- No multi-root config complexity -- one folder, one scan root.
+- Clean path to cloud sync -- managed folder is the upload source and download destination.
+- Selective sync is natural -- each device materializes only what it needs.
+- Library is portable -- the managed folder can be backed up or moved as a unit.
+- Matches established patterns (Horos, Google Photos).
+
+Negative:
+
+- Disk space duplication. Imported files are copies. Users with very large datasets on limited storage may need to delete originals after import.
+- Import takes longer than reference-in-place (file copy vs. just indexing). For large folders, this could be minutes.
+- Reversing the reference-in-place philosophy from ADRs 002 and 006. The reasoning has changed because the product scope has grown from "viewer" to "library with cloud sync."
+- Migration from v1 requires a one-time import of the existing library folder. This must handle edge cases (permissions, disk space, interrupted import).
+- The managed folder can grow large. No automatic cleanup or storage management in v1.
+
+## Research References
+
+- Horos library model: [RESEARCH-horos-library-model-prompt_2026-03-27_2021.md](../planning/RESEARCH-horos-library-model-prompt_2026-03-27_2021.md)
+- Google Photos library model: [RESEARCH-google-photos-library-model-prompt_2026-03-28_0849.md](../planning/RESEARCH-google-photos-library-model-prompt_2026-03-28_0849.md)
+- Managed folder as local cache principle: [PRINCIPLE-managed-folder-as-local-cache.md](../planning/PRINCIPLE-managed-folder-as-local-cache.md)
+- ADR 002 (persistent local library -- superseded by this ADR for desktop mode): [002-persistent-local-library.md](002-persistent-local-library.md)
+- ADR 005 (native desktop persistence): [005-native-desktop-persistence.md](005-native-desktop-persistence.md)
+- ADR 006 (cloud sync storage architecture): [006-cloud-sync-storage-architecture.md](006-cloud-sync-storage-architecture.md)
+
+## Review Iterations
+
+**Review 1 (external critique of the reference-in-place draft):** Five findings about cache schema accuracy, source identity canonicalization, offline-drive behavior, series-level duplicate notice, and nondeterministic first-seen metadata. All valid, all symptomatic of the underlying complexity of managing scattered file references. This review was a factor in reconsidering the reference-in-place approach entirely.
+
+**Review 2 (hardener analysis of merge safety):** Recommended merge-unconditionally with a targeted collision guard (compare Patient Name across source roots). Sound within the reference-in-place model, but the discussion revealed that the guard catches symptoms, not the root cause. Copy-on-import eliminates the collision surface by deduplicating at import time.
+
+**Review 3 (cloud sync implications):** Analysis of how reference-in-place vs. copy-on-import interact with future cloud sync (ADR 006). Copy-on-import aligns with the Google Photos model: managed folder as local cache of cloud state, clean upload source, natural selective sync. Reference-in-place would require the sync engine to discover files across N folders with partial availability. This was the deciding factor.
+
+**Review 4 (external critique of copy-on-import draft, 5 findings):**
+
+1. **[P1] Lossy import.** The pipeline filtered on `isRenderableImageMetadata()`, meaning SEG/SR/PR and other non-image DICOM objects would never be copied. Fixed: import all valid DICOM instances, mark renderability as a UI flag, not an import filter.
+
+2. **[P1] Aggressive v1 migration.** Auto-importing on first launch is risky for large libraries (long copy, surprise disk-space spike, interrupted-upgrade edge cases). Fixed: migration requires explicit user confirmation with a preflight check showing file count, size, and available disk. Import is resumable if interrupted. Status downgraded from Accepted to Proposed until migration UX is validated.
+
+3. **[P2] UID collision still possible.** Copy-on-import changes the failure mode from "merge wrong files" to "silently drop a distinct colliding file." Fixed: dedup check now compares file size when the target path already exists. Size mismatch flags a collision for the user rather than silently skipping.
+
+4. **[P2] "Indexed in SQLite" was vague.** `addSliceToStudies()` is an in-memory assembler, not a persistent index. Fixed: added Metadata Index section clarifying the flow (SQLite scan cache -> in-memory assembly -> UI display) and confirming `desktop_scan_cache` is sufficient for v1.
+
+5. **[P3] "No offline drive problems" overstated.** If `libraryPath` is configured to an external drive, that drive must be mounted. Fixed: qualified the claim in Consequences.

--- a/docs/planning/PRINCIPLE-managed-folder-as-local-cache.md
+++ b/docs/planning/PRINCIPLE-managed-folder-as-local-cache.md
@@ -1,0 +1,30 @@
+<!--
+  PRINCIPLE: Managed Folder as Local Cache
+  Copyright (c) 2026 Divergent Health Technologies
+  https://divergent.health/
+-->
+
+# Principle: The Managed Folder Is a Local Cache of the Cloud
+
+Two foundational principles for how the local app and cloud service relate:
+
+## 1. The managed folder is a local materialization of the cloud state
+
+The sync engine only talks to the managed folder. It does not need to know about the user's filesystem layout, external drives, source folders, or where files originally came from. On the primary device, the managed folder is the upload source. On a new device, it starts empty and fills as studies are pulled from the cloud.
+
+This decouples sync from filesystem complexity entirely. There is one well-known location to upload from, one well-known location to download into. The import pipeline (drop folder, copy files in, index in SQLite) is a local concern. The sync pipeline (upload bytes, download bytes, reconcile metadata) is a cloud concern. They share the managed folder as their interface boundary.
+
+## 2. Selective sync is a natural consequence
+
+The cloud tracks what studies exist. Each device's managed folder only contains what has been pulled. A user with 200 GB of imaging in the cloud but only 50 GB of disk on their laptop can keep only recent studies locally. There are no phantom references to files that don't exist -- if a study is in the managed folder, its files are there. If it's not, it's cloud-only (browsable via metadata, downloadable on demand).
+
+This avoids the problems of reference-in-place at scale: no offline drive warnings, no broken path references, no ambiguity about what's available locally. The managed folder is always consistent -- everything in it is real and readable.
+
+## Relationship to existing ADRs
+
+- **ADR 006** (Cloud Sync Storage Architecture): defines the sync protocol and metadata layer. This principle defines the file-level interface between local and cloud.
+- **ADR 007** (Multi-Source Library): defines how files get into the managed folder (copy on import from dropped folders). This principle defines what happens after they're there.
+
+## Benchmark
+
+This is the Google Photos model. The cloud is the source of truth. Each device contributes via upload and materializes via download. No device holds the complete library unless it chooses to. See [RESEARCH-google-photos-library-model](RESEARCH-google-photos-library-model-prompt_2026-03-28_0849.md) for the full benchmark.

--- a/docs/planning/RESEARCH-google-photos-library-model-prompt.md
+++ b/docs/planning/RESEARCH-google-photos-library-model-prompt.md
@@ -1,0 +1,14 @@
+How does Google Photos handle its library model, import pipeline, and sync architecture?
+
+Specifically:
+
+1. What happens when a user imports photos/videos -- are originals copied into a managed location or referenced in place?
+2. How does Google Photos handle the local storage vs cloud storage relationship? Is the local library a cache of the cloud, or is the cloud a backup of local?
+3. How does deduplication work -- at import time, during sync, or both? What identifiers are used (content hash, metadata, etc.)?
+4. How does selective sync / "free up space" work -- how does a device keep a partial local copy of the full cloud library?
+5. How does multi-device sync work -- what happens when you import on Device A and want to access on Device B?
+6. How does Google Photos handle offline access -- what's available when there's no internet?
+7. What is the folder/storage structure on disk (Android, iOS, desktop)?
+8. How does Google Photos handle the transition from "local photo library" to "cloud-synced library" -- what was the migration path from local-only tools like Picasa?
+9. How does Google Photos handle large libraries (100K+ items) -- any pagination, lazy loading, or tiered storage?
+10. What are the known limitations or pain points of the Google Photos model that we should learn from?

--- a/docs/planning/RESEARCH-google-photos-library-model-prompt_2026-03-28_0849.md
+++ b/docs/planning/RESEARCH-google-photos-library-model-prompt_2026-03-28_0849.md
@@ -1,0 +1,154 @@
+# Google Photos: Library Model, Import Pipeline, and Sync Architecture
+
+## 1. Import Pipeline: Copy, Not Reference
+
+Google Photos always copies files to the cloud. It never references originals in place. The local originals remain on the device, untouched. There is no managed library folder on disk -- Google Photos does not reorganize, move, or rename local files.
+
+Upload pipeline:
+1. Client computes SHA-256 content hash for deduplication
+2. Chunked upload (4-8MB chunks) with resumable sessions (24-48h expiry)
+3. Background execution via WorkManager (Android) / NSURLSession (iOS)
+4. Server-side async processing: thumbnails, video transcoding, EXIF extraction, ML inference
+
+Two quality tiers: Original (byte-for-byte, counts against quota) and Storage Saver (recompressed to 16MP max, lossy, also counts against quota since June 2021).
+
+## 2. Cloud Is the Source of Truth
+
+The cloud is the canonical store. The local device is a partial, disposable cache.
+
+- **One-way upload**: Photos flow from device to cloud. The cloud does not push originals back down automatically.
+- **Metadata syncs bidirectionally**: Album membership, favorites, descriptions, edits sync across devices. Image bytes only flow upward.
+- **Device as contributor, not mirror**: Each device contributes its camera roll. No device holds a complete copy of the full cloud library.
+- **Local metadata cache**: Complete metadata stored locally in SQLite (< 1KB per photo). Even 100K+ libraries fit in ~100MB of metadata. But image bytes are cloud-only after backup.
+
+## 3. Deduplication
+
+SHA-256 content hash at upload time. Server-side check before storing.
+
+- Exact byte-identical copies: deduplicated (same media item ID returned)
+- Rotated, cropped, re-encoded, or re-saved copies: NOT caught (different bytes = different hash)
+- No post-upload duplicate detection. No built-in near-duplicate scanning.
+- Filename from the first upload is retained for subsequent duplicates.
+
+## 4. Selective Sync / "Free Up Space"
+
+"Free up space" is a one-shot destructive operation: deletes ALL local copies of backed-up photos. Not selective.
+
+- No per-photo or per-album "keep offline" option
+- No on-demand virtual filesystem (unlike iCloud Photos or OneDrive)
+- Thumbnails and previews remain cached in app storage for browsing
+- Full-resolution viewing after "Free up space" requires re-downloading from cloud
+- Selective backup (separate feature) controls which device folders get backed up at all
+
+## 5. Multi-Device Sync
+
+Cloud library acts as hub. All devices sync through it, never peer-to-peer.
+
+- Each device uploads its camera roll to the shared cloud library
+- Metadata syncs down via change log with monotonic sequence numbers
+- Push + poll hybrid: push notifications for connected clients, batch sync on reconnect
+- Device B receives metadata push, displays thumbnails from CDN, streams full-resolution on demand
+- SQLite union table on device joins cloud metadata and local-only metadata using file hashes
+
+Conflict resolution:
+- Metadata edits: last-writer-wins
+- Deletions: tombstones synced to other devices
+- In-place edits: versioned edit lists (deterministic modification sequences), stale edits rejected
+
+## 6. Offline Access
+
+Limited. Only locally cached thumbnails and previously viewed/downloaded photos are available offline.
+
+- Thumbnails: browsing works offline
+- Full-resolution: only if previously viewed or manually downloaded
+- Search: requires server-side ML, does not work offline
+- Uploads: queued for when connectivity returns
+- No "make all photos available offline" bulk option
+
+Google released Gallery Go (now Google Gallery) as a separate 10MB app for offline-first use on Android Go devices -- an acknowledgment that offline is a gap in the main app.
+
+## 7. Storage Structure on Disk
+
+Google Photos does not create its own folder structure. It reads from existing OS folders and maintains a private app cache.
+
+**Android:**
+- Reads from DCIM/Camera/, DCIM/Screenshots/, Pictures/, etc.
+- App cache: thumbnails, previews, recently viewed media
+- SQLite databases for local metadata cache and sync state
+
+**iOS:**
+- Reads from Camera Roll via Photos framework
+- Sandboxed app container for cache
+
+**Desktop:**
+- No native desktop app. Google Drive for Desktop can upload photos from specified folders.
+- photos.google.com web interface is the primary desktop access.
+
+**Cloud (server-side):**
+```
+bucket/user_id/year/month/day/photo_original.jpg
+bucket/user_id/year/month/day/photo_thumbnail.jpg
+```
+Multiple resolutions per photo. Videos at multiple transcodes.
+
+## 8. Picasa to Google Photos Transition
+
+No automated migration path. Google sunset the local tool and told users to re-upload.
+
+- Picasa Web Albums automatically appeared in Google Photos (same Google account)
+- Image files on the user's hard drive were preserved (they were always local)
+- Lost: folder hierarchy (Google Photos flattens everything), Picasa face tags and edits (not migrated), local organization metadata (.picasa.ini files), original quality (some users reported recompression during upload)
+- Google called it "switching," not "migrating"
+
+## 9. Large Libraries (100K+ Items)
+
+### Client-side (Web)
+- Justified grid layout using Knuth-Plass line-breaking algorithm (~10ms for 1,000 photos)
+- Virtual DOM: never more than ~50 photo elements in DOM regardless of library size
+- Section-based metadata loading: initial load sends only section photo counts, not individual metadata
+- Multi-resolution progressive loading: full thumbnails nearby, low-res placeholders (889 bytes) further out, CSS-generated grid textures for unloaded sections
+- Scroll-aware prefetching with request batching (~10 concurrent, not 100)
+
+### Client-side (Mobile)
+- Complete metadata stored locally in SQLite (< 1KB per photo)
+- Paged database results: primary grid data loads/unloads with scroll, secondary metadata (dates) stays in memory
+
+### Server-side
+- Cursor-based pagination (nextPageToken, max 100 items per request)
+- Date-range indexing for efficient time-based queries
+- Media URLs expire after 60 minutes (must re-request, not cache)
+- Tiered storage: hot (recent, thumbnails), warm (30-90 days), cold (older), archive (very old videos)
+
+## 10. Limitations and Pain Points
+
+1. **Deletion model is confusing**: Deleting from the app deletes both local and cloud. "Delete from device" is buried. Major source of user data loss.
+
+2. **No on-demand files**: Unlike iCloud Photos, no virtual filesystem with placeholders. Binary choice: have the file locally or don't.
+
+3. **No folder/hierarchy support**: Everything flattens into a timeline. No nested albums. Careful folder structures lost on import.
+
+4. **No post-upload dedup**: Only catches byte-identical files at upload time. Near-duplicates accumulate.
+
+5. **Storage Saver is irreversible**: Once recompressed, originals are gone from Google's servers. If local originals also deleted, full-resolution permanently lost.
+
+6. **Minimal offline access**: No bulk offline mode. No "keep this album offline."
+
+7. **Lock-in via ML features**: Search by face, object, location powered by server-side ML. No export of these labels. Switching services means losing organizational intelligence.
+
+8. **API limitations**: No file sizes, no two-way sync, no media modification, strict rate limits, 60-minute URL expiry.
+
+## Key Takeaways for Our Design
+
+1. **Cloud as source of truth works.** Every device contributes; no device is the mirror. This is the model to follow for our cloud mode.
+
+2. **Content hashing at import is essential.** SHA-256 dedup at upload time prevents waste. Already planned in ADR 006.
+
+3. **Complete metadata locally, bytes on demand.** Google Photos keeps < 1KB of metadata per photo in local SQLite. This lets the app browse the full library offline while streaming full-resolution on demand. Directly applicable to our architecture.
+
+4. **Don't replicate Google's deletion confusion.** The "delete means delete everywhere" model is their biggest user complaint. We should have clear separation between "remove from library" and "delete the file."
+
+5. **Flat timeline is a limitation, not a feature.** Google Photos lost folder hierarchy deliberately (simplicity for billions of users). We serve a different audience -- medical imaging users need study/series hierarchy. Our advantage.
+
+6. **Offline access is a differentiator.** Google Photos is weak here. Our copy-on-import model with local managed folder gives us full offline access by default.
+
+7. **The Picasa migration was painful.** No automated path, lost metadata, quality degradation. When we eventually transition from local-only to cloud, we should do better.

--- a/docs/planning/RESEARCH-horos-library-model-prompt.md
+++ b/docs/planning/RESEARCH-horos-library-model-prompt.md
@@ -1,0 +1,12 @@
+How does Horos (the open-source DICOM viewer for macOS, fork of OsiriX) handle its image library and database?
+
+Specifically:
+
+1. How does Horos store references to DICOM files -- does it copy files into its own database folder or reference them in-place?
+2. What happens when you drag-and-drop a folder of DICOM files onto an existing Horos library?
+3. How does Horos handle duplicate studies/series when importing?
+4. What is the structure of the Horos database folder (DATABASE.noindex, etc.)?
+5. Does Horos support multiple library locations or source folders?
+6. How does Horos handle the "copy files" vs "reference in place" choice?
+7. What is the user experience when importing -- progress indicators, error handling, batch behavior?
+8. How does Horos persist the library index across app restarts?

--- a/docs/planning/RESEARCH-horos-library-model-prompt_2026-03-27_2021.md
+++ b/docs/planning/RESEARCH-horos-library-model-prompt_2026-03-27_2021.md
@@ -1,0 +1,107 @@
+# Horos Library & Database Model -- Research Findings
+
+## 1. File Storage: Copy vs Reference
+
+Horos supports **both** modes, tracked per-image:
+
+- Each `DicomImage` Core Data entity has a `storedInDatabaseFolder` boolean
+- **Copy mode**: Files are renamed to numeric filenames and moved into `DATABASE.noindex/` under numbered subdirectories (up to 10,000 files each)
+- **Reference mode**: The original absolute path is stored; the file stays where it is
+
+This is a per-file property, not a global toggle -- a single library can have a mix of copied and referenced files.
+
+## 2. Drag-and-Drop Import
+
+The import pipeline (`addFilesAndFolderToDatabase:`) works as follows:
+
+1. Recursively enumerates dropped directories
+2. Handles ZIP extraction and DICOMDIR parsing automatically
+3. Filters out known non-DICOM extensions
+4. Parses DICOM metadata from each file
+5. Applies the user's copy/reference preference
+6. Indexes everything into Core Data (Study -> Series -> Image hierarchy)
+
+Drop is always **additive** -- new studies/series/images are added to the existing library. There is no "replace" behavior.
+
+## 3. Duplicate Detection
+
+Three-level UID matching:
+
+- **Study**: `StudyInstanceUID` (0020,000D) -- if a study with this UID already exists, it is reused
+- **Series**: `SeriesInstanceUID` (0020,000E) -- same, nested under the matched study
+- **Image**: `SOPInstanceUID` (0008,0018) -- if the exact image already exists, it can be skipped or its metadata refreshed
+
+A `rereadExistingItems` flag controls whether metadata is refreshed on collision. By default, exact duplicates (same SOP Instance UID) are recognized and not re-imported.
+
+## 4. Database Folder Structure
+
+```
+Horos Data/
+  DATABASE.noindex/          # Copied DICOM files (numbered subdirs, 10K files each)
+  INCOMING.noindex/          # Staging area for imports in progress
+  DECOMPRESSION.noindex/     # Temp space for decompressing files
+  TEMP.noindex/              # General temp files
+  NOT READABLE/              # Files that failed to parse
+  REPORTS/                   # Generated reports
+  ROIs/                      # Region of interest data
+  Database.sql               # Core Data SQLite database
+  DB_VERSION                 # Text file with model version ("2.5")
+```
+
+The `.noindex` suffix prevents Spotlight from indexing DICOM files (performance + privacy).
+
+## 5. Multiple Library Locations
+
+Horos has a multi-source architecture, but only **one source is active at a time**:
+
+- Default local database (the main library)
+- Additional local paths (user-configured)
+- Remote OsiriX/Horos servers
+- DICOM nodes (PACS)
+- Auto-detected mounted volumes
+- Bonjour-discovered services
+
+Users can switch between sources, but there is no "merged view" across multiple sources.
+
+## 6. Copy vs Reference Choice
+
+Controlled by two preferences:
+
+- `COPYDATABASE` (boolean) -- master toggle for whether to copy at all
+- `COPYDATABASEMODE` -- how to decide:
+  - `0` = Always copy
+  - `2` = Copy only if source is not on the main drive
+  - `3` = Ask the user each time (default)
+
+When the user is asked, the dialog offers:
+- **Copy** -- file is moved into `DATABASE.noindex/`, `storedInDatabaseFolder=YES`
+- **Copy Links** -- file stays in place, `storedInDatabaseFolder=NO`, absolute path is stored
+
+## 7. Import UX
+
+- Background thread with progress bar (0.0 to 1.0)
+- Status messages throttled to 0.5s updates (not every file)
+- Cancellation support
+- Chunked processing (batches of ~20K files)
+- Per-error handling:
+  - Unparseable files moved to `NOT READABLE/`
+  - Password-protected ZIPs trigger a prompt
+  - Failed DICOMDIR falls back to full directory scan
+- Non-blocking -- user can continue browsing the library during import
+
+## 8. Library Persistence
+
+- **Core Data** with SQLite backing (`Database.sql`)
+- Three main entities: `DicomStudy`, `DicomSeries`, `DicomImage` (plus `DicomAlbum` for organization)
+- `NSConfinementConcurrencyType` threading model with recursive locks for file operations
+- Automatic lightweight migration when the model version changes
+- The index can be fully rebuilt by rescanning `DATABASE.noindex/` (the files are the source of truth, not the database)
+
+## Key Takeaways for Our Design
+
+1. **Copy-by-default with reference option** is the Horos model. Most users want files organized in one place.
+2. **Per-file tracking** of copied vs referenced is important -- not a global setting.
+3. **Three-level UID dedup** is standard and reliable.
+4. **Additive import is the only behavior** -- drop always adds, never replaces.
+5. **Background import with progress** is expected UX.
+6. **Single active source** -- Horos does not merge multiple folders into one view.


### PR DESCRIPTION
## Summary
- ADR 007: Copy-on-Import Library -- documents the decision to adopt copy-on-import for the desktop library. Benchmarked against Horos and Google Photos. Four review iterations.
- Divergent Central Guide -- canonical product/architecture document covering vision, domain separation, history, and roadmap.
- Horos and Google Photos library model research docs.
- Managed-folder-as-local-cache principle doc.
- Email update to gabriel@divergent.health across config files.

## Test plan
- [ ] Docs-only PR, no code changes except email in Cargo.toml
- [ ] Verify ADR 007 links resolve correctly
- [ ] Verify Central Guide links resolve correctly

Generated with [Claude Code](https://claude.com/claude-code)