### PR TITLE
feat: add auto-update infrastructure with release workflow

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -106,4 +106,11 @@ jobs:
         run: npm ci
 
       - name: Build unsigned macOS app bundle
+        env:
+          # Smoke test needs a signing key because createUpdaterArtifacts is
+          # enabled. This uses the real key stored as a repo secret. The
+          # resulting signature is not distributed to users (only release.yml
+          # publishes artifacts).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --bundles app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Divergent Health Technologies
+# Release Workflow - Builds, signs, notarizes, and publishes desktop releases
+#
+# Triggered by pushing a tag matching v* (e.g. v0.2.0).
+# Creates a draft GitHub Release with signed + notarized DMGs and updater
+# artifacts for both aarch64 and x86_64. Publish the draft manually after
+# verifying the artifacts.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Only one release at a time
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  build-and-release:
+    name: Build macOS Release
+    runs-on: macos-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+
+    defaults:
+      run:
+        working-directory: desktop
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
+
+      - name: Import Apple signing certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build and release (aarch64)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: desktop
+          tauriScript: npm run tauri
+          tagName: v__VERSION__
+          releaseName: 'myradone v__VERSION__'
+          releaseBody: 'See the [changelog](https://github.com/elgabrielc/dicom-viewer/blob/main/CHANGELOG.md) for details.'
+          releaseDraft: true
+          prerelease: false
+          args: --target aarch64-apple-darwin
+
+      - name: Build and release (x86_64)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: desktop
+          tauriScript: npm run tauri
+          tagName: v__VERSION__
+          releaseName: 'myradone v__VERSION__'
+          releaseDraft: true
+          prerelease: false
+          args: --target x86_64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 # Copyright (c) 2026 Divergent Health Technologies
 # Release Workflow - Builds, signs, notarizes, and publishes desktop releases
 #
-# Triggered by pushing a tag matching v* (e.g. v0.2.0).
+# Triggered by pushing a stable semver tag (e.g. v0.2.0).
+# Tags with pre-release suffixes (v0.2.0-rc.1, v0.2.0-beta.1) are marked
+# as GitHub prereleases so they don't become the /releases/latest endpoint.
+#
 # Creates a draft GitHub Release with signed + notarized DMGs and updater
 # artifacts for both aarch64 and x86_64. Publish the draft manually after
 # verifying the artifacts.
@@ -11,7 +14,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 # Only one release at a time
 concurrency:
@@ -33,6 +36,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Validate tag matches app version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          APP_VERSION=$(node -p "require('./src-tauri/tauri.conf.json').version")
+          if [ "$TAG_VERSION" != "$APP_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match app version ($APP_VERSION)"
+            exit 1
+          fi
+
+      - name: Detect prerelease
+        id: meta
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          if echo "$TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -86,11 +108,11 @@ jobs:
         with:
           projectPath: desktop
           tauriScript: npm run tauri
-          tagName: v__VERSION__
-          releaseName: 'myradone v__VERSION__'
+          tagName: ${{ github.ref_name }}
+          releaseName: 'myradone ${{ github.ref_name }}'
           releaseBody: 'See the [changelog](https://github.com/elgabrielc/dicom-viewer/blob/main/CHANGELOG.md) for details.'
           releaseDraft: true
-          prerelease: false
+          prerelease: ${{ steps.meta.outputs.prerelease }}
           args: --target aarch64-apple-darwin
 
       - name: Build and release (x86_64)
@@ -108,8 +130,8 @@ jobs:
         with:
           projectPath: desktop
           tauriScript: npm run tauri
-          tagName: v__VERSION__
-          releaseName: 'myradone v__VERSION__'
+          tagName: ${{ github.ref_name }}
+          releaseName: 'myradone ${{ github.ref_name }}'
           releaseDraft: true
-          prerelease: false
+          prerelease: ${{ steps.meta.outputs.prerelease }}
           args: --target x86_64-apple-darwin

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +606,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +752,9 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-persisted-scope",
+ "tauri-plugin-process",
  "tauri-plugin-sql",
+ "tauri-plugin-updater",
  "tokio",
 ]
 
