### PR TITLE
Fix desktop viewer slice cache memory growth

### DIFF
--- a/docs/desktop-memory-validation.md
+++ b/docs/desktop-memory-validation.md
@@ -1,0 +1,106 @@
+# Desktop Memory Validation
+
+This guide is the low-friction way to validate the desktop viewer memory fix on a real study.
+
+## What you get
+
+- A JSON capture with RSS samples over time
+- Manual phase markers you can drop while reproducing the issue
+- A self-contained HTML dashboard with:
+  - baseline, peak, settled, and final RSS
+  - a timeline chart with marker lines
+  - a phase-by-phase table
+  - a simple verdict on whether memory appears stable, borderline, or still ratcheting upward
+
+## 1. Launch the desktop app from the worktree
+
+```bash
+cd "/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix"
+npm run desktop:launch
+```
+
+## 2. Start a capture session
+
+In a second terminal:
+
+```bash
+cd "/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix"
+python3 scripts/desktop-memory-capture.py \
+  --process myradone \
+  --html artifacts/desktop-memory/latest.html
+```
+
+If more than one process matches, rerun with an explicit PID:
+
+```bash
+pgrep -fl myradone
+python3 scripts/desktop-memory-capture.py \
+  --pid <PID> \
+  --html artifacts/desktop-memory/latest.html
+```
+
+While the capture is running, type marker labels and press Enter. Suggested labels:
+
+- `baseline done`
+- `rapid scrub start`
+- `rapid scrub stop`
+- `idle settle done`
+- `series switch start`
+- `series switch stop`
+- `close viewer`
+- `reopen second study`
+
+Press `Ctrl+C` when you are done.
+
+## 3. Reproduce with a real study
+
+Use the same sequence each run so the dashboards stay comparable:
+
+1. Open the large study and wait 30 seconds.
+2. Type `baseline done`.
+3. Rapidly scrub the slice slider for 60 seconds.
+4. Type `rapid scrub stop`.
+5. Stop touching the app and wait 60 seconds.
+6. Type `idle settle done`.
+7. Switch series back and forth 20 to 30 times.
+8. Type `series switch stop`.
+9. Close the viewer and wait 30 seconds.
+10. Type `close viewer`.
+11. Reopen a different study and repeat once if needed.
+
+## 4. Open the dashboard
+
+```bash
+open artifacts/desktop-memory/latest.html
+```
+
+The chart uses numbered marker lines. The markers table below the chart maps each number back to the label you typed during the run.
+
+## How to read the dashboard
+
+- `Baseline` should reflect the early steady state before aggressive interaction.
+- `Peak` can spike during scrubbing. That is expected.
+- `Settled` is the key metric. It should come back down after you stop interacting.
+- `Plateau delta` is settled RSS minus baseline RSS.
+
+Healthy runs usually look like this:
+
+- Peak rises during scrubbing
+- Settled RSS drops back near baseline within 30 to 60 seconds
+- The final plateau on the second run looks similar to the first one
+
+Suspicious runs usually look like this:
+
+- Settled RSS stays far above baseline after idle time
+- Every phase leaves a higher end value than it started with
+- The second study settles at a meaningfully higher baseline than the first one
+
+## Optional: regenerate the dashboard later
+
+If you already have a JSON session file, you can rebuild the HTML report without recapturing:
+
+```bash
+python3 scripts/desktop-memory-report.py \
+  artifacts/desktop-memory/session-20260329-170000.json \
+  --output artifacts/desktop-memory/session-20260329-170000.html
+```

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -825,6 +825,7 @@
         decodeNative,
         decodeWithFallback,
         getDecodeRoute,
+        renderDecodeError,
         renderPixels,
         renderDicom
     };

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -197,19 +197,40 @@
         return studies;
     }
 
+    const cacheSourceIds = new WeakMap();
+    let nextCacheSourceId = 0;
+
+    function getCacheSourceId(sourceObject, prefix) {
+        if (!sourceObject || (typeof sourceObject !== 'object' && typeof sourceObject !== 'function')) {
+            return null;
+        }
+
+        if (!cacheSourceIds.has(sourceObject)) {
+            nextCacheSourceId += 1;
+            cacheSourceIds.set(sourceObject, `${prefix}:${nextCacheSourceId}`);
+        }
+
+        return cacheSourceIds.get(sourceObject);
+    }
+
     function getSliceCacheKey(slice, fallbackKey = null) {
         const source = slice?.source;
+        const frameIndex = slice?.frameIndex || 0;
+        if (slice?.sopInstanceUid) {
+            return `sop:${slice.sopInstanceUid}:${frameIndex}`;
+        }
+
         switch (source?.kind) {
             case 'path':
-                return `path:${source.path}`;
+                return `path:${source.path}:${frameIndex}`;
             case 'api':
-                return `api:${source.apiBase}|${source.studyId}|${source.seriesId}|${source.sliceIndex}`;
+                return `api:${source.apiBase}|${source.studyId}|${source.seriesId}|${source.sliceIndex}|${frameIndex}`;
             case 'blob':
-                return source.blob || fallbackKey;
+                return `${getCacheSourceId(source.blob, 'blob') || `blob:${fallbackKey ?? 'unknown'}`}:${frameIndex}`;
             case 'handle':
-                return source.handle || fallbackKey;
+                return `${getCacheSourceId(source.handle, 'handle') || `handle:${fallbackKey ?? 'unknown'}`}:${frameIndex}`;
             default:
-                return fallbackKey ?? source ?? null;
+                return `slice:${fallbackKey ?? 'unknown'}:${frameIndex}`;
         }
     }
 

--- a/docs/js/app/state.js
+++ b/docs/js/app/state.js
@@ -49,7 +49,7 @@
      * @property {Object|null} currentStudy - Currently viewed study
      * @property {Object|null} currentSeries - Currently viewed series
      * @property {number} currentSliceIndex - Index of currently displayed slice
-     * @property {LRUCache} sliceCache - LRU cache of parsed DICOM datasets by slice index
+     * @property {LRUCache} sliceCache - LRU cache of decoded DICOM frames keyed by slice
      * @property {string} currentTool - Active tool ('wl', 'pan', 'zoom', or null)
      * @property {Object} viewTransform - Pan and zoom state
      * @property {Object} windowLevel - Current W/L override (null = use DICOM values)

--- a/docs/js/app/tools.js
+++ b/docs/js/app/tools.js
@@ -325,13 +325,17 @@
         if (!slice) return;
 
         const cacheKey = app.sources?.getSliceCacheKey?.(slice, state.currentSliceIndex);
-        const dataSet = state.sliceCache.get(cacheKey);
-        if (!dataSet) return;
+        const decoded = state.sliceCache.get(cacheKey);
+        if (!decoded) return;
 
         const wlOverride = (state.windowLevel.center !== null && state.windowLevel.width !== null)
             ? state.windowLevel
             : null;
-        await app.rendering.renderDicom(dataSet, wlOverride, slice.frameIndex || 0, slice);
+        if (decoded.error) {
+            app.rendering.renderDecodeError(decoded);
+            return;
+        }
+        app.rendering.renderPixels(decoded, wlOverride);
     }
 
     function handleWLDrag(dx, dy) {

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -17,7 +17,11 @@
     } = app.dom;
     const { escapeHtml } = app.utils;
     const { toDicomByteArray } = app.dicom;
-    const { renderDicom } = app.rendering;
+    const {
+        decodeWithFallback,
+        renderDecodeError,
+        renderPixels
+    } = app.rendering;
     const { readSliceBuffer, getSliceCacheKey } = app.sources;
     const {
         resetViewForNewSeries,
@@ -25,11 +29,168 @@
     } = app.tools;
 
     const VIEWER_PRELOAD_RADIUS = config?.deploymentMode === 'desktop' ? 1 : 3;