@@ -968,6 +990,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1044,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1645,6 +1694,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +2322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,6 +2415,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2573,6 +2650,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2586,6 +2664,18 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2643,10 +2733,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "pango"
@@ -3259,15 +3369,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3304,6 +3419,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,6 +3462,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3572,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3415,6 +3639,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4149,6 +4396,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,6 +4601,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-sql"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,6 +4628,39 @@ dependencies = [
  "time",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -4460,6 +4761,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4581,6 +4895,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4910,6 +5234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5212,6 +5542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5458,6 +5797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5937,6 +6285,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6037,6 +6395,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -25,5 +25,7 @@ tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-persisted-scope = "2"
+tauri-plugin-process = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
+tauri-plugin-updater = "2"
 tokio = { version = "1", features = ["sync", "time"] }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -18,6 +18,8 @@
     "fs:allow-write-file",
     "sql:default",
     "sql:allow-execute",
+    "updater:default",
+    "process:allow-restart",
     {
       "identifier": "fs:scope",
       "allow": [

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -30,9 +30,11 @@ fn reveal_in_finder(path: String) -> Result<(), String> {
 
 const MENU_OPEN_FOLDER: &str = "open-folder";
 const MENU_SHOW_LIBRARY: &str = "show-library-in-finder";
+const MENU_CHECK_UPDATES: &str = "check-for-updates";
 const MENU_OPEN_HELP: &str = "open-help";
 const EVENT_OPEN_FOLDER: &str = "desktop://open-folder";
 const EVENT_SHOW_LIBRARY: &str = "desktop://show-library-in-finder";
+const EVENT_CHECK_UPDATES: &str = "desktop://check-for-updates";
 const EVENT_OPEN_HELP: &str = "desktop://open-help";
 const DESKTOP_DB_URL: &str = "sqlite:viewer.db";
 
@@ -58,8 +60,12 @@ fn build_menu<R: Runtime, M: Manager<R>>(manager: &M) -> tauri::Result<Menu<R>> 
     let show_library =
         MenuItemBuilder::with_id(MENU_SHOW_LIBRARY, "Show Library in Finder").build(manager)?;
     let open_help = MenuItemBuilder::with_id(MENU_OPEN_HELP, "Viewer Help").build(manager)?;
+    let check_updates =
+        MenuItemBuilder::with_id(MENU_CHECK_UPDATES, "Check for Updates...").build(manager)?;
     let app_menu = SubmenuBuilder::new(manager, &display_name)
         .about(Some(about_metadata))
+        .separator()
+        .item(&check_updates)
         .separator()
         .services()
         .separator()
@@ -161,6 +167,8 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_persisted_scope::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(
             tauri_plugin_sql::Builder::default()
                 .add_migrations(DESKTOP_DB_URL, desktop_db_migrations())
@@ -179,6 +187,7 @@ fn main() {
         .on_menu_event(|app, event| match event.id().as_ref() {
             MENU_OPEN_FOLDER => emit_menu_event(app, EVENT_OPEN_FOLDER),
             MENU_SHOW_LIBRARY => emit_menu_event(app, EVENT_SHOW_LIBRARY),
+            MENU_CHECK_UPDATES => emit_menu_event(app, EVENT_CHECK_UPDATES),
             MENU_OPEN_HELP => emit_menu_event(app, EVENT_OPEN_HELP),
             _ => {}
         })

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -36,9 +36,18 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "macOS": {
       "entitlements": "entitlements.plist",
       "minimumSystemVersion": "11.0"
+    }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk4MzBCQjA5QkJDODJFRDkKUldUWkxzaTdDYnN3bUY3ZitiaWlZVml3MVlibkpyczhmUE5OZTFoYWZSdTBiZWk0dDVrZG9VSWEK",
+      "endpoints": [
+        "https://github.com/elgabrielc/dicom-viewer/releases/latest/download/latest.json"
+      ]
     }
   }
 }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1754,6 +1754,50 @@ header .subtitle {
     }
 }
 
+/* Update banner - fixed at top, desktop auto-update notifications */
+.update-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 0.6rem 1.5rem;
+    background-color: #0a2d4d;
+    border-bottom: 1px solid #1a5a8b;
+    color: #a0d0f0;
+    font-size: 0.85rem;
+    text-align: center;
+}
+
+.update-banner-btn {
+    padding: 0.2rem 0.6rem;
+    border: 1px solid #1a5a8b;
+    border-radius: 4px;
+    background-color: transparent;
+    color: #a0d0f0;
+    font-size: 0.75rem;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background-color 0.2s;
+}
+
+.update-banner-btn:hover {
+    background-color: #143d5e;
+}
+
+.update-banner-btn.primary {
+    background-color: #1a5a8b;
+    border-color: #2a7abf;
+}
+
+.update-banner-btn.primary:hover {
+    background-color: #2a7abf;
+}
+
 /* Conflict banner - fixed at top of page, dismissible */
 .sync-conflict-banner {
     position: fixed;

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,13 @@ Copyright (c) 2026 Divergent Health Technologies
     <script src="js/persistence/dispatcher.js"></script>
 </head>
 <body>
+    <!-- UPDATE BANNER (desktop mode only) -->
+    <div id="updateBanner" class="update-banner" style="display: none;">
+        <span id="updateBannerText"></span>
+        <button id="updateBannerAction" class="update-banner-btn primary"></button>
+        <button id="updateBannerDismiss" class="update-banner-btn">Dismiss</button>
+    </div>
+
     <!-- SYNC CONFLICT BANNER (cloud mode only) -->
     <div id="syncConflictBanner" class="sync-conflict-banner" style="display: none;">
         <span id="syncConflictText"></span>
@@ -270,6 +277,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <script src="js/app/sync-status-ui.js"></script>
     <script src="js/app/sync-engine.js"></script>
     <script src="js/app/account-ui.js"></script>
+    <script src="js/app/update-ui.js"></script>
     <script src="js/app/main.js"></script>
 </body>
 </html>

--- a/docs/js/app/update-ui.js
+++ b/docs/js/app/update-ui.js
@@ -28,6 +28,7 @@ const _UpdateUI = (() => {
 
     let initialized = false;
     let pendingUpdate = null;
+    let installing = false;
 
     function init() {
         if (initialized) return;
@@ -100,10 +101,13 @@ const _UpdateUI = (() => {
     }
 
     async function handleActionClick() {
+        if (installing) return;
+
         const actionBtn = document.getElementById('updateBannerAction');
 
         // If update is installed and waiting for restart
         if (actionBtn && actionBtn.dataset.state === 'restart') {
+            installing = true;
             const process = window.__TAURI__?.process;
             if (process?.relaunch) {
                 await process.relaunch();
@@ -111,9 +115,17 @@ const _UpdateUI = (() => {
             return;
         }
 
+        // Retry after failure -- get a fresh update object
+        if (actionBtn && actionBtn.dataset.state === 'retry') {
+            installing = false;
+            await checkForUpdates(true);
+            return;
+        }
+
         // Download and install the pending update
         if (!pendingUpdate) return;
 
+        installing = true;
         if (actionBtn) {
             actionBtn.textContent = 'Downloading...';
             actionBtn.disabled = true;
@@ -135,11 +147,16 @@ const _UpdateUI = (() => {
                 actionBtn.disabled = false;
             }
             pendingUpdate = null;
+            installing = false;
         } catch (err) {
             console.error('Update install failed:', err);
-            showBanner('Update failed. Try again later.', null);
+            // Clear stale update object -- re-check will get a fresh one
+            pendingUpdate = null;
+            installing = false;
+            showBanner('Update failed. Try again later.', 'Retry');
             if (actionBtn) {
                 actionBtn.disabled = false;
+                actionBtn.dataset.state = 'retry';
             }
         }
     }
@@ -179,11 +196,12 @@ const _UpdateUI = (() => {
         }
     }
 
-    // Self-initialize: init() gates on CONFIG.features.autoUpdate.
+    // Self-initialize: call init() directly (not _UpdateUI.init()) because
+    // the IIFE hasn't returned yet when this runs.
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', () => _UpdateUI.init());
+        document.addEventListener('DOMContentLoaded', () => init());
     } else {
-        _UpdateUI.init();
+        init();
     }
 
     return { init };

--- a/docs/js/app/update-ui.js
+++ b/docs/js/app/update-ui.js
@@ -1,0 +1,190 @@
+/**
+ * UpdateUI - Desktop auto-update banner
+ *
+ * Checks for updates on launch (after a short delay) and when triggered
+ * by the "Check for Updates..." menu item. Shows a non-intrusive banner
+ * at the top of the app when an update is available.
+ *
+ * Uses window.__TAURI__.updater (withGlobalTauri) -- no npm imports needed.
+ *
+ * Feature-gated: only activates when CONFIG.features.autoUpdate is true.
+ *
+ * Depends on:
+ *   window.CONFIG (config.js)
+ *   window.__TAURI__.updater (tauri-plugin-updater, registered in main.rs)
+ *   window.__TAURI__.process (tauri-plugin-process, for relaunch)
+ *   window.__TAURI__.event (for menu event listener)
+ *
+ * Copyright (c) 2026 Divergent Health Technologies
+ */
+
+const _UpdateUI = (() => {
+
+    // Delay before first background check (let the app finish loading)
+    const INITIAL_CHECK_DELAY_MS = 3000;
+
+    // Brief message display time for "up to date" on manual check
+    const UP_TO_DATE_DISPLAY_MS = 4000;
+
+    let initialized = false;
+    let pendingUpdate = null;
+
+    function init() {
+        if (initialized) return;
+
+        const config = window.CONFIG;
+        if (!config || !config.features || !config.features.autoUpdate) {
+            return;
+        }
+
+        initialized = true;
+
+        // Listen for manual "Check for Updates..." menu event
+        const eventApi = window.__TAURI__?.event;
+        if (eventApi?.listen) {
+            eventApi.listen('desktop://check-for-updates', () => {
+                checkForUpdates(true);
+            }).catch(err => {
+                console.warn('Failed to register update menu handler:', err);
+            });
+        }
+
+        // Wire banner buttons
+        const dismissBtn = document.getElementById('updateBannerDismiss');
+        if (dismissBtn) {
+            dismissBtn.addEventListener('click', hideBanner);
+        }
+
+        const actionBtn = document.getElementById('updateBannerAction');
+        if (actionBtn) {
+            actionBtn.addEventListener('click', handleActionClick);
+        }
+
+        // Background check after initial delay
+        setTimeout(() => checkForUpdates(false), INITIAL_CHECK_DELAY_MS);
+    }
+
+    async function checkForUpdates(manual) {
+        const updater = window.__TAURI__?.updater;
+        if (!updater?.check) {
+            if (manual) {
+                showBanner('Auto-update is not available in this build.', null);
+            }
+            return;
+        }
+
+        if (manual) {
+            showBanner('Checking for updates...', null);
+        }
+
+        try {
+            const update = await updater.check();
+
+            if (update) {
+                pendingUpdate = update;
+                showBanner(
+                    'Version ' + update.version + ' is available.',
+                    'Download and Install'
+                );
+            } else if (manual) {
+                showBanner('You are on the latest version.', null);
+                setTimeout(hideBanner, UP_TO_DATE_DISPLAY_MS);
+            }
+        } catch (err) {
+            console.warn('Update check failed:', err);
+            if (manual) {
+                showBanner('Could not check for updates.', null);
+                setTimeout(hideBanner, UP_TO_DATE_DISPLAY_MS);
+            }
+        }
+    }
+
+    async function handleActionClick() {
+        const actionBtn = document.getElementById('updateBannerAction');
+
+        // If update is installed and waiting for restart
+        if (actionBtn && actionBtn.dataset.state === 'restart') {
+            const process = window.__TAURI__?.process;
+            if (process?.relaunch) {
+                await process.relaunch();
+            }
+            return;
+        }
+
+        // Download and install the pending update
+        if (!pendingUpdate) return;
+
+        if (actionBtn) {
+            actionBtn.textContent = 'Downloading...';
+            actionBtn.disabled = true;
+        }
+
+        try {
+            await pendingUpdate.downloadAndInstall((event) => {
+                if (event.event === 'Started' && actionBtn) {
+                    actionBtn.textContent = 'Downloading...';
+                } else if (event.event === 'Finished' && actionBtn) {
+                    actionBtn.textContent = 'Restart Now';
+                }
+            });
+
+            // Download + install complete -- prompt restart
+            showBanner('Update installed. Restart to apply.', 'Restart Now');
+            if (actionBtn) {
+                actionBtn.dataset.state = 'restart';
+                actionBtn.disabled = false;
+            }
+            pendingUpdate = null;
+        } catch (err) {
+            console.error('Update install failed:', err);
+            showBanner('Update failed. Try again later.', null);
+            if (actionBtn) {
+                actionBtn.disabled = false;
+            }
+        }
+    }
+
+    function showBanner(text, actionLabel) {
+        const banner = document.getElementById('updateBanner');
+        const textEl = document.getElementById('updateBannerText');
+        const actionBtn = document.getElementById('updateBannerAction');
+        const dismissBtn = document.getElementById('updateBannerDismiss');
+
+        if (!banner || !textEl) return;
+
+        textEl.textContent = text;
+
+        if (actionBtn) {
+            if (actionLabel) {
+                actionBtn.textContent = actionLabel;
+                actionBtn.style.display = '';
+                actionBtn.disabled = false;
+                actionBtn.dataset.state = '';
+            } else {
+                actionBtn.style.display = 'none';
+            }
+        }
+
+        if (dismissBtn) {
+            dismissBtn.style.display = '';
+        }
+
+        banner.style.display = '';
+    }
+
+    function hideBanner() {
+        const banner = document.getElementById('updateBanner');
+        if (banner) {
+            banner.style.display = 'none';
+        }
+    }
+
+    // Self-initialize: init() gates on CONFIG.features.autoUpdate.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => _UpdateUI.init());
+    } else {
+        _UpdateUI.init();
+    }
+
+    return { init };
+})();

--- a/docs/js/app/update-ui.js
+++ b/docs/js/app/update-ui.js
@@ -6,8 +6,12 @@
  * at the top of the app when an update is available.
  *
  * Uses window.__TAURI__.updater (withGlobalTauri) -- no npm imports needed.
+ * Waits for the Tauri runtime to be fully available before registering
+ * event listeners or checking for updates.
  *
  * Feature-gated: only activates when CONFIG.features.autoUpdate is true.
+ * Disabled in dev builds (non-packaged apps) to avoid hitting the updater
+ * endpoint during local development.
  *
  * Depends on:
  *   window.CONFIG (config.js)
@@ -26,6 +30,10 @@ const _UpdateUI = (() => {
     // Brief message display time for "up to date" on manual check
     const UP_TO_DATE_DISPLAY_MS = 4000;
 
+    // Max time to wait for Tauri runtime APIs to become available
+    const RUNTIME_WAIT_TIMEOUT_MS = 5000;
+    const RUNTIME_POLL_INTERVAL_MS = 50;
+
     let initialized = false;
     let pendingUpdate = null;
     let installing = false;
@@ -38,19 +46,14 @@ const _UpdateUI = (() => {
             return;
         }
 
-        initialized = true;
-
-        // Listen for manual "Check for Updates..." menu event
-        const eventApi = window.__TAURI__?.event;
-        if (eventApi?.listen) {
-            eventApi.listen('desktop://check-for-updates', () => {
-                checkForUpdates(true);
-            }).catch(err => {
-                console.warn('Failed to register update menu handler:', err);
-            });
+        // Skip updater in dev builds (cargo tauri dev serves from localhost)
+        if (!isPackagedApp()) {
+            return;
         }
 
-        // Wire banner buttons
+        initialized = true;
+
+        // Wire banner buttons (DOM is ready, safe to query)
         const dismissBtn = document.getElementById('updateBannerDismiss');
         if (dismissBtn) {
             dismissBtn.addEventListener('click', hideBanner);
@@ -61,8 +64,63 @@ const _UpdateUI = (() => {
             actionBtn.addEventListener('click', handleActionClick);
         }
 
-        // Background check after initial delay
-        setTimeout(() => checkForUpdates(false), INITIAL_CHECK_DELAY_MS);
+        // Wait for Tauri runtime, then register listeners and check
+        waitForUpdaterRuntime().then(runtime => {
+            if (!runtime) return;
+
+            // Register menu event listener
+            const eventApi = runtime.event;
+            if (eventApi?.listen) {
+                eventApi.listen('desktop://check-for-updates', () => {
+                    checkForUpdates(true);
+                }).catch(err => {
+                    console.warn('Failed to register update menu handler:', err);
+                });
+            }
+
+            // Background check after initial delay
+            setTimeout(() => checkForUpdates(false), INITIAL_CHECK_DELAY_MS);
+        });
+    }
+
+    async function waitForUpdaterRuntime() {
+        // Check if already available
+        if (hasUpdaterApis(window.__TAURI__)) {
+            return window.__TAURI__;
+        }
+
+        // Wait for the ready promise if available
+        const ready = window.__DICOM_VIEWER_TAURI_READY__;
+        if (ready && typeof ready.then === 'function') {
+            const resolved = await ready;
+            if (hasUpdaterApis(resolved)) return resolved;
+        }
+
+        // Poll for late-arriving runtime
+        const deadline = performance.now() + RUNTIME_WAIT_TIMEOUT_MS;
+        while (performance.now() < deadline) {
+            if (hasUpdaterApis(window.__TAURI__)) {
+                return window.__TAURI__;
+            }
+            await new Promise(resolve => setTimeout(resolve, RUNTIME_POLL_INTERVAL_MS));
+        }
+
+        return null;
+    }
+
+    function hasUpdaterApis(runtime) {
+        return !!(
+            runtime
+            && typeof runtime.updater?.check === 'function'
+            && typeof runtime.event?.listen === 'function'
+        );
+    }
+
+    function isPackagedApp() {
+        // Packaged Tauri apps serve from tauri: or tauri.localhost, not localhost:1420
+        const protocol = window.location?.protocol || '';
+        const hostname = window.location?.hostname || '';
+        return protocol === 'tauri:' || hostname === 'tauri.localhost';
     }
 
     async function checkForUpdates(manual) {

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -84,6 +84,9 @@ const CONFIG = {
             // Only when running with the Flask server or cloud platform
             notesServer: mode === 'personal' || mode === 'cloud',
 
+            // Auto-update -- desktop app checks for new versions
+            autoUpdate: mode === 'desktop',
+
             // Cloud sync (future feature)
             // Only available on the cloud platform
             cloudSync: mode === 'cloud',


### PR DESCRIPTION
## Summary
- Wire `tauri-plugin-updater` and `tauri-plugin-process` for in-app update checks with Ed25519 signature verification
- Add "Check for Updates..." menu item in the app menu
- Add non-intrusive update banner UI: check on launch (3s delay), download/install on user action, restart when ready
- Add GitHub Actions release workflow (`release.yml`): tag push triggers dual-arch (aarch64 + x86_64) signed + notarized builds, uploads to draft GitHub Release with `latest.json` for the updater endpoint
- Add `autoUpdate` feature flag gated to desktop mode

## Architecture
- Frontend uses `window.__TAURI__.updater` (withGlobalTauri) -- no npm bundler needed
- Update banner follows existing sync-conflict-banner pattern (fixed top, dismissible)
- `downloadAndInstall()` does NOT auto-restart on macOS -- user controls when to restart via "Restart Now" button
- Release workflow creates draft releases; manual publish makes `latest.json` available at `/releases/latest/download/latest.json`

## Prerequisites before first release
- [ ] Export Developer ID certificate as .p12 and store as `APPLE_CERTIFICATE` secret
- [ ] Add all 8 GitHub Secrets (APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD, APPLE_SIGNING_IDENTITY, APPLE_TEAM_ID, APPLE_ID, APPLE_PASSWORD, TAURI_SIGNING_PRIVATE_KEY, TAURI_SIGNING_PRIVATE_KEY_PASSWORD)
- [ ] Back up Ed25519 private key (`~/.tauri/dicom-viewer.key`) to a secure secondary location

## Test plan
- [x] `cargo check` passes with new plugins
- [ ] CI Playwright tests pass (no desktop changes affect web tests)
- [ ] CI Tauri build smoke passes
- [ ] Local signed build produces .app with "Check for Updates..." menu item
- [ ] Tag push triggers release workflow and creates draft release with artifacts

Generated with [Claude Code](https://claude.ai/code)