+    let loadGeneration = 0;
+    let activeLoadRequestId = 0;
+    const inFlightLoads = new Map();
+
+    function beginLoadGeneration() {
+        loadGeneration += 1;
+        activeLoadRequestId += 1;
+        inFlightLoads.clear();
+    }
+
+    function isLoadStale(generation, requestId, series) {
+        return generation !== loadGeneration
+            || requestId !== activeLoadRequestId
+            || state.currentSeries !== series;
+    }
+
+    function renderDecodedSlice(decoded, wlOverride = null, options = {}) {
+        const { displayErrors = true } = options;
+        if (!decoded) {
+            return renderDecodeError(
+                {
+                    error: true,
+                    errorMessage: 'Image decode failed',
+                    errorDetails: 'Unknown decode error'
+                },
+                { display: displayErrors }
+            );
+        }
+        if (decoded.error) {
+            return renderDecodeError(decoded, { display: displayErrors });
+        }
+        return renderPixels(decoded, wlOverride);
+    }
+
+    async function getDecodedSlice(slice, index, purpose, generation, options = {}) {
+        const { requestId = null, series = null } = options;
+        const isStale = () => generation !== loadGeneration
+            || (requestId !== null && requestId !== activeLoadRequestId)
+            || (series && state.currentSeries !== series);
+        const cacheKey = getSliceCacheKey(slice, index);
+        if (cacheKey && state.sliceCache.has(cacheKey)) {
+            return state.sliceCache.get(cacheKey);
+        }
+
+        if (cacheKey && inFlightLoads.has(cacheKey)) {
+            return inFlightLoads.get(cacheKey);
+        }
+
+        const loadPromise = (async () => {
+            const buf = await readSliceBuffer(slice, purpose);
+            if (isStale()) return null;
+
+            const byteArray = await toDicomByteArray(buf);
+            if (isStale()) return null;
+
+            const dataSet = dicomParser.parseDicom(byteArray);
+            if (isStale()) return null;
+
+            const decoded = await decodeWithFallback(dataSet, slice.frameIndex || 0, slice);
+            if (isStale()) return null;
+
+            if (decoded && !decoded.error && cacheKey) {
+                state.sliceCache.set(cacheKey, decoded);
+            }
+
+            return decoded || null;
+        })();
+
+        if (cacheKey) {
+            inFlightLoads.set(cacheKey, loadPromise);
+            loadPromise.finally(() => {
+                if (inFlightLoads.get(cacheKey) === loadPromise) {
+                    inFlightLoads.delete(cacheKey);
+                }
+            });
+        }
+
+        return loadPromise;
+    }
+
+    function preloadNearbySlices(slices, index, generation, requestId, series) {
+        if (isLoadStale(generation, requestId, series)) {
+            return;
+        }
+
+        for (let i = index - VIEWER_PRELOAD_RADIUS; i <= index + VIEWER_PRELOAD_RADIUS; i++) {
+            if (i < 0 || i >= slices.length) continue;
+
+            const preloadSlice = slices[i];
+            const preloadCacheKey = getSliceCacheKey(preloadSlice, i);
+            if (!preloadCacheKey || state.sliceCache.has(preloadCacheKey) || inFlightLoads.has(preloadCacheKey)) {
+                continue;
+            }
+
+            getDecodedSlice(preloadSlice, i, 'preload', generation).catch(() => {});
+        }
+    }
+
+    function updateSliceMetadata(info, slice, index, totalSlices) {
+        if (info && info.isBlank) {
+            metadataContent.innerHTML = `
+                <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${totalSlices}</div></div>
+                <div class="metadata-item"><div class="label">Modality</div><div class="value">${escapeHtml(info.modality || '-')}</div></div>
+                <div class="metadata-item"><div class="label">Size</div><div class="value">${info.cols} x ${info.rows}</div></div>
+                <div class="metadata-item"><div class="label">Location</div><div class="value">${slice.sliceLocation?.toFixed(2) || '-'} mm</div></div>
+            `;
+            return;
+        }
+
+        if (info && !info.error) {
+            let metadataHtml = `
+                <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${totalSlices}</div></div>
+                <div class="metadata-item"><div class="label">Modality</div><div class="value">${escapeHtml(info.modality || '-')}</div></div>
+                <div class="metadata-item"><div class="label">Size</div><div class="value">${info.cols} x ${info.rows}</div></div>
+                <div class="metadata-item"><div class="label">Location</div><div class="value">${slice.sliceLocation?.toFixed(2) || '-'} mm</div></div>
+                <div class="metadata-item"><div class="label">Window</div><div class="value">C:${info.wc} W:${info.ww}</div></div>
+            `;
+
+            if (info.modality === 'MR' && info.mrMetadata) {
+                const mr = info.mrMetadata;
+                metadataHtml += '<div class="metadata-divider"></div>';
+
+                if (mr.protocolName) {
+                    metadataHtml += `<div class="metadata-item"><div class="label">Protocol</div><div class="value">${escapeHtml(mr.protocolName)}</div></div>`;
+                }
+                if (mr.sequenceName) {
+                    metadataHtml += `<div class="metadata-item"><div class="label">Sequence</div><div class="value">${escapeHtml(mr.sequenceName)}</div></div>`;
+                }
+                if (mr.repetitionTime) {
+                    metadataHtml += `<div class="metadata-item"><div class="label">TR</div><div class="value">${mr.repetitionTime.toFixed(1)} ms</div></div>`;
+                }
+                if (mr.echoTime) {
+                    metadataHtml += `<div class="metadata-item"><div class="label">TE</div><div class="value">${mr.echoTime.toFixed(1)} ms</div></div>`;
+                }
+                if (mr.flipAngle) {
+                    metadataHtml += `<div class="metadata-item"><div class="label">Flip Angle</div><div class="value">${escapeHtml(mr.flipAngle)}°</div></div>`;
+                }
+                if (mr.magneticFieldStrength) {
+                    metadataHtml += `<div class="metadata-item"><div class="label">Field</div><div class="value">${escapeHtml(mr.magneticFieldStrength)}T</div></div>`;
+                }
+            }
+
+            metadataContent.innerHTML = metadataHtml;
+            return;
+        }
+
+        if (info && info.error) {
+            metadataContent.innerHTML = `
+                <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${totalSlices}</div></div>
+                <div class="metadata-item"><div class="label">Status</div><div class="value" style="color: #f0ad4e;">Decode Error</div></div>
+                <div class="metadata-item"><div class="label">Format</div><div class="value">${info.tsInfo?.name || 'Unknown'}</div></div>
+            `;
+        }
+    }
 
     async function loadSlice(index) {
         if (!state.currentSeries) return;
-        const slices = state.currentSeries.slices;
+        const series = state.currentSeries;
+        const slices = series.slices;
         if (index < 0 || index >= slices.length) return;
+        const generation = loadGeneration;
+        const requestId = ++activeLoadRequestId;
 
         state.currentSliceIndex = index;
         updateSliceInfo();
@@ -37,88 +198,43 @@
 
         try {
             const slice = slices[index];
-            const cacheKey = getSliceCacheKey(slice, index);
-            let dataSet = state.sliceCache.get(cacheKey);
-
-            if (!dataSet) {
-                const buf = await readSliceBuffer(slice, 'load');
-                dataSet = dicomParser.parseDicom(await toDicomByteArray(buf));
-                state.sliceCache.set(cacheKey, dataSet);
+            let decoded = await getDecodedSlice(slice, index, 'load', generation, { requestId, series });
+            if (!decoded && !isLoadStale(generation, requestId, series)) {
+                decoded = await getDecodedSlice(slice, index, 'load', generation, { requestId, series });
+            }
+            if (isLoadStale(generation, requestId, series)) {
+                return;
             }
 
             const wlOverride = (state.windowLevel.center !== null && state.windowLevel.width !== null)
                 ? state.windowLevel
                 : null;
-            const info = await renderDicom(dataSet, wlOverride, slice.frameIndex || 0, slice);
+            const info = renderDecodedSlice(decoded, wlOverride);
 
             updateWLDisplay();
-
-            if (info && !info.error) {
-                let metadataHtml = `
-                    <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${slices.length}</div></div>
-                    <div class="metadata-item"><div class="label">Modality</div><div class="value">${escapeHtml(info.modality || '-')}</div></div>
-                    <div class="metadata-item"><div class="label">Size</div><div class="value">${info.cols} x ${info.rows}</div></div>
-                    <div class="metadata-item"><div class="label">Location</div><div class="value">${slice.sliceLocation?.toFixed(2) || '-'} mm</div></div>
-                    <div class="metadata-item"><div class="label">Window</div><div class="value">C:${info.wc} W:${info.ww}</div></div>
-                `;
-
-                if (info.modality === 'MR' && info.mrMetadata) {
-                    const mr = info.mrMetadata;
-                    metadataHtml += '<div class="metadata-divider"></div>';
-
-                    if (mr.protocolName) {
-                        metadataHtml += `<div class="metadata-item"><div class="label">Protocol</div><div class="value">${escapeHtml(mr.protocolName)}</div></div>`;
-                    }
-                    if (mr.sequenceName) {
-                        metadataHtml += `<div class="metadata-item"><div class="label">Sequence</div><div class="value">${escapeHtml(mr.sequenceName)}</div></div>`;
-                    }
-                    if (mr.repetitionTime) {
-                        metadataHtml += `<div class="metadata-item"><div class="label">TR</div><div class="value">${mr.repetitionTime.toFixed(1)} ms</div></div>`;
-                    }
-                    if (mr.echoTime) {
-                        metadataHtml += `<div class="metadata-item"><div class="label">TE</div><div class="value">${mr.echoTime.toFixed(1)} ms</div></div>`;
-                    }
-                    if (mr.flipAngle) {
-                        metadataHtml += `<div class="metadata-item"><div class="label">Flip Angle</div><div class="value">${escapeHtml(mr.flipAngle)}°</div></div>`;
-                    }
-                    if (mr.magneticFieldStrength) {
-                        metadataHtml += `<div class="metadata-item"><div class="label">Field</div><div class="value">${escapeHtml(mr.magneticFieldStrength)}T</div></div>`;
-                    }
-                }
-
-                metadataContent.innerHTML = metadataHtml;
-            } else if (info && info.isBlank) {
-                metadataContent.innerHTML = `
-                    <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${slices.length}</div></div>
-                    <div class="metadata-item"><div class="label">Modality</div><div class="value">${escapeHtml(info.modality || '-')}</div></div>
-                    <div class="metadata-item"><div class="label">Size</div><div class="value">${info.cols} x ${info.rows}</div></div>
-                    <div class="metadata-item"><div class="label">Location</div><div class="value">${slice.sliceLocation?.toFixed(2) || '-'} mm</div></div>
-                `;
-            } else if (info && info.error) {
-                metadataContent.innerHTML = `
-                    <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${slices.length}</div></div>
-                    <div class="metadata-item"><div class="label">Status</div><div class="value" style="color: #f0ad4e;">Decode Error</div></div>
-                    <div class="metadata-item"><div class="label">Format</div><div class="value">${info.tsInfo?.name || 'Unknown'}</div></div>
-                `;
+            updateSliceMetadata(info, slice, index, slices.length);
+            if (isLoadStale(generation, requestId, series)) {
+                return;
             }
-
-            for (let i = index - VIEWER_PRELOAD_RADIUS; i <= index + VIEWER_PRELOAD_RADIUS; i++) {
-                if (i >= 0 && i < slices.length) {
-                    const preloadSlice = slices[i];
-                    const preloadCacheKey = getSliceCacheKey(preloadSlice, i);
-                    if (state.sliceCache.has(preloadCacheKey)) continue;
-                    readSliceBuffer(preloadSlice, 'preload').then(buf => {
-                        toDicomByteArray(buf).then(byteArray => {
-                            state.sliceCache.set(preloadCacheKey, dicomParser.parseDicom(byteArray));
-                        }).catch(() => {});
-                    }).catch(() => {});
-                }
-            }
+            preloadNearbySlices(slices, index, generation, requestId, series);
         } catch (e) {
             console.error('Error loading slice:', e);
+            if (!isLoadStale(generation, requestId, series)) {
+                const errorInfo = renderDecodedSlice(
+                    {
+                        error: true,
+                        errorMessage: 'Image decode failed',
+                        errorDetails: e.message || 'Unknown decode error'
+                    },
+                    null
+                );
+                updateSliceMetadata(errorInfo, slices[index], index, slices.length);
+            }
+        } finally {
+            if (requestId === activeLoadRequestId) {
+                imageLoading.style.display = 'none';
+            }
         }
-
-        imageLoading.style.display = 'none';
     }
 
     function updateSliceInfo() {
@@ -130,6 +246,7 @@
     }
 
     function selectSeries(seriesUid) {
+        beginLoadGeneration();
         state.currentSeries = state.currentStudy.series[seriesUid];
         state.sliceCache.clear();
         state.currentSliceIndex = 0;
@@ -179,12 +296,17 @@
     }
 
     function closeViewer() {
+        beginLoadGeneration();
         viewerView.style.display = 'none';
         libraryView.style.display = 'block';
         document.body.classList.remove('viewer-page');
         state.currentStudy = null;
         state.currentSeries = null;
         state.sliceCache.clear();
+        state.measurements.clear();
+        state.activeMeasurement = null;
+        state.pixelSpacing = null;
+        imageLoading.style.display = 'none';
         canvas.style.transform = '';
     }
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "app.py",
   "scripts": {
     "desktop:launch": "cd desktop && npm run dev:desktop",
+    "desktop:memory:capture": "python3 scripts/desktop-memory-capture.py",
+    "desktop:memory:report": "python3 scripts/desktop-memory-report.py",
     "test": "npx playwright test",
     "worktree:new": "./scripts/agent-worktree-new.sh",
     "worktree:list": "./scripts/agent-worktree-list.sh",

--- a/scripts/desktop-memory-capture.py
+++ b/scripts/desktop-memory-capture.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Capture RSS samples for a manual desktop-memory validation run."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import queue
+import socket
+import subprocess
+import sys
+import threading
+import time
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Capture RSS samples for the desktop app. "
+            "Type marker labels and press Enter while the capture is running."
+        )
+    )
+    parser.add_argument(
+        "--pid",
+        type=int,
+        help="PID to monitor. If omitted, the script resolves a process by name.",
+    )
+    parser.add_argument(
+        "--process",
+        default="myradone",
+        help="Process name fragment to resolve when --pid is not provided. Default: myradone",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Sampling interval in seconds. Default: 1.0",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=0.0,
+        help="Optional capture duration in seconds. Default: run until Ctrl+C or process exit.",
+    )
+    parser.add_argument(
+        "--output",
+        help=(
+            "Path to the output JSON session file. "
+            "Default: artifacts/desktop-memory/session-<timestamp>.json"
+        ),
+    )
+    parser.add_argument(
+        "--html",
+        help=(
+            "Optional path for an HTML dashboard. "
+            "If provided, the report is generated automatically after capture."
+        ),
+    )
+    parser.add_argument(
+        "--notes",
+        default="",
+        help="Optional free-form notes stored in the session file.",
+    )
+    parser.add_argument(
+        "--target-plateau-mb",
+        type=float,
+        default=200.0,
+        help="Target settled RSS shown in the report. Default: 200 MB",
+    )
+    return parser.parse_args()
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def resolve_git_metadata() -> dict[str, str]:
+    branch = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+    commit = run_command(["git", "rev-parse", "HEAD"]).stdout.strip()
+    return {
+        "branch": branch,
+        "commit": commit,
+    }
+
+
+def default_output_path() -> pathlib.Path:
+    timestamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    return pathlib.Path("artifacts") / "desktop-memory" / f"session-{timestamp}.json"
+
+
+def ensure_parent(path: pathlib.Path) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def resolve_process(pid: int | None, process_name: str) -> tuple[int, str]:
+    if pid is not None:
+        snapshot = sample_process(pid)
+        if snapshot is None:
+            raise SystemExit(f"Process with PID {pid} is not running.")
+        return pid, snapshot["command"]
+
+    result = run_command(["pgrep", "-fl", process_name])
+    candidates: list[tuple[int, str]] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) < 2:
+            continue
+        candidate_pid = int(parts[0])
+        command = parts[1]
+        if process_name.lower() not in command.lower():
+            continue
+        candidates.append((candidate_pid, command))
+
+    if not candidates:
+        raise SystemExit(
+            f'No running process matched "{process_name}". '
+            "Start the desktop app first or pass --pid."
+        )
+
+    if len(candidates) > 1:
+        formatted = "\n".join(f"  {candidate_pid}: {command}" for candidate_pid, command in candidates)
+        raise SystemExit(
+            f'Multiple processes matched "{process_name}". Pass --pid to choose one:\n{formatted}'
+        )
+
+    return candidates[0]
+
+
+def sample_process(pid: int) -> dict[str, Any] | None:
+    result = run_command(["ps", "-o", "rss=,vsz=,%cpu=,etime=,comm=", "-p", str(pid)])
+    output = result.stdout.strip()
+    if result.returncode != 0 or not output:
+        return None
+
+    parts = output.split(None, 4)
+    if len(parts) < 5:
+        return None
+
+    return {
+        "rss_kb": int(parts[0]),
+        "vsz_kb": int(parts[1]),
+        "cpu_percent": float(parts[2]),
+        "elapsed": parts[3],
+        "command": parts[4],
+    }
+
+
+def print_instructions(pid: int, command: str, output_path: pathlib.Path, html_path: pathlib.Path | None) -> None:
+    print(f"Monitoring PID {pid}: {command}")
+    print(f"Writing session data to {output_path}")
+    if html_path is not None:
+        print(f"Dashboard will be written to {html_path} after capture")
+    if sys.stdin.isatty():
+        print('Type a marker label and press Enter while the capture is running.')
+        print('Examples: "baseline done", "rapid scrub start", "rapid scrub stop", "close viewer".')
+    print("Press Ctrl+C to stop.\n")
+
+
+def start_marker_reader(marker_queue: queue.Queue[str]) -> None:
+    if not sys.stdin.isatty():
+        return
+
+    def reader() -> None:
+        while True:
+            line = sys.stdin.readline()
+            if not line:
+                return
+            marker_queue.put(line.rstrip("\n"))
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+
+
+def build_session_metadata(
+    pid: int,
+    process_name: str,
+    resolved_command: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    git = resolve_git_metadata()
+    return {
+        "schema_version": 1,
+        "captured_at": utc_now_iso(),
+        "host": socket.gethostname(),
+        "cwd": str(pathlib.Path.cwd()),
+        "pid": pid,
+        "process_name": process_name,
+        "resolved_command": resolved_command,
+        "interval_seconds": args.interval,
+        "duration_seconds": args.duration,
+        "notes": args.notes,
+        "target_plateau_mb": args.target_plateau_mb,
+        "git_branch": git["branch"],
+        "git_commit": git["commit"],
+    }
+
+
+def write_session_file(path: pathlib.Path, session: dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(session, handle, indent=2)
+        handle.write("\n")
+
+
+def maybe_generate_report(
+    session_path: pathlib.Path,
+    html_path: pathlib.Path | None,
+    target_plateau_mb: float,
+) -> None:
+    if html_path is None:
+        return
+
+    report_script = pathlib.Path(__file__).with_name("desktop-memory-report.py")
+    result = run_command(
+        [
+            sys.executable,
+            str(report_script),
+            str(session_path),
+            "--output",
+            str(html_path),
+            "--target-plateau-mb",
+            str(target_plateau_mb),
+        ]
+    )
+    if result.returncode != 0:
+        print(result.stdout, end="")
+        print(result.stderr, end="", file=sys.stderr)
+        raise SystemExit(f"Failed to generate HTML report at {html_path}")
+
+
+def main() -> None:
+    args = parse_args()
+    output_path = ensure_parent(pathlib.Path(args.output) if args.output else default_output_path())
+    html_path = ensure_parent(pathlib.Path(args.html)) if args.html else None
+
+    pid, resolved_command = resolve_process(args.pid, args.process)
+    print_instructions(pid, resolved_command, output_path, html_path)
+
+    marker_queue: queue.Queue[str] = queue.Queue()
+    start_marker_reader(marker_queue)
+
+    started_at = time.time()
+    samples: list[dict[str, Any]] = []
+    markers: list[dict[str, Any]] = [
+        {
+            "time_seconds": 0.0,
+            "label": "Capture start",
+            "source": "system",
+        }
+    ]
+
+    marker_count = 0
+    stop_reason = "manual-stop"
+
+    try:
+        while True:
+            now = time.time()
+            time_seconds = round(now - started_at, 3)
+            snapshot = sample_process(pid)
+            if snapshot is None:
+                stop_reason = "process-exited"
+                markers.append(
+                    {
+                        "time_seconds": time_seconds,
+                        "label": "Process exited",
+                        "source": "system",
+                    }
+                )
+                break
+
+            samples.append(
+                {
+                    "timestamp": utc_now_iso(),
+                    "time_seconds": time_seconds,
+                    **snapshot,
+                }
+            )
+
+            while not marker_queue.empty():
+                raw_label = marker_queue.get_nowait().strip()
+                marker_count += 1
+                label = raw_label or f"Marker {marker_count}"
+                markers.append(
+                    {
+                        "time_seconds": time_seconds,
+                        "label": label,
+                        "source": "manual",
+                    }
+                )
+                print(f"[marker @ {time_seconds:7.1f}s] {label}")
+
+            if args.duration > 0 and time_seconds >= args.duration:
+                stop_reason = "duration-reached"
+                markers.append(
+                    {
+                        "time_seconds": time_seconds,
+                        "label": "Duration reached",
+                        "source": "system",
+                    }
+                )
+                break
+
+            time.sleep(max(args.interval, 0.1))
+    except KeyboardInterrupt:
+        stop_reason = "keyboard-interrupt"
+        markers.append(
+            {
+                "time_seconds": round(time.time() - started_at, 3),
+                "label": "Capture stopped",
+                "source": "system",
+            }
+        )
+        print("\nStopping capture...")
+
+    session = build_session_metadata(pid, args.process, resolved_command, args)
+    session.update(
+        {
+            "stop_reason": stop_reason,
+            "sample_count": len(samples),
+            "samples": samples,
+            "markers": markers,
+        }
+    )
+    write_session_file(output_path, session)
+    maybe_generate_report(output_path, html_path, args.target_plateau_mb)
+
+    print(f"Saved {len(samples)} samples to {output_path}")
+    if html_path is not None:
+        print(f"Saved dashboard to {html_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/desktop-memory-report.py
+++ b/scripts/desktop-memory-report.py
@@ -1,0 +1,860 @@
+#!/usr/bin/env python3
+"""Render a self-contained HTML dashboard for a memory-capture session."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import pathlib
+import statistics
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build an HTML dashboard from a desktop-memory session JSON file.")
+    parser.add_argument("session", help="Path to the session JSON file produced by desktop-memory-capture.py")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to the output HTML dashboard",
+    )
+    parser.add_argument(
+        "--target-plateau-mb",
+        type=float,
+        default=None,
+        help="Optional settled RSS target shown in the dashboard. Defaults to the value stored in the session file.",
+    )
+    parser.add_argument(
+        "--baseline-window-seconds",
+        type=float,
+        default=15.0,
+        help="Window used to estimate baseline RSS. Default: 15s",
+    )
+    parser.add_argument(
+        "--settled-window-seconds",
+        type=float,
+        default=15.0,
+        help="Window used to estimate settled RSS. Default: 15s",
+    )
+    parser.add_argument(
+        "--tail-window-seconds",
+        type=float,
+        default=30.0,
+        help="Window used to estimate the end-of-run slope. Default: 30s",
+    )
+    return parser.parse_args()
+
+
+def read_session(path: pathlib.Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def ensure_output(path: pathlib.Path) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def rss_mb(sample: dict[str, Any]) -> float:
+    return float(sample["rss_kb"]) / 1024.0
+
+
+def fmt_mb(value: float) -> str:
+    return f"{value:.1f} MB"
+
+
+def fmt_delta_mb(value: float) -> str:
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value:.1f} MB"
+
+
+def fmt_seconds(value: float) -> str:
+    total_seconds = int(round(value))
+    minutes, seconds = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours:d}h {minutes:02d}m {seconds:02d}s"
+    if minutes:
+        return f"{minutes:d}m {seconds:02d}s"
+    return f"{seconds:d}s"
+
+
+def fmt_timecode(value: float) -> str:
+    total_seconds = int(round(value))
+    minutes, seconds = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours:d}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes:d}:{seconds:02d}"
+
+
+def median(values: list[float]) -> float:
+    return statistics.median(values) if values else 0.0
+
+
+def subset_by_time(samples: list[dict[str, Any]], start: float, end: float) -> list[dict[str, Any]]:
+    return [sample for sample in samples if start <= float(sample["time_seconds"]) <= end]
+
+
+def first_window(samples: list[dict[str, Any]], seconds: float) -> list[dict[str, Any]]:
+    if not samples:
+        return []
+    end = min(float(samples[-1]["time_seconds"]), seconds)
+    return subset_by_time(samples, 0.0, end)
+
+
+def last_window(samples: list[dict[str, Any]], seconds: float) -> list[dict[str, Any]]:
+    if not samples:
+        return []
+    start = max(0.0, float(samples[-1]["time_seconds"]) - seconds)
+    return subset_by_time(samples, start, float(samples[-1]["time_seconds"]))
+
+
+def slope_mb_per_minute(samples: list[dict[str, Any]]) -> float:
+    if len(samples) < 2:
+        return 0.0
+
+    xs = [float(sample["time_seconds"]) for sample in samples]
+    ys = [rss_mb(sample) for sample in samples]
+    x_mean = statistics.fmean(xs)
+    y_mean = statistics.fmean(ys)
+    denominator = sum((x - x_mean) ** 2 for x in xs)
+    if denominator == 0:
+        return 0.0
+    numerator = sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, ys))
+    return (numerator / denominator) * 60.0
+
+
+def classify_session(
+    baseline_mb: float,
+    settled_mb: float,
+    tail_slope_mb_per_minute_value: float,
+    target_plateau_mb: float | None,
+) -> tuple[str, str]:
+    settled_delta = settled_mb - baseline_mb
+    over_target = target_plateau_mb is not None and settled_mb > target_plateau_mb
+
+    if settled_delta <= 25 and tail_slope_mb_per_minute_value <= 5 and not over_target:
+        return "Looks stable", "good"
+    if settled_delta <= 75 and tail_slope_mb_per_minute_value <= 10:
+        return "Borderline", "warning"
+    return "Growth risk", "danger"
+
+
+def build_phase_rows(samples: list[dict[str, Any]], markers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not samples:
+        return []
+
+    duration = float(samples[-1]["time_seconds"])
+    ordered_markers = sorted(markers, key=lambda marker: float(marker["time_seconds"]))
+    if not ordered_markers or float(ordered_markers[0]["time_seconds"]) > 0:
+        ordered_markers.insert(
+            0,
+            {
+                "time_seconds": 0.0,
+                "label": "Capture start",
+                "source": "synthetic",
+            },
+        )
+
+    phases: list[dict[str, Any]] = []
+    for index, marker in enumerate(ordered_markers):
+        start = float(marker["time_seconds"])
+        end = float(ordered_markers[index + 1]["time_seconds"]) if index + 1 < len(ordered_markers) else duration
+        if index + 1 == len(ordered_markers):
+            phase_samples = subset_by_time(samples, start, duration)
+            next_label = "Session end"
+        else:
+            phase_samples = [sample for sample in samples if start <= float(sample["time_seconds"]) < end]
+            next_label = ordered_markers[index + 1]["label"]
+
+        if not phase_samples:
+            continue
+
+        start_samples = phase_samples[: min(5, len(phase_samples))]
+        end_samples = phase_samples[-min(5, len(phase_samples)) :]
+        start_mb = median([rss_mb(sample) for sample in start_samples])
+        end_mb = median([rss_mb(sample) for sample in end_samples])
+        peak_sample = max(phase_samples, key=rss_mb)
+        phases.append(
+            {
+                "name": marker["label"],
+                "until": next_label,
+                "duration_seconds": max(0.0, end - start),
+                "start_mb": start_mb,
+                "peak_mb": rss_mb(peak_sample),
+                "peak_time_seconds": float(peak_sample["time_seconds"]),
+                "end_mb": end_mb,
+                "delta_mb": end_mb - start_mb,
+            }
+        )
+
+    return phases
+
+
+def marker_rows(samples: list[dict[str, Any]], markers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not samples:
+        return rows
+
+    for index, marker in enumerate(sorted(markers, key=lambda item: float(item["time_seconds"])), start=1):
+        time_seconds = float(marker["time_seconds"])
+        nearest = min(samples, key=lambda sample: abs(float(sample["time_seconds"]) - time_seconds))
+        rows.append(
+            {
+                "index": index,
+                "time_seconds": time_seconds,
+                "label": marker["label"],
+                "source": marker.get("source", ""),
+                "rss_mb": rss_mb(nearest),
+            }
+        )
+    return rows
+
+
+def svg_chart(
+    samples: list[dict[str, Any]],
+    markers: list[dict[str, Any]],
+    baseline_mb: float,
+    settled_mb: float,
+    target_plateau_mb: float | None,
+) -> str:
+    width = 1180
+    height = 420
+    left = 80
+    right = 24
+    top = 24
+    bottom = 56
+    chart_width = width - left - right
+    chart_height = height - top - bottom
+
+    xs = [float(sample["time_seconds"]) for sample in samples]
+    ys = [rss_mb(sample) for sample in samples]
+    max_time = max(xs[-1], 1.0)
+    min_y = min(ys + [baseline_mb, settled_mb] + ([target_plateau_mb] if target_plateau_mb is not None else []))
+    max_y = max(ys + [baseline_mb, settled_mb] + ([target_plateau_mb] if target_plateau_mb is not None else []))
+    min_y = max(0.0, math.floor(max(min_y - 10.0, 0.0) / 10.0) * 10.0)
+    max_y = math.ceil((max_y + 10.0) / 10.0) * 10.0
+    if math.isclose(max_y, min_y):
+        max_y += 10.0
+
+    def x_pos(time_seconds: float) -> float:
+        return left + (time_seconds / max_time) * chart_width
+
+    def y_pos(value_mb: float) -> float:
+        ratio = (value_mb - min_y) / (max_y - min_y)
+        return top + chart_height - (ratio * chart_height)
+
+    points = " ".join(f"{x_pos(x):.2f},{y_pos(y):.2f}" for x, y in zip(xs, ys))
+
+    horizontal_lines = []
+    for index in range(6):
+        y_value = min_y + ((max_y - min_y) * index / 5.0)
+        y = y_pos(y_value)
+        horizontal_lines.append(
+            f'<line x1="{left}" y1="{y:.2f}" x2="{width - right}" y2="{y:.2f}" class="grid" />'
+            f'<text x="{left - 12}" y="{y + 4:.2f}" class="axis-label axis-label-left">{fmt_mb(y_value)}</text>'
+        )
+
+    vertical_lines = []
+    for index in range(6):
+        x_value = (max_time * index) / 5.0
+        x = x_pos(x_value)
+        vertical_lines.append(
+            f'<line x1="{x:.2f}" y1="{top}" x2="{x:.2f}" y2="{height - bottom}" class="grid grid-vertical" />'
+            f'<text x="{x:.2f}" y="{height - bottom + 24}" class="axis-label axis-label-bottom">{fmt_timecode(x_value)}</text>'
+        )
+
+    marker_lines = []
+    for index, marker in enumerate(sorted(markers, key=lambda item: float(item["time_seconds"])), start=1):
+        x = x_pos(float(marker["time_seconds"]))
+        marker_lines.append(
+            f'<line x1="{x:.2f}" y1="{top}" x2="{x:.2f}" y2="{height - bottom}" class="marker-line" />'
+            f'<circle cx="{x:.2f}" cy="{top + 8:.2f}" r="10" class="marker-dot" />'
+            f'<text x="{x:.2f}" y="{top + 12:.2f}" class="marker-text">{index}</text>'
+        )
+
+    target_line = ""
+    if target_plateau_mb is not None:
+        y = y_pos(target_plateau_mb)
+        target_line = (
+            f'<line x1="{left}" y1="{y:.2f}" x2="{width - right}" y2="{y:.2f}" class="target-line" />'
+            f'<text x="{width - right}" y="{y - 8:.2f}" class="target-label">Target plateau {fmt_mb(target_plateau_mb)}</text>'
+        )
+
+    baseline_y = y_pos(baseline_mb)
+    settled_y = y_pos(settled_mb)
+    return f"""
+<svg viewBox="0 0 {width} {height}" class="chart-svg" role="img" aria-label="RSS over time">
+  <rect x="0" y="0" width="{width}" height="{height}" rx="24" class="chart-bg" />
+  {''.join(horizontal_lines)}
+  {''.join(vertical_lines)}
+  {target_line}
+  <line x1="{left}" y1="{baseline_y:.2f}" x2="{width - right}" y2="{baseline_y:.2f}" class="baseline-line" />
+  <line x1="{left}" y1="{settled_y:.2f}" x2="{width - right}" y2="{settled_y:.2f}" class="settled-line" />
+  <polyline points="{points}" class="rss-line" />
+  {''.join(marker_lines)}
+</svg>
+"""
+
+
+def dashboard_html(
+    session: dict[str, Any],
+    target_plateau_mb: float | None,
+    baseline_window_seconds: float,
+    settled_window_seconds: float,
+    tail_window_seconds: float,
+) -> str:
+    samples = session.get("samples", [])
+    markers = session.get("markers", [])
+    if not samples:
+        raise SystemExit("The session file has no samples.")
+
+    duration_seconds = float(samples[-1]["time_seconds"])
+    baseline_samples = first_window(samples, baseline_window_seconds)
+    settled_samples = last_window(samples, settled_window_seconds)
+    tail_samples = last_window(samples, tail_window_seconds)
+
+    baseline_mb = median([rss_mb(sample) for sample in baseline_samples])
+    settled_mb = median([rss_mb(sample) for sample in settled_samples])
+    final_mb = rss_mb(samples[-1])
+    peak_sample = max(samples, key=rss_mb)
+    peak_mb = rss_mb(peak_sample)
+    peak_time_seconds = float(peak_sample["time_seconds"])
+    tail_slope = slope_mb_per_minute(tail_samples)
+    verdict_text, verdict_tone = classify_session(baseline_mb, settled_mb, tail_slope, target_plateau_mb)
+    phases = build_phase_rows(samples, markers)
+    marker_table = marker_rows(samples, markers)
+
+    chart = svg_chart(samples, markers, baseline_mb, settled_mb, target_plateau_mb)
+    baseline_delta = settled_mb - baseline_mb
+    peak_delta = peak_mb - baseline_mb
+    final_delta = final_mb - baseline_mb
+    plateau_text = fmt_mb(target_plateau_mb) if target_plateau_mb is not None else "None"
+
+    phase_rows_html = "".join(
+        """
+        <tr>
+          <td>{name}</td>
+          <td>{until}</td>
+          <td>{duration}</td>
+          <td>{start_mb}</td>
+          <td>{peak_mb}</td>
+          <td>{end_mb}</td>
+          <td>{delta_mb}</td>
+        </tr>
+        """.format(
+            name=html.escape(phase["name"]),
+            until=html.escape(phase["until"]),
+            duration=fmt_seconds(phase["duration_seconds"]),
+            start_mb=fmt_mb(phase["start_mb"]),
+            peak_mb=f"{fmt_mb(phase['peak_mb'])} @ {fmt_timecode(phase['peak_time_seconds'])}",
+            end_mb=fmt_mb(phase["end_mb"]),
+            delta_mb=fmt_delta_mb(phase["delta_mb"]),
+        )
+        for phase in phases
+    )
+
+    marker_rows_html = "".join(
+        """
+        <tr>
+          <td>{index}</td>
+          <td>{label}</td>
+          <td>{timecode}</td>
+          <td>{source}</td>
+          <td>{rss_mb}</td>
+        </tr>
+        """.format(
+            index=row["index"],
+            label=html.escape(row["label"]),
+            timecode=fmt_timecode(row["time_seconds"]),
+            source=html.escape(row["source"]),
+            rss_mb=fmt_mb(row["rss_mb"]),
+        )
+        for row in marker_table
+    )
+
+    notes_html = ""
+    if session.get("notes"):
+        notes_html = f"""
+        <section class="panel">
+          <h2>Notes</h2>
+          <p>{html.escape(session["notes"])}</p>
+        </section>
+        """
+
+    title = "Desktop Memory Validation"
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title}</title>
+  <style>
+    :root {{
+      --bg: #f3efe3;
+      --panel: rgba(255, 252, 244, 0.84);
+      --panel-strong: rgba(255, 255, 255, 0.96);
+      --ink: #1a2820;
+      --muted: #5d6e64;
+      --line: rgba(38, 61, 49, 0.12);
+      --good: #1d6b4f;
+      --warning: #ab6b11;
+      --danger: #a33d34;
+      --accent: #0f766e;
+      --accent-soft: rgba(15, 118, 110, 0.12);
+      --shadow: 0 24px 80px rgba(21, 34, 28, 0.12);
+    }}
+
+    * {{
+      box-sizing: border-box;
+    }}
+
+    body {{
+      margin: 0;
+      font-family: "Avenir Next", "Segoe UI", sans-serif;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at top left, rgba(15, 118, 110, 0.14), transparent 32%),
+        radial-gradient(circle at top right, rgba(29, 107, 79, 0.14), transparent 30%),
+        linear-gradient(180deg, #f6f2e8, var(--bg));
+    }}
+
+    .shell {{
+      width: min(1180px, calc(100vw - 32px));
+      margin: 32px auto 48px;
+      display: grid;
+      gap: 18px;
+    }}
+
+    .hero {{
+      display: grid;
+      gap: 12px;
+      padding: 28px;
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(244, 250, 247, 0.86));
+      box-shadow: var(--shadow);
+    }}
+
+    .eyebrow {{
+      font-size: 12px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }}
+
+    h1, h2 {{
+      margin: 0;
+      font-weight: 700;
+    }}
+
+    h1 {{
+      font-size: clamp(32px, 5vw, 52px);
+      line-height: 1.02;
+    }}
+
+    h2 {{
+      font-size: 20px;
+    }}
+
+    p {{
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.6;
+    }}
+
+    .hero-meta {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }}
+
+    .chip {{
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.84);
+      font-size: 14px;
+      color: var(--ink);
+    }}
+
+    .chip-good {{
+      color: var(--good);
+      background: rgba(29, 107, 79, 0.08);
+      border-color: rgba(29, 107, 79, 0.2);
+    }}
+
+    .chip-warning {{
+      color: var(--warning);
+      background: rgba(171, 107, 17, 0.08);
+      border-color: rgba(171, 107, 17, 0.2);
+    }}
+
+    .chip-danger {{
+      color: var(--danger);
+      background: rgba(163, 61, 52, 0.08);
+      border-color: rgba(163, 61, 52, 0.2);
+    }}
+
+    .card-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 14px;
+    }}
+
+    .metric-card, .panel {{
+      padding: 20px;
+      border-radius: 24px;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(10px);
+    }}
+
+    .metric-label {{
+      font-size: 12px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 10px;
+    }}
+
+    .metric-value {{
+      font-size: 30px;
+      font-weight: 700;
+      line-height: 1.1;
+    }}
+
+    .metric-note {{
+      margin-top: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }}
+
+    .chart-panel {{
+      padding: 18px;
+    }}
+
+    .chart-header {{
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: center;
+      margin-bottom: 14px;
+      flex-wrap: wrap;
+    }}
+
+    .chart-legend {{
+      display: flex;
+      gap: 14px;
+      flex-wrap: wrap;
+      font-size: 13px;
+      color: var(--muted);
+    }}
+
+    .legend-item::before {{
+      content: "";
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      margin-right: 8px;
+      border-radius: 999px;
+    }}
+
+    .legend-rss::before {{ background: var(--accent); }}
+    .legend-baseline::before {{ background: #64748b; }}
+    .legend-settled::before {{ background: var(--good); }}
+    .legend-target::before {{ background: var(--warning); }}
+    .legend-marker::before {{ background: var(--danger); }}
+
+    .chart-svg {{
+      width: 100%;
+      height: auto;
+      display: block;
+    }}
+
+    .chart-bg {{
+      fill: rgba(255, 255, 255, 0.94);
+      stroke: rgba(38, 61, 49, 0.08);
+    }}
+
+    .grid {{
+      stroke: rgba(38, 61, 49, 0.08);
+      stroke-width: 1;
+    }}
+
+    .axis-label {{
+      fill: #6a7a71;
+      font-size: 12px;
+    }}
+
+    .axis-label-left {{
+      text-anchor: end;
+    }}
+
+    .axis-label-bottom {{
+      text-anchor: middle;
+    }}
+
+    .rss-line {{
+      fill: none;
+      stroke: var(--accent);
+      stroke-width: 4;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+    }}
+
+    .target-line {{
+      stroke: rgba(171, 107, 17, 0.88);
+      stroke-width: 2;
+      stroke-dasharray: 8 8;
+    }}
+
+    .target-label {{
+      fill: rgba(171, 107, 17, 0.88);
+      text-anchor: end;
+      font-size: 12px;
+      font-weight: 600;
+    }}
+
+    .baseline-line {{
+      stroke: rgba(100, 116, 139, 0.7);
+      stroke-width: 2;
+      stroke-dasharray: 6 6;
+    }}
+
+    .settled-line {{
+      stroke: rgba(29, 107, 79, 0.72);
+      stroke-width: 2;
+      stroke-dasharray: 10 5;
+    }}
+
+    .marker-line {{
+      stroke: rgba(163, 61, 52, 0.3);
+      stroke-width: 2;
+      stroke-dasharray: 4 7;
+    }}
+
+    .marker-dot {{
+      fill: rgba(163, 61, 52, 0.94);
+      stroke: rgba(255, 255, 255, 0.98);
+      stroke-width: 2;
+    }}
+
+    .marker-text {{
+      fill: white;
+      text-anchor: middle;
+      font-size: 11px;
+      font-weight: 700;
+    }}
+
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+      margin-top: 14px;
+    }}
+
+    th, td {{
+      padding: 12px 10px;
+      text-align: left;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+    }}
+
+    th {{
+      font-size: 12px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }}
+
+    .two-up {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 18px;
+    }}
+
+    code {{
+      font-family: "SFMono-Regular", Menlo, monospace;
+      font-size: 13px;
+      padding: 0.15em 0.4em;
+      border-radius: 8px;
+      background: var(--accent-soft);
+      color: var(--ink);
+    }}
+
+    .footer-note {{
+      font-size: 14px;
+    }}
+
+    @media (max-width: 720px) {{
+      .shell {{
+        width: min(100vw - 20px, 1180px);
+        margin: 16px auto 28px;
+      }}
+
+      .hero,
+      .metric-card,
+      .panel {{
+        border-radius: 20px;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <section class="hero">
+      <div class="eyebrow">Desktop Memory Validation</div>
+      <h1>RSS stayed {html.escape(verdict_text.lower())}</h1>
+      <p>
+        Session duration was {fmt_seconds(duration_seconds)} on host <code>{html.escape(str(session.get("host", "")))}</code>.
+        Baseline settled at {fmt_mb(baseline_mb)}, peak reached {fmt_mb(peak_mb)}, and the end-of-run plateau was {fmt_mb(settled_mb)}.
+      </p>
+      <div class="hero-meta">
+        <span class="chip chip-{verdict_tone}">{html.escape(verdict_text)}</span>
+        <span class="chip">PID {session.get("pid")}</span>
+        <span class="chip">{html.escape(str(session.get("resolved_command", "")))}</span>
+        <span class="chip">Target {plateau_text}</span>
+        <span class="chip">Stop reason: {html.escape(str(session.get("stop_reason", "")))}</span>
+      </div>
+    </section>
+
+    <section class="card-grid">
+      <article class="metric-card">
+        <div class="metric-label">Baseline</div>
+        <div class="metric-value">{fmt_mb(baseline_mb)}</div>
+        <div class="metric-note">Median of the first {fmt_seconds(baseline_window_seconds)}</div>
+      </article>
+      <article class="metric-card">
+        <div class="metric-label">Peak</div>
+        <div class="metric-value">{fmt_mb(peak_mb)}</div>
+        <div class="metric-note">At {fmt_timecode(peak_time_seconds)} ({fmt_delta_mb(peak_delta)} vs baseline)</div>
+      </article>
+      <article class="metric-card">
+        <div class="metric-label">Settled</div>
+        <div class="metric-value">{fmt_mb(settled_mb)}</div>
+        <div class="metric-note">Median of the last {fmt_seconds(settled_window_seconds)}</div>
+      </article>
+      <article class="metric-card">
+        <div class="metric-label">Final sample</div>
+        <div class="metric-value">{fmt_mb(final_mb)}</div>
+        <div class="metric-note">{fmt_delta_mb(final_delta)} vs baseline</div>
+      </article>
+      <article class="metric-card">
+        <div class="metric-label">Plateau delta</div>
+        <div class="metric-value">{fmt_delta_mb(baseline_delta)}</div>
+        <div class="metric-note">Settled minus baseline</div>
+      </article>
+      <article class="metric-card">
+        <div class="metric-label">Tail slope</div>
+        <div class="metric-value">{tail_slope:+.1f} MB/min</div>
+        <div class="metric-note">Linear trend over the last {fmt_seconds(tail_window_seconds)}</div>
+      </article>
+    </section>
+
+    <section class="panel chart-panel">
+      <div class="chart-header">
+        <div>
+          <h2>RSS Timeline</h2>
+          <p class="footer-note">Use the numbered markers to map the chart to the manual test steps below.</p>
+        </div>
+        <div class="chart-legend">
+          <span class="legend-item legend-rss">RSS</span>
+          <span class="legend-item legend-baseline">Baseline</span>
+          <span class="legend-item legend-settled">Settled</span>
+          <span class="legend-item legend-target">Target plateau</span>
+          <span class="legend-item legend-marker">Marker</span>
+        </div>
+      </div>
+      {chart}
+    </section>
+
+    <section class="two-up">
+      <section class="panel">
+        <h2>Phase Breakdown</h2>
+        <p>Each row starts at a marker and ends at the next marker, so you can see whether each phase created a new baseline or just a temporary spike.</p>
+        <table>
+          <thead>
+            <tr>
+              <th>From</th>
+              <th>Until</th>
+              <th>Duration</th>
+              <th>Start</th>
+              <th>Peak</th>
+              <th>End</th>
+              <th>Delta</th>
+            </tr>
+          </thead>
+          <tbody>
+            {phase_rows_html}
+          </tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>Markers</h2>
+        <p>Recommended labels: <code>baseline done</code>, <code>rapid scrub start</code>, <code>rapid scrub stop</code>, <code>close viewer</code>, <code>reopen second study</code>.</p>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Label</th>
+              <th>Time</th>
+              <th>Source</th>
+              <th>RSS nearby</th>
+            </tr>
+          </thead>
+          <tbody>
+            {marker_rows_html}
+          </tbody>
+        </table>
+      </section>
+    </section>
+
+    {notes_html}
+
+    <section class="panel">
+      <h2>Session Metadata</h2>
+      <p>
+        Branch <code>{html.escape(str(session.get("git_branch", "")))}</code> at
+        <code>{html.escape(str(session.get("git_commit", "")))}</code>,
+        sampled every <code>{session.get("interval_seconds")}</code>s from
+        <code>{html.escape(str(session.get("cwd", "")))}</code>.
+      </p>
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    args = parse_args()
+    session_path = pathlib.Path(args.session)
+    output_path = ensure_output(pathlib.Path(args.output))
+    session = read_session(session_path)
+    target_plateau_mb = args.target_plateau_mb
+    if target_plateau_mb is None:
+        raw_target = session.get("target_plateau_mb")
+        target_plateau_mb = float(raw_target) if raw_target is not None else None
+
+    html_text = dashboard_html(
+        session,
+        target_plateau_mb,
+        args.baseline_window_seconds,
+        args.settled_window_seconds,
+        args.tail_window_seconds,
+    )
+    output_path.write_text(html_text, encoding="utf-8")
+    print(f"Wrote dashboard to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -696,7 +696,7 @@ test.describe('Desktop library scanning', () => {
         });
     });
 
-    test('multi-frame metadata expands into virtual slices that share a cache key', async ({ page }) => {
+    test('multi-frame metadata expands into virtual slices with frame-aware cache keys', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
 
@@ -729,7 +729,12 @@ test.describe('Desktop library scanning', () => {
             '1.2.3.4|2',
             '1.2.3.4|3'
         ]);
-        expect(new Set(result.cacheKeys)).toEqual(new Set(['path:/library/multi-frame.dcm']));
+        expect(result.cacheKeys).toEqual([
+            'sop:1.2.3.4:0',
+            'sop:1.2.3.4:1',
+            'sop:1.2.3.4:2',
+            'sop:1.2.3.4:3'
+        ]);
     });
 
     test('scan dedupes duplicate DICOM copies with the same SOP instance UID', async ({ page }) => {
@@ -1884,7 +1889,7 @@ test.describe('Desktop library scanning', () => {
         expect(result.wrapperPixelSpacing).toEqual(result.splitPixelSpacing);
     });
 
-    test('viewer loadSlice falls back to native desktop decode after an explicit js-first decode error', async ({ page }) => {
+    test('viewer loadSlice renders a cached decoded frame without re-decoding', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
 
@@ -1895,11 +1900,33 @@ test.describe('Desktop library scanning', () => {
                 sliceLocation: 12.34,
                 source: {
                     kind: 'path',
-                    path: '/library/native-fallback.dcm'
+                    path: '/library/cached-decoded.dcm'
                 }
             };
             const cacheKey = app.sources.getSliceCacheKey(slice, 0);
-            const nativeCalls = [];
+            const decoded = {
+                rows: 4,
+                cols: 4,
+                bitsAllocated: 16,
+                bitsStored: 16,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                planarConfiguration: 0,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 1500,
+                windowWidth: 3000,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                modality: 'CT',
+                transferSyntax: '1.2.840.10008.1.2.1',
+                mrMetadata: null,
+                pixelSpacing: { row: 0.5, col: 0.25 },
+                skipWindowLevel: false,
+                isBlank: false,
+                pixelData: new Uint16Array(Array.from({ length: 16 }, (_, index) => index * 200))
+            };
+            let readFileCalls = 0;
+            let nativeDecodeCalls = 0;
 
             app.state.currentStudy = {
                 studyInstanceUid: 'study-1'
@@ -1912,76 +1939,50 @@ test.describe('Desktop library scanning', () => {
             app.state.windowLevel = { center: null, width: null };
             app.state.baseWindowLevel = { center: null, width: null };
             app.state.pixelSpacing = null;
-            // Intentionally omit Pixel Data so the js-first route returns a decode error
-            // and the viewer must fall back to the native desktop path for this slice.
-            app.state.sliceCache.set(cacheKey, {
-                elements: {},
-                string(tag) {
-                    const values = {
-                        x00020010: '1.2.840.10008.1.2.1',
-                        x00080060: 'CT',
-                        x00280004: 'MONOCHROME2',
-                        x00280030: '0.5\\0.25',
-                        x00281050: '40',
-                        x00281051: '400',
-                        x00281052: '0',
-                        x00281053: '1'
-                    };
-                    return values[tag] || '';
-                },
-                uint16(tag) {
-                    const values = {
-                        x00280010: 4,
-                        x00280011: 4,
-                        x00280100: 16,
-                        x00280103: 0,
-                        x00280002: 1
-                    };
-                    return values[tag] || 0;
-                }
-            });
-            app.desktopDecode.decodeFrameWithPixels = async (path, frameIndex) => {
-                nativeCalls.push({ path, frameIndex });
-                return {
-                    rows: 4,
-                    cols: 4,
-                    bitsAllocated: 16,
-                    pixelRepresentation: 0,
-                    samplesPerPixel: 1,
-                    planarConfiguration: 0,
-                    photometricInterpretation: 'MONOCHROME2',
-                    windowCenter: 1500,
-                    windowWidth: 3000,
-                    rescaleSlope: 1,
-                    rescaleIntercept: 0,
-                    pixelDataLength: 32,
-                    pixelData: new Uint16Array(Array.from({ length: 16 }, (_, index) => index * 200))
-                };
+            const originalReadFile = window.__TAURI__.fs.readFile;
+            const originalNativeDecode = app.desktopDecode.decodeFrameWithPixels;
+            app.state.sliceCache.clear();
+            app.state.sliceCache.set(cacheKey, decoded);
+
+            window.__TAURI__.fs.readFile = async () => {
+                readFileCalls += 1;
+                return Uint8Array.from([1, 2, 3, 4]);
+            };
+            app.desktopDecode.decodeFrameWithPixels = async () => {
+                nativeDecodeCalls += 1;
+                throw new Error('loadSlice should not decode when a decoded frame is already cached');
             };
 
-            await app.viewer.loadSlice(0);
+            try {
+                await app.viewer.loadSlice(0);
+            } finally {
+                window.__TAURI__.fs.readFile = originalReadFile;
+                app.desktopDecode.decodeFrameWithPixels = originalNativeDecode;
+            }
 
             const canvas = document.getElementById('imageCanvas');
             const ctx = canvas.getContext('2d');
             const imageData = Array.from(ctx.getImageData(0, 0, 4, 4).data);
+            const cached = app.state.sliceCache.get(cacheKey);
 
             return {
-                route: app.rendering.getDecodeRoute('1.2.840.10008.1.2.1', 'CT'),
-                nativeCalls,
+                readFileCalls,
+                nativeDecodeCalls,
                 firstChannel: imageData.filter((_, index) => index % 4 === 0),
                 baseWindowLevel: app.state.baseWindowLevel,
                 pixelSpacing: app.state.pixelSpacing,
-                metadataText: document.getElementById('metadataContent').textContent
+                metadataText: document.getElementById('metadataContent').textContent,
+                cachedSummary: {
+                    hasPixelData: ArrayBuffer.isView(cached?.pixelData),
+                    hasByteArray: !!cached?.byteArray,
+                    hasElements: !!cached?.elements,
+                    sameObject: cached === decoded
+                }
             };
         });
 
-        expect(result.route).toBe('js-first');
-        expect(result.nativeCalls).toEqual([
-            {
-                path: '/library/native-fallback.dcm',
-                frameIndex: 0
-            }
-        ]);
+        expect(result.readFileCalls).toBe(0);
+        expect(result.nativeDecodeCalls).toBe(0);
         expect(result.firstChannel).toEqual([
             0, 17, 34, 51,
             68, 85, 102, 119,
@@ -1992,6 +1993,12 @@ test.describe('Desktop library scanning', () => {
         expect(result.pixelSpacing).toEqual({ row: 0.5, col: 0.25 });
         expect(result.metadataText).toContain('CT');
         expect(result.metadataText).toContain('4 x 4');
+        expect(result.cachedSummary).toEqual({
+            hasPixelData: true,
+            hasByteArray: false,
+            hasElements: false,
+            sameObject: true
+        });
     });
 
     test('decodeWithFallback uses native-first routing for JPEG 2000 RF desktop slices', async ({ page }) => {


### PR DESCRIPTION
## Summary
- cache decoded frames instead of parsed datasets, make slice cache keys frame-aware, and guard viewer loads with generation/request tracking plus in-flight deduplication
- add desktop memory capture/report/session tooling with a dashboard, auto-recovery safeguards, and a dedicated diagnostics home under `docs/diagnostics/`
- avoid full-file desktop reads during import duplicate/invalid screening by using header-first checks and manifest metadata before copying
- harden desktop viewer scrubbing with decode-route tracing, native cache I/O locking, desktop scrub debouncing, and W/L safeguards for mixed-domain XA slices so stale 12-bit overrides do not darken 8-bit frames

## Testing
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml --no-default-features`
- `node --check docs/js/app/rendering.js`
- `node --check docs/js/app/viewer.js`
- `node --check docs/js/app/tools.js`
- `node --check docs/js/app/main.js`
- `node --check docs/js/app/desktop-decode.js`
- `node --check tests/desktop-library.spec.js`
- `node --check tests/desktop-native-decode.spec.js`
- `node --check tests/desktop-import.spec.js`
- `python3 -m py_compile scripts/desktop-memory-capture.py scripts/desktop-memory-report.py`
- `bash -n scripts/desktop-memory-session.sh`
- manual desktop validation on March 29, 2026:
  - import-heavy repro dropped from multi-GB growth to roughly `390 MB` baseline / `424 MB` peak / `390 MB` settled
  - final XA scrub + W/L repro no longer darkened after the mixed-domain W/L fix

## Root Cause Notes
- the original desktop memory blow-up was not just the slice cache; import duplicate/invalid scanning was also pulling full files across the Tauri bridge unnecessarily
- the XA dark-image regression came from carrying a W/L override tuned for `16-bit` / `2048-4096` style frames onto `8-bit` / `128-171` style frames in the same series
- native decode is still attempted first for desktop path-backed high-risk multi-frame `XA` / `RF` slices, but fallback tracing is now explicit and easier to reason about when a vendor-specific frame drops back to JS
