### PR TITLE
Stabilize desktop XA scrubbing and diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 
 # Logs
 *.log
+artifacts/desktop-memory/
 
 # Session history (private)
 session-history*.md

--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -7,7 +7,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
         LazyLock, Mutex,
     },
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use dicom_core::Tag;
@@ -17,6 +17,8 @@ use dicom_pixeldata::{DecodedPixelData, PixelDecoder};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::{ipc::Response, AppHandle, Manager, Runtime, State};
+
+use crate::DebugSettings;
 
 const DECODE_TIMEOUT_SECS: u64 = 30;
 const MAX_DECODE_STORE_ENTRIES: usize = 8;
@@ -31,6 +33,7 @@ type DecodeResult<T> = Result<T, DecodeError>;
 
 static PENDING_CACHE_TOUCHES: LazyLock<Mutex<HashMap<String, u128>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+static DECODE_CACHE_IO_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -64,6 +67,42 @@ pub struct DecodeFrameMetadata {
     pub rescale_slope: Option<f64>,
     pub rescale_intercept: Option<f64>,
     pub pixel_data_length: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct DecodeFrameBinaryHeader {
+    rows: u16,
+    cols: u16,
+    bits_allocated: u16,
+    pixel_representation: u16,
+    samples_per_pixel: u16,
+    planar_configuration: u16,
+    photometric_interpretation: String,
+    window_center: Option<f64>,
+    window_width: Option<f64>,
+    rescale_slope: Option<f64>,
+    rescale_intercept: Option<f64>,
+    pixel_data_length: usize,
+}
+
+impl From<DecodedFrameMetadata> for DecodeFrameBinaryHeader {
+    fn from(metadata: DecodedFrameMetadata) -> Self {
+        Self {
+            rows: metadata.rows,
+            cols: metadata.cols,
+            bits_allocated: metadata.bits_allocated,
+            pixel_representation: metadata.pixel_representation,
+            samples_per_pixel: metadata.samples_per_pixel,
+            planar_configuration: metadata.planar_configuration,
+            photometric_interpretation: metadata.photometric_interpretation,
+            window_center: metadata.window_center,
+            window_width: metadata.window_width,
+            rescale_slope: metadata.rescale_slope,
+            rescale_intercept: metadata.rescale_intercept,
+            pixel_data_length: metadata.pixel_data_length,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -155,6 +194,14 @@ impl DecodeStore {
             .pixels_by_id
             .len()
     }
+
+    fn pending_count_live(&self) -> usize {
+        self.entries
+            .lock()
+            .expect("decode store poisoned")
+            .pixels_by_id
+            .len()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -205,12 +252,65 @@ pub async fn decode_frame<R: Runtime>(
     path: String,
     frame_index: u32,
     store: State<'_, DecodeStore>,
+    debug_settings: State<'_, DebugSettings>,
 ) -> DecodeResult<DecodeFrameMetadata> {
     let scoped_path = resolve_canonical_path(&path, "decode", "Decode path")?;
     let cache_paths = resolve_cache_paths(&app)?;
-    let decode_result = run_decode_with_timeout(scoped_path, frame_index, cache_paths).await?;
+    let native_decode_debug = debug_settings.native_decode_debug;
+    let started_at = Instant::now();
+    let decode_result = run_decode_with_timeout(
+        scoped_path.clone(),
+        frame_index,
+        cache_paths,
+        native_decode_debug,
+    )
+    .await?;
+    let pixel_data_length = decode_result.metadata.pixel_data_length;
     let decode_id = store.insert(decode_result.pixel_bytes);
+    if native_decode_debug {
+        eprintln!(
+            "[native-decode] response path={} frame={} decode_id={} pixel_bytes={} store_pending={} elapsed_ms={}",
+            scoped_path.display(),
+            frame_index,
+            decode_id,
+            pixel_data_length,
+            store.pending_count_live(),
+            started_at.elapsed().as_millis()
+        );
+    }
     Ok(decode_result.metadata.into_response(decode_id))
+}
+
+#[tauri::command]
+pub async fn decode_frame_with_pixels<R: Runtime>(
+    app: AppHandle<R>,
+    path: String,
+    frame_index: u32,
+    debug_settings: State<'_, DebugSettings>,
+) -> DecodeResult<Response> {
+    let scoped_path = resolve_canonical_path(&path, "decode", "Decode path")?;
+    let cache_paths = resolve_cache_paths(&app)?;
+    let native_decode_debug = debug_settings.native_decode_debug;
+    let started_at = Instant::now();
+    let decoded_frame = run_decode_with_timeout(
+        scoped_path.clone(),
+        frame_index,
+        cache_paths,
+        native_decode_debug,
+    )
+    .await?;
+    let pixel_data_length = decoded_frame.metadata.pixel_data_length;
+    let response = build_decode_frame_with_pixels_response(decoded_frame)?;
+    if native_decode_debug {
+        eprintln!(
+            "[native-decode] response-with-pixels path={} frame={} pixel_bytes={} elapsed_ms={}",
+            scoped_path.display(),
+            frame_index,
+            pixel_data_length,
+            started_at.elapsed().as_millis()
+        );
+    }
+    Ok(response)
 }
 
 #[tauri::command]
@@ -246,9 +346,11 @@ async fn run_decode_with_timeout(
     path: PathBuf,
     frame_index: u32,
     cache_paths: DecodeCachePaths,
+    native_decode_debug: bool,
 ) -> DecodeResult<DecodedFrame> {
-    let decode_task =
-        tokio::task::spawn_blocking(move || decode_frame_impl_with_cache(&path, frame_index, &cache_paths));
+    let decode_task = tokio::task::spawn_blocking(move || {
+        decode_frame_impl_with_cache(&path, frame_index, &cache_paths, native_decode_debug)
+    });
 
     match tokio::time::timeout(Duration::from_secs(DECODE_TIMEOUT_SECS), decode_task).await {
         Ok(Ok(result)) => result,
@@ -335,11 +437,38 @@ fn read_scan_header_impl(path: &Path, max_bytes: usize) -> DecodeResult<Vec<u8>>
     Ok(bytes)
 }
 
+fn build_decode_frame_with_pixels_response(decoded_frame: DecodedFrame) -> DecodeResult<Response> {
+    let DecodedFrame {
+        metadata,
+        mut pixel_bytes,
+    } = decoded_frame;
+    let metadata_json = serde_json::to_vec(&DecodeFrameBinaryHeader::from(metadata)).map_err(|error| {
+        DecodeError::new(
+            "pixel-transfer",
+            format!("Failed to serialize decoded frame metadata: {error}"),
+        )
+    })?;
+    let metadata_length = u32::try_from(metadata_json.len()).map_err(|_| {
+        DecodeError::new(
+            "pixel-transfer",
+            "Decoded frame metadata header exceeded the desktop binary response size limit.",
+        )
+    })?;
+
+    let mut payload = Vec::with_capacity(4 + metadata_json.len() + pixel_bytes.len());
+    payload.extend_from_slice(&metadata_length.to_le_bytes());
+    payload.extend_from_slice(&metadata_json);
+    payload.append(&mut pixel_bytes);
+    Ok(Response::new(payload))
+}
+
 fn decode_frame_impl_with_cache(
     path: &Path,
     frame_index: u32,
     cache_paths: &DecodeCachePaths,
+    native_decode_debug: bool,
 ) -> DecodeResult<DecodedFrame> {
+    let started_at = Instant::now();
     let object = open_file(path).map_err(|error| {
         DecodeError::new(
             "decode",
@@ -356,7 +485,24 @@ fn decode_frame_impl_with_cache(
     };
 
     if let Some(cache_key) = cache_key.as_deref() {
-        if let Some(cached_frame) = read_cached_frame(cache_paths, cache_key) {
+        let cached_frame = {
+            let _cache_guard = DECODE_CACHE_IO_LOCK
+                .lock()
+                .expect("decode cache I/O lock poisoned");
+            read_cached_frame(cache_paths, cache_key)
+        };
+        if let Some(cached_frame) = cached_frame {
+            if native_decode_debug {
+                eprintln!(
+                    "[native-decode] cache-hit path={} frame={} pixel_bytes={} rows={} cols={} elapsed_ms={}",
+                    path.display(),
+                    frame_index,
+                    cached_frame.metadata.pixel_data_length,
+                    cached_frame.metadata.rows,
+                    cached_frame.metadata.cols,
+                    started_at.elapsed().as_millis()
+                );
+            }
             return Ok(cached_frame);
         }
     }
@@ -364,9 +510,27 @@ fn decode_frame_impl_with_cache(
     let decoded_frame = decode_frame_from_object(path, &object, frame_index)?;
 
     if let Some(cache_key) = cache_key.as_deref() {
-        if let Err(error) = write_cached_frame(cache_paths, cache_key, &decoded_frame) {
+        let cache_write_result = {
+            let _cache_guard = DECODE_CACHE_IO_LOCK
+                .lock()
+                .expect("decode cache I/O lock poisoned");
+            write_cached_frame(cache_paths, cache_key, &decoded_frame)
+        };
+        if let Err(error) = cache_write_result {
             eprintln!("Skipping decode cache write for {}: {}", path.display(), error);
         }
+    }
+
+    if native_decode_debug {
+        eprintln!(
+            "[native-decode] cache-miss path={} frame={} pixel_bytes={} rows={} cols={} elapsed_ms={}",
+            path.display(),
+            frame_index,
+            decoded_frame.metadata.pixel_data_length,
+            decoded_frame.metadata.rows,
+            decoded_frame.metadata.cols,
+            started_at.elapsed().as_millis()
+        );
     }
 
     Ok(decoded_frame)
@@ -929,10 +1093,10 @@ mod tests {
 
     #[test]
     fn decode_frame_impl_with_cache_uses_cached_pixels_after_first_decode() {
-        let fixture = fixture_path("test-data/mri-samples/MR2_J2KI.dcm");
+        let fixture = fixture_path("test-fixtures/MR2_J2KI.dcm");
         let cache_paths = test_cache_paths("decode-cache-hit");
 
-        let first = decode_frame_impl_with_cache(&fixture, 0, &cache_paths)
+        let first = decode_frame_impl_with_cache(&fixture, 0, &cache_paths, false)
             .expect("first decode should populate cache");
         let object = open_file(&fixture).expect("fixture should be readable");
         let cache_key =
@@ -941,11 +1105,39 @@ mod tests {
         let cached_bytes = vec![7; first.metadata.pixel_data_length];
         fs::write(&entry_paths.pixel_bytes, &cached_bytes).expect("cached payload should be rewritable");
 
-        let second = decode_frame_impl_with_cache(&fixture, 0, &cache_paths)
+        let second = decode_frame_impl_with_cache(&fixture, 0, &cache_paths, false)
             .expect("second decode should reuse cached payload");
 
         assert_eq!(second.pixel_bytes, cached_bytes);
         assert_eq!(second.metadata, first.metadata);
+
+        let _ = fs::remove_dir_all(&cache_paths.dir);
+    }
+
+    #[test]
+    fn decode_frame_impl_with_cache_tolerates_concurrent_writers() {
+        let fixture = fixture_path("test-fixtures/MR2_J2KI.dcm");
+        let cache_paths = test_cache_paths("decode-cache-concurrent");
+
+        let mut workers = Vec::new();
+        for _ in 0..4 {
+            let fixture = fixture.clone();
+            let cache_paths = cache_paths.clone();
+            workers.push(std::thread::spawn(move || {
+                decode_frame_impl_with_cache(&fixture, 0, &cache_paths, false)
+            }));
+        }
+
+        let mut pixel_lengths = Vec::new();
+        for worker in workers {
+            let decoded = worker
+                .join()
+                .expect("decode worker thread should complete")
+                .expect("concurrent cache decode should succeed");
+            pixel_lengths.push(decoded.metadata.pixel_data_length);
+        }
+
+        assert!(pixel_lengths.iter().all(|length| *length == pixel_lengths[0]));
 
         let _ = fs::remove_dir_all(&cache_paths.dir);
     }
@@ -1006,7 +1198,7 @@ mod tests {
 
     #[test]
     fn decode_frame_impl_decodes_real_jpeg2000_fixture() {
-        let fixture = fixture_path("test-data/mri-samples/MR2_J2KI.dcm");
+        let fixture = fixture_path("test-fixtures/MR2_J2KI.dcm");
         let decoded = decode_frame_impl(&fixture, 0).expect("fixture should decode");
 
         assert_eq!(decoded.metadata.rows, 1024);

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ mod decode;
 mod scan;
 mod secure_store;
 
+use serde::Serialize;
 use tauri::{
     menu::{AboutMetadata, Menu, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder},
     AppHandle, Emitter, Manager, Runtime,
@@ -37,6 +38,92 @@ const EVENT_SHOW_LIBRARY: &str = "desktop://show-library-in-finder";
 const EVENT_CHECK_UPDATES: &str = "desktop://check-for-updates";
 const EVENT_OPEN_HELP: &str = "desktop://open-help";
 const DESKTOP_DB_URL: &str = "sqlite:viewer.db";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DebugSettings {
+    pub decode_mode: String,
+    pub preload_mode: String,
+    pub frontend_decode_trace: bool,
+    pub native_decode_debug: bool,
+}
+
+impl Default for DebugSettings {
+    fn default() -> Self {
+        Self {
+            decode_mode: "auto".into(),
+            preload_mode: "auto".into(),
+            frontend_decode_trace: false,
+            native_decode_debug: false,
+        }
+    }
+}
+
+fn parse_debug_settings() -> DebugSettings {
+    let mut settings = DebugSettings::default();
+    let args: Vec<String> = std::env::args().collect();
+    let mut index = 1;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--decode-mode" => {
+                if let Some(value) = args.get(index + 1) {
+                    match value.as_str() {
+                        "auto" | "js" | "native" => {
+                            settings.decode_mode = value.clone();
+                            index += 1;
+                        }
+                        other => {
+                            eprintln!(
+                                "[desktop-debug] ignoring unsupported decode mode argument: {other}"
+                            );
+                        }
+                    }
+                }
+            }
+            "--preload-mode" => {
+                if let Some(value) = args.get(index + 1) {
+                    match value.as_str() {
+                        "auto" | "on" | "off" => {
+                            settings.preload_mode = value.clone();
+                            index += 1;
+                        }
+                        other => {
+                            eprintln!(
+                                "[desktop-debug] ignoring unsupported preload mode argument: {other}"
+                            );
+                        }
+                    }
+                }
+            }
+            "--decode-debug" | "--native-decode-debug" => {
+                settings.native_decode_debug = true;
+            }
+            "--decode-trace" | "--frontend-decode-trace" => {
+                settings.frontend_decode_trace = true;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    settings
+}
+
+#[tauri::command]
+fn get_debug_settings(settings: tauri::State<'_, DebugSettings>) -> DebugSettings {
+    settings.inner().clone()
+}
+
+#[tauri::command]
+fn log_frontend_decode_event(
+    settings: tauri::State<'_, DebugSettings>,
+    message: String,
+) {
+    if settings.frontend_decode_trace {
+        eprintln!("[frontend-decode] {message}");
+    }
+}
 
 fn build_menu<R: Runtime, M: Manager<R>>(manager: &M) -> tauri::Result<Menu<R>> {
     let package_info = manager.package_info();
@@ -157,8 +244,24 @@ fn desktop_db_migrations() -> Vec<Migration> {
 }
 
 fn main() {
+    let debug_settings = parse_debug_settings();
+    if debug_settings.decode_mode != "auto"
+        || debug_settings.preload_mode != "auto"
+        || debug_settings.frontend_decode_trace
+        || debug_settings.native_decode_debug
+    {
+        eprintln!(
+            "[desktop-debug] decode_mode={} preload_mode={} frontend_decode_trace={} native_decode_debug={}",
+            debug_settings.decode_mode,
+            debug_settings.preload_mode,
+            debug_settings.frontend_decode_trace,
+            debug_settings.native_decode_debug
+        );
+    }
+
     tauri::Builder::default()
         .manage(decode::DecodeStore::default())
+        .manage(debug_settings)
         .setup(|app| {
             let menu = build_menu(app)?;
             app.set_menu(menu)?;
@@ -175,7 +278,10 @@ fn main() {
                 .build(),
         )
         .invoke_handler(tauri::generate_handler![
+            get_debug_settings,
+            log_frontend_decode_event,
             decode::decode_frame,
+            decode::decode_frame_with_pixels,
             decode::take_decoded_frame,
             decode::read_scan_header,
             scan::read_scan_manifest,

--- a/docs/desktop-memory-validation.md
+++ b/docs/desktop-memory-validation.md
@@ -14,12 +14,39 @@ This guide is the low-friction way to validate the desktop viewer memory fix on 
 
 ## 1. Launch the desktop app from the worktree
 
+The simplest path is the session wrapper:
+
+```bash
+cd "/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix"
+npm run desktop:memory:session
+```
+
+That one command will:
+
+- free rebuildable launch artifacts if disk space is too tight
+- launch the desktop app
+- wait for the Tauri process to appear
+- start memory capture automatically
+- generate [latest.html](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix/artifacts/desktop-memory/latest.html) when the app closes
+
+If you want the dashboard to open automatically when the run finishes:
+
+```bash
+npm run desktop:memory:session -- --open-report
+```
+
+You can still type marker labels into the terminal while the session is running.
+
+## 2. Manual launch and capture
+
+Use this path only if you want to launch and capture separately.
+
 ```bash
 cd "/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix"
 npm run desktop:launch
 ```
 
-## 2. Start a capture session
+## 3. Start a capture session
 
 In a second terminal:
 
@@ -58,7 +85,7 @@ While the capture is running, type marker labels and press Enter. Suggested labe
 
 Press `Ctrl+C` when you are done.
 
-## 3. Reproduce with a real study
+## 4. Reproduce with a real study
 
 Use the same sequence each run so the dashboards stay comparable:
 
@@ -74,7 +101,7 @@ Use the same sequence each run so the dashboards stay comparable:
 10. Type `close viewer`.
 11. Reopen a different study and repeat once if needed.
 
-## 4. Open the dashboard
+## 5. Open the dashboard
 
 ```bash
 open artifacts/desktop-memory/latest.html

--- a/docs/desktop-memory-validation.md
+++ b/docs/desktop-memory-validation.md
@@ -25,19 +25,25 @@ In a second terminal:
 
 ```bash
 cd "/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix"
-python3 scripts/desktop-memory-capture.py \
-  --process myradone \
+npm run desktop:memory:capture -- \
   --html artifacts/desktop-memory/latest.html
 ```
 
 If more than one process matches, rerun with an explicit PID:
 
 ```bash
-pgrep -fl myradone
-python3 scripts/desktop-memory-capture.py \
+pgrep -fl "dicom-viewer-desktop|myradone"
+npm run desktop:memory:capture -- \
   --pid <PID> \
   --html artifacts/desktop-memory/latest.html
 ```
+
+The npm shortcut adds two safety rails automatically:
+
+- It checkpoints the session to a `.partial.json` file every few seconds while the run is active.
+- If free disk space is below 1 GB, it will delete the rebuildable [desktop/src-tauri/target](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix/desktop/src-tauri/target) directory before starting the capture.
+
+That `target` cleanup is safe, but the next desktop launch will need to rebuild the native app.
 
 While the capture is running, type marker labels and press Enter. Suggested labels:
 
@@ -103,4 +109,12 @@ If you already have a JSON session file, you can rebuild the HTML report without
 python3 scripts/desktop-memory-report.py \
   artifacts/desktop-memory/session-20260329-170000.json \
   --output artifacts/desktop-memory/session-20260329-170000.html
+```
+
+If a run is interrupted, you can also rebuild the dashboard from the checkpoint file:
+
+```bash
+python3 scripts/desktop-memory-report.py \
+  artifacts/desktop-memory/session-20260329-170000.partial.json \
+  --output artifacts/desktop-memory/recovered.html
 ```

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -1,0 +1,14 @@
+# Diagnostics
+
+This folder is the home for repeatable validation tools and runbooks that help us turn flaky desktop behavior into something we can reproduce, measure, and compare over time.
+
+Current entries:
+
+- [Desktop Memory Validation](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix/docs/diagnostics/desktop-memory-validation.md)
+
+Good candidates for future additions:
+
+- desktop startup timing
+- import / scan throughput
+- native-vs-JS decode route checks
+- sync activity timelines

--- a/docs/diagnostics/desktop-memory-validation.md
+++ b/docs/diagnostics/desktop-memory-validation.md
@@ -35,6 +35,15 @@ If you want the dashboard to open automatically when the run finishes:
 npm run desktop:memory:session -- --open-report
 ```
 
+If you want to compare decode paths directly, the session wrapper also supports forced decode modes:
+
+```bash
+npm run desktop:memory:session -- --decode-mode js --notes "forced JS decode"
+npm run desktop:memory:session -- --decode-mode native --decode-debug --notes "forced native decode"
+```
+
+`--decode-debug` adds verbose native decode timing and cache logs to [latest-launch.log](/Users/gabriel/ai-worktrees/dicom-viewer/codex-desktop-memory-fix/artifacts/desktop-memory/latest-launch.log).
+
 You can still type marker labels into the terminal while the session is running.
 
 ## 2. Manual launch and capture

--- a/docs/index.html
+++ b/docs/index.html
@@ -265,22 +265,22 @@ Copyright (c) 2026 Divergent Health Technologies
     <script src="js/app/dom.js"></script>
     <script src="js/app/utils.js"></script>
     <script src="js/app/dicom.js"></script>
-    <script src="js/app/tools.js"></script>
-    <script src="js/app/rendering.js"></script>
-    <script src="js/app/sources.js"></script>
-    <script src="js/app/import-pipeline.js"></script>
-    <script src="js/app/desktop-library.js"></script>
-    <script src="js/app/desktop-decode.js"></script>
+    <script src="js/app/tools.js?v=20260329-memoryfix2"></script>
+    <script src="js/app/rendering.js?v=20260329-memoryfix2"></script>
+    <script src="js/app/sources.js?v=20260329-memoryfix2"></script>
+    <script src="js/app/import-pipeline.js?v=20260329-memoryfix2"></script>
+    <script src="js/app/desktop-library.js?v=20260329-memoryfix2"></script>
+    <script src="js/app/desktop-decode.js?v=20260329-memoryfix2"></script>
     <script src="js/app/notes-ui.js"></script>
     <script src="js/app/comments-ui.js"></script>
     <script src="js/app/reports-ui.js"></script>
     <script src="js/app/help-viewer.js"></script>
-    <script src="js/app/viewer.js"></script>
-    <script src="js/app/library.js"></script>
+    <script src="js/app/viewer.js?v=20260329-memoryfix2"></script>
+    <script src="js/app/library.js?v=20260329-memoryfix2"></script>
     <script src="js/app/sync-status-ui.js"></script>
     <script src="js/app/sync-engine.js"></script>
     <script src="js/app/account-ui.js"></script>
     <script src="js/app/update-ui.js"></script>
-    <script src="js/app/main.js"></script>
+    <script src="js/app/main.js?v=20260329-memoryfix2"></script>
 </body>
 </html>

--- a/docs/js/app/desktop-decode.js
+++ b/docs/js/app/desktop-decode.js
@@ -2,7 +2,8 @@
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { createStagedError, normalizeStagedError, getPixelDataArrayType } = app.utils;
     let activeQueuedNativeDecode = null;
-    let pendingQueuedNativeDecode = null;
+    let activeQueuedNativeDecodeRequest = null;
+    const pendingQueuedNativeDecodeRequests = [];
 
     function describeBinaryPayload(payload) {
         if (payload === null) {
@@ -18,6 +19,8 @@
     }
 
     function normalizeBinaryResponse(bytes) {
+        // Unlike import header probing, the decode bridge cannot recover from an absent or malformed
+        // payload here. Treat unexpected shapes as a hard error so callers never consume partial pixels.
         if (bytes instanceof Uint8Array) {
             return bytes;
         }
@@ -102,15 +105,29 @@
         return new PixelArrayType(bytes.buffer, bytes.byteOffset, sampleCount).slice();
     }
 
+    function findQueuedNativeDecodeRequest(path, frameIndex) {
+        if (
+            activeQueuedNativeDecodeRequest &&
+            activeQueuedNativeDecodeRequest.path === path &&
+            activeQueuedNativeDecodeRequest.frameIndex === frameIndex
+        ) {
+            return activeQueuedNativeDecodeRequest;
+        }
+
+        return pendingQueuedNativeDecodeRequests.find((request) =>
+            request.path === path && request.frameIndex === frameIndex
+        ) || null;
+    }
+
     function drainQueuedNativeDecodes(runtime) {
         if (activeQueuedNativeDecode) {
             return activeQueuedNativeDecode;
         }
 
         activeQueuedNativeDecode = (async () => {
-            while (pendingQueuedNativeDecode) {
-                const request = pendingQueuedNativeDecode;
-                pendingQueuedNativeDecode = null;
+            while (pendingQueuedNativeDecodeRequests.length > 0) {
+                const request = pendingQueuedNativeDecodeRequests.shift();
+                activeQueuedNativeDecodeRequest = request;
 
                 try {
                     const payload = await runtime.core.invoke('decode_frame_with_pixels', {
@@ -125,11 +142,14 @@
                     for (const waiter of request.waiters) {
                         waiter.reject(normalizedError);
                     }
+                } finally {
+                    activeQueuedNativeDecodeRequest = null;
                 }
             }
         })().finally(() => {
             activeQueuedNativeDecode = null;
-            if (pendingQueuedNativeDecode) {
+            activeQueuedNativeDecodeRequest = null;
+            if (pendingQueuedNativeDecodeRequests.length > 0) {
                 void drainQueuedNativeDecodes(runtime);
             }
         });
@@ -139,26 +159,17 @@
 
     function queueNativeDecodeWithPixels(runtime, path, frameIndex = 0) {
         return new Promise((resolve, reject) => {
-            const nextRequest = {
-                path,
-                frameIndex,
-                waiters: [{ resolve, reject }]
-            };
-
-            if (
-                pendingQueuedNativeDecode &&
-                pendingQueuedNativeDecode.path === path &&
-                pendingQueuedNativeDecode.frameIndex === frameIndex
-            ) {
-                pendingQueuedNativeDecode.waiters.push({ resolve, reject });
+            const existingRequest = findQueuedNativeDecodeRequest(path, frameIndex);
+            if (existingRequest) {
+                existingRequest.waiters.push({ resolve, reject });
                 return;
             }
 
-            if (pendingQueuedNativeDecode) {
-                nextRequest.waiters.push(...pendingQueuedNativeDecode.waiters);
-            }
-
-            pendingQueuedNativeDecode = nextRequest;
+            pendingQueuedNativeDecodeRequests.push({
+                path,
+                frameIndex,
+                waiters: [{ resolve, reject }]
+            });
             void drainQueuedNativeDecodes(runtime);
         });
     }

--- a/docs/js/app/desktop-decode.js
+++ b/docs/js/app/desktop-decode.js
@@ -102,7 +102,11 @@
             pixelRepresentation,
             'Unsupported Bits Allocated value from native decode'
         );
-        return new PixelArrayType(bytes.buffer, bytes.byteOffset, sampleCount).slice();
+        const bytesPerElement = PixelArrayType.BYTES_PER_ELEMENT || 1;
+        const alignedBytes = bytes.byteOffset % bytesPerElement === 0
+            ? bytes
+            : Uint8Array.from(bytes);
+        return new PixelArrayType(alignedBytes.buffer, alignedBytes.byteOffset, sampleCount).slice();
     }
 
     function findQueuedNativeDecodeRequest(path, frameIndex) {

--- a/docs/js/app/desktop-decode.js
+++ b/docs/js/app/desktop-decode.js
@@ -1,6 +1,8 @@
 (() => {
     const app = window.DicomViewerApp = window.DicomViewerApp || {};
     const { createStagedError, normalizeStagedError, getPixelDataArrayType } = app.utils;
+    let activeQueuedNativeDecode = null;
+    let pendingQueuedNativeDecode = null;
 
     function describeBinaryPayload(payload) {
         if (payload === null) {
@@ -38,6 +40,43 @@
         );
     }
 
+    function parseDecodedFrameWithPixelsResponse(payload) {
+        const bytes = normalizeBinaryResponse(payload);
+        if (bytes.byteLength < 4) {
+            throw createStagedError(
+                'pixel-transfer',
+                'Native decode payload was too short to include a metadata header.'
+            );
+        }
+
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const metadataLength = view.getUint32(0, true);
+        const metadataOffset = 4;
+        const pixelOffset = metadataOffset + metadataLength;
+        if (metadataLength === 0 || pixelOffset > bytes.byteLength) {
+            throw createStagedError(
+                'pixel-transfer',
+                `Native decode payload declared an invalid metadata header length: ${metadataLength}.`
+            );
+        }
+
+        let metadata;
+        try {
+            const metadataJson = new TextDecoder().decode(bytes.subarray(metadataOffset, pixelOffset));
+            metadata = JSON.parse(metadataJson);
+        } catch (error) {
+            throw createStagedError(
+                'pixel-transfer',
+                `Failed to parse native decoded frame metadata: ${error?.message || error}`
+            );
+        }
+
+        return {
+            metadata,
+            pixelBytes: bytes.subarray(pixelOffset)
+        };
+    }
+
     function coercePixelData(bytes, bitsAllocated, pixelRepresentation) {
         if (!Number.isFinite(bitsAllocated) || bitsAllocated <= 0 || bitsAllocated % 8 !== 0) {
             throw createStagedError(
@@ -61,6 +100,67 @@
             'Unsupported Bits Allocated value from native decode'
         );
         return new PixelArrayType(bytes.buffer, bytes.byteOffset, sampleCount).slice();
+    }
+
+    function drainQueuedNativeDecodes(runtime) {
+        if (activeQueuedNativeDecode) {
+            return activeQueuedNativeDecode;
+        }
+
+        activeQueuedNativeDecode = (async () => {
+            while (pendingQueuedNativeDecode) {
+                const request = pendingQueuedNativeDecode;
+                pendingQueuedNativeDecode = null;
+
+                try {
+                    const payload = await runtime.core.invoke('decode_frame_with_pixels', {
+                        path: request.path,
+                        frameIndex: request.frameIndex
+                    });
+                    for (const waiter of request.waiters) {
+                        waiter.resolve(payload);
+                    }
+                } catch (error) {
+                    const normalizedError = normalizeStagedError(error, 'decode');
+                    for (const waiter of request.waiters) {
+                        waiter.reject(normalizedError);
+                    }
+                }
+            }
+        })().finally(() => {
+            activeQueuedNativeDecode = null;
+            if (pendingQueuedNativeDecode) {
+                void drainQueuedNativeDecodes(runtime);
+            }
+        });
+
+        return activeQueuedNativeDecode;
+    }
+
+    function queueNativeDecodeWithPixels(runtime, path, frameIndex = 0) {
+        return new Promise((resolve, reject) => {
+            const nextRequest = {
+                path,
+                frameIndex,
+                waiters: [{ resolve, reject }]
+            };
+
+            if (
+                pendingQueuedNativeDecode &&
+                pendingQueuedNativeDecode.path === path &&
+                pendingQueuedNativeDecode.frameIndex === frameIndex
+            ) {
+                pendingQueuedNativeDecode.waiters.push({ resolve, reject });
+                return;
+            }
+
+            if (pendingQueuedNativeDecode) {
+                nextRequest.waiters.push(...pendingQueuedNativeDecode.waiters);
+            }
+
+            pendingQueuedNativeDecode = nextRequest;
+            void drainQueuedNativeDecodes(runtime);
+        });
     }
 
     const DesktopDecode = {
@@ -93,11 +193,8 @@
         },
 
         async decodeFrameWithPixels(path, frameIndex = 0) {
-            const metadata = await this.decodeFrame(path, frameIndex);
-            if (!metadata?.decodeId) {
-                throw createStagedError('pixel-transfer', 'Native decode response did not include a decodeId.');
-            }
-            const pixelBytes = await this.takeDecodedFrame(metadata.decodeId);
+            const payload = await queueNativeDecodeWithPixels(this.getRuntime(), path, frameIndex);
+            const { metadata, pixelBytes } = parseDecodedFrameWithPixelsResponse(payload);
             if (Number.isFinite(metadata.pixelDataLength) && metadata.pixelDataLength !== pixelBytes.byteLength) {
                 throw createStagedError(
                     'pixel-conversion',

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -27,6 +27,11 @@
         throw new Error('Unsupported DICOM metadata source');
     }
 
+    async function parseDicomHeaderDataSet(input) {
+        const byteArray = await toDicomByteArray(input);
+        return dicomParser.parseDicom(byteArray, { untilTag: 'x7fe00010' });
+    }
+
     function getMetadataNumber(dataSet, tag, fallback = 0) {
         const stringValue = getNumber(dataSet, tag, Number.NaN);
         if (Number.isFinite(stringValue)) {
@@ -898,6 +903,7 @@
     app.dicom = {
         parseDicomMetadata,
         parseDicomMetadataDetailed,
+        parseDicomHeaderDataSet,
         parseDicomDirectory,
         parseDicomDirectoryDetailed,
         toDicomByteArray,

--- a/docs/js/app/import-pipeline.js
+++ b/docs/js/app/import-pipeline.js
@@ -22,6 +22,15 @@
     const MAX_UID_SEGMENT_LENGTH = 64;
     const UID_SANITIZE_PATTERN = /[^a-zA-Z0-9.]/g;
     const UNKNOWN_UID_PLACEHOLDER = 'unknown';
+    const IMPORT_HEADER_READ_SIZES = Object.freeze([
+        64 * 1024,
+        256 * 1024
+    ]);
+    const IMPORT_TRUNCATION_ERROR_PATTERNS = [
+        'buffer overrun',
+        'attempt to read past end of buffer',
+        'missing required meta header attribute 0002,0010'
+    ];
 
     // =====================================================================
     // HELPERS
@@ -66,6 +75,121 @@
      */
     function yieldToEventLoop() {
         return new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    function normalizeBinaryResponse(bytes) {
+        if (bytes instanceof Uint8Array) {
+            return bytes;
+        }
+        if (bytes instanceof ArrayBuffer) {
+            return new Uint8Array(bytes);
+        }
+        if (bytes?.buffer instanceof ArrayBuffer && typeof bytes.byteLength === 'number') {
+            return new Uint8Array(bytes.buffer, bytes.byteOffset || 0, bytes.byteLength);
+        }
+        if (Array.isArray(bytes)) {
+            return Uint8Array.from(bytes);
+        }
+        if (bytes && Object.prototype.hasOwnProperty.call(bytes, 'data')) {
+            return normalizeBinaryResponse(bytes.data);
+        }
+        return null;
+    }
+
+    function getImportParseErrorMessage(error) {
+        if (!error) return '';
+        if (typeof error === 'string') return error;
+        if (typeof error.message === 'string' && error.message) return error.message;
+        if (typeof error.exception === 'string' && error.exception) return error.exception;
+        return String(error);
+    }
+
+    function hasDicomPreamble(bytes) {
+        return !!(
+            bytes &&
+            bytes.byteLength >= 132 &&
+            bytes[128] === 0x44 &&
+            bytes[129] === 0x49 &&
+            bytes[130] === 0x43 &&
+            bytes[131] === 0x4d
+        );
+    }
+
+    function shouldExpandImportHeaderRead(parseResult, headerBytes, requestedBytes) {
+        if (!headerBytes || headerBytes.byteLength < requestedBytes) return false;
+
+        if (parseResult?.meta) {
+            return hasLikelyDicomMetadata(parseResult.meta) && !parseResult.meta.sopInstanceUid;
+        }
+
+        if (hasDicomPreamble(headerBytes)) {
+            return true;
+        }
+
+        const message = getImportParseErrorMessage(parseResult?.error).toLowerCase();
+        return IMPORT_TRUNCATION_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+    }
+
+    async function readImportHeader(path, maxBytes) {
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (typeof invoke !== 'function') {
+            return null;
+        }
+
+        try {
+            const bytes = await invoke('read_scan_header', { path, maxBytes });
+            return normalizeBinaryResponse(bytes);
+        } catch {
+            return null;
+        }
+    }
+
+    async function readImportMetadata(fs, filePath) {
+        for (let stageIndex = 0; stageIndex < IMPORT_HEADER_READ_SIZES.length; stageIndex += 1) {
+            const requestedBytes = IMPORT_HEADER_READ_SIZES[stageIndex];
+            const headerBytes = await readImportHeader(filePath, requestedBytes);
+            if (!headerBytes) {
+                break;
+            }
+
+            const headerResult = await parseDicomMetadataDetailed(headerBytes);
+            if (headerResult?.meta) {
+                if (
+                    shouldExpandImportHeaderRead(headerResult, headerBytes, requestedBytes) &&
+                    stageIndex < IMPORT_HEADER_READ_SIZES.length - 1
+                ) {
+                    continue;
+                }
+                return headerResult;
+            }
+
+            if (headerBytes.byteLength < requestedBytes) {
+                return headerResult;
+            }
+
+            if (shouldExpandImportHeaderRead(headerResult, headerBytes, requestedBytes)) {
+                if (stageIndex < IMPORT_HEADER_READ_SIZES.length - 1) {
+                    continue;
+                }
+                break;
+            }
+
+            return headerResult;
+        }
+
+        const buffer = await fs.readFile(filePath);
+        return parseDicomMetadataDetailed(buffer);
+    }
+
+    async function getImportSourceSize(fs, fileEntry) {
+        const manifestSize = Number(fileEntry?.size);
+        if (Number.isFinite(manifestSize) && manifestSize >= 0) {
+            return manifestSize;
+        }
+
+        const stat = await fs.stat(fileEntry?.path || '');
+        const statSize = Number(stat?.size ?? stat?.len);
+        return Number.isFinite(statSize) ? statSize : -1;
     }
 
     /**
@@ -207,11 +331,18 @@
         }
 
         // Normalize manifest entries to a flat list of file paths
-        const filePaths = manifestEntries
-            .map(entry => (typeof entry?.path === 'string' ? entry.path : ''))
-            .filter(Boolean);
+        const fileEntries = manifestEntries
+            .map((entry) => ({
+                path: typeof entry?.path === 'string' ? entry.path : '',
+                name: typeof entry?.name === 'string' && entry.name ? entry.name : '',
+                rootPath: typeof entry?.rootPath === 'string'
+                    ? entry.rootPath
+                    : (typeof entry?.root_path === 'string' ? entry.root_path : ''),
+                size: Number.isFinite(Number(entry?.size)) ? Number(entry.size) : null
+            }))
+            .filter((entry) => entry.path);
 
-        stats.discovered = filePaths.length;
+        stats.discovered = fileEntries.length;
         stats.phase = 'importing';
         emitProgress(onProgress, stats, '', true);
 
@@ -223,10 +354,11 @@
         const claimedDestinations = new Set();
 
         async function processNextFile() {
-            while (fileIndex < filePaths.length) {
+            while (fileIndex < fileEntries.length) {
                 // Grab the next file atomically
                 const currentIndex = fileIndex++;
-                const filePath = filePaths[currentIndex];
+                const fileEntry = fileEntries[currentIndex];
+                const filePath = fileEntry.path;
 
                 // Check for abort before each file
                 if (signal?.aborted) {
@@ -234,7 +366,7 @@
                 }
 
                 try {
-                    await processOneFile(fs, libraryRoot, filePath, stats, studies, claimedDestinations);
+                    await processOneFile(fs, libraryRoot, fileEntry, stats, studies, claimedDestinations);
                 } catch (error) {
                     if (error.name === 'AbortError') throw error;
                     stats.errors++;
@@ -252,7 +384,7 @@
         }
 
         // Launch worker pool (up to IMPORT_CONCURRENCY parallel workers)
-        const workerCount = Math.min(IMPORT_CONCURRENCY, filePaths.length);
+        const workerCount = Math.min(IMPORT_CONCURRENCY, fileEntries.length);
         const workers = Array.from({ length: workerCount }, () => processNextFile());
         await Promise.all(workers);
 
@@ -274,12 +406,9 @@
     /**
      * Process a single file: read, parse, deduplicate, and copy.
      */
-    async function processOneFile(fs, libraryRoot, filePath, stats, studies, claimedDestinations) {
-        // Read the entire file (we need the full buffer for copying anyway)
-        const buffer = await fs.readFile(filePath);
-
-        // Parse DICOM metadata from the buffer
-        const result = await parseDicomMetadataDetailed(buffer);
+    async function processOneFile(fs, libraryRoot, fileEntry, stats, studies, claimedDestinations) {
+        const filePath = fileEntry.path;
+        const result = await readImportMetadata(fs, filePath);
         const meta = result?.meta;
 
         // Validate: is this actually a DICOM file with meaningful metadata?
@@ -311,7 +440,7 @@
             // Compare sizes to distinguish true duplicate from UID collision
             try {
                 const destStat = await fs.stat(destPath);
-                const sourceSize = buffer.byteLength || buffer.length;
+                const sourceSize = await getImportSourceSize(fs, fileEntry);
                 const destSize = destStat?.size ?? destStat?.len ?? -1;
 
                 if (sourceSize === destSize) {
@@ -326,6 +455,9 @@
             }
             return;
         }
+
+        // Only pull the full file bytes across the bridge when we actually need to copy.
+        const buffer = await fs.readFile(filePath);
 
         // Create parent directories and write the file
         const parentDir = getParentDir(destPath);

--- a/docs/js/app/import-pipeline.js
+++ b/docs/js/app/import-pipeline.js
@@ -50,6 +50,14 @@
         );
     }
 
+    function hasImportDestinationMetadata(meta) {
+        return !!(
+            meta?.studyInstanceUid &&
+            meta?.seriesInstanceUid &&
+            meta?.sopInstanceUid
+        );
+    }
+
     /**
      * Sanitize a single UID segment for use as a directory or file name.
      * Replaces non-alphanumeric/non-dot characters with underscore and
@@ -119,7 +127,7 @@
         if (!headerBytes || headerBytes.byteLength < requestedBytes) return false;
 
         if (parseResult?.meta) {
-            return hasLikelyDicomMetadata(parseResult.meta) && !parseResult.meta.sopInstanceUid;
+            return hasLikelyDicomMetadata(parseResult.meta) && !hasImportDestinationMetadata(parseResult.meta);
         }
 
         if (hasDicomPreamble(headerBytes)) {

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -60,6 +60,55 @@
     const searchParams = new URLSearchParams(window.location.search);
     const isTestMode = searchParams.has('test');
     const noLib = searchParams.has('nolib');
+    const DESKTOP_SCRUB_DEBOUNCE_MS = config?.deploymentMode === 'desktop' ? 75 : 0;
+    let pendingSliderLoadIndex = null;
+    let pendingSliderLoadTimer = null;
+
+    await app.rendering?.hydrateDebugSettings?.();
+
+    function clearPendingSliderLoad() {
+        pendingSliderLoadIndex = null;
+        if (pendingSliderLoadTimer) {
+            clearTimeout(pendingSliderLoadTimer);
+            pendingSliderLoadTimer = null;
+        }
+    }
+
+    function flushPendingSliderLoad() {
+        if (!Number.isInteger(pendingSliderLoadIndex)) {
+            clearPendingSliderLoad();
+            return null;
+        }
+
+        const index = pendingSliderLoadIndex;
+        clearPendingSliderLoad();
+        return loadSlice(index);
+    }
+
+    function loadSliceNow(index) {
+        clearPendingSliderLoad();
+        return loadSlice(index);
+    }
+
+    function scheduleSliderLoad(index) {
+        if (!Number.isInteger(index)) {
+            return null;
+        }
+
+        if (DESKTOP_SCRUB_DEBOUNCE_MS <= 0) {
+            return loadSliceNow(index);
+        }
+
+        pendingSliderLoadIndex = index;
+        if (pendingSliderLoadTimer) {
+            clearTimeout(pendingSliderLoadTimer);
+        }
+        pendingSliderLoadTimer = setTimeout(() => {
+            pendingSliderLoadTimer = null;
+            void flushPendingSliderLoad();
+        }, DESKTOP_SCRUB_DEBOUNCE_MS);
+        return null;
+    }
 
     function abortLibraryLoad() {
         if (state.libraryAbort) {
@@ -408,17 +457,24 @@
 
     backBtn.onclick = e => {
         e.preventDefault();
+        clearPendingSliderLoad();
         closeViewer();
     };
-    slider.oninput = () => loadSlice(parseInt(slider.value, 10));
+    slider.oninput = () => {
+        scheduleSliderLoad(parseInt(slider.value, 10));
+    };
+    slider.onchange = () => {
+        pendingSliderLoadIndex = parseInt(slider.value, 10);
+        void flushPendingSliderLoad();
+    };
     prevBtn.onclick = () => {
         if (state.currentSliceIndex > 0) {
-            loadSlice(state.currentSliceIndex - 1);
+            loadSliceNow(state.currentSliceIndex - 1);
         }
     };
     nextBtn.onclick = () => {
         if (state.currentSeries && state.currentSliceIndex < state.currentSeries.slices.length - 1) {
-            loadSlice(state.currentSliceIndex + 1);
+            loadSliceNow(state.currentSliceIndex + 1);
         }
     };
 
@@ -476,17 +532,18 @@
         if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
             e.preventDefault();
             if (state.currentSliceIndex > 0) {
-                loadSlice(state.currentSliceIndex - 1);
+                loadSliceNow(state.currentSliceIndex - 1);
             }
         } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
             e.preventDefault();
             if (state.currentSeries && state.currentSliceIndex < state.currentSeries.slices.length - 1) {
-                loadSlice(state.currentSliceIndex + 1);
+                loadSliceNow(state.currentSliceIndex + 1);
             }
         } else if (e.key === 'Escape') {
             if ($('reportViewer').style.display !== 'none') {
                 closeReportViewer();
             } else {
+                clearPendingSliderLoad();
                 closeViewer();
             }
         }
@@ -517,10 +574,10 @@
 
         if (e.deltaY > 0) {
             if (state.currentSeries && state.currentSliceIndex < state.currentSeries.slices.length - 1) {
-                loadSlice(state.currentSliceIndex + 1);
+                loadSliceNow(state.currentSliceIndex + 1);
             }
         } else if (state.currentSliceIndex > 0) {
-            loadSlice(state.currentSliceIndex - 1);
+            loadSliceNow(state.currentSliceIndex - 1);
         }
     });
 

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -34,6 +34,9 @@
         frontendDecodeTrace: false,
         nativeDecodeDebug: false
     };
+    // XA series can mix 8-bit scout-style frames with 12/16-bit angiography frames.
+    // A 4x default window-width jump is a reliable signal that a carried-over W/L override
+    // is crossing into a different display domain and should be dropped.
     const INCOMPATIBLE_WINDOW_WIDTH_RATIO = 4;
     let reusableRenderImageData = null;
     let frontendDecodeTraceSequence = 0;
@@ -270,12 +273,21 @@
             windowLevel.width > 0;
     }
 
+    function getWindowLevelAnchor() {
+        return hasWindowLevel(state.windowLevelAnchor) ? state.windowLevelAnchor : null;
+    }
+
     function shouldResetWindowLevelOverride(decoded, wlOverride) {
         if (!hasWindowLevel(wlOverride)) {
             return false;
         }
 
-        const previousBaseWidth = Number(state.baseWindowLevel.width);
+        const anchor = getWindowLevelAnchor();
+        if (!anchor) {
+            return false;
+        }
+
+        const previousBaseWidth = Number(anchor.width);
         const nextBaseWidth = Number(decoded.windowWidth);
         if (
             !Number.isFinite(previousBaseWidth) ||
@@ -291,7 +303,7 @@
             return true;
         }
 
-        const previousBaseCenter = Number(state.baseWindowLevel.center);
+        const previousBaseCenter = Number(anchor.center);
         const nextBaseCenter = Number(decoded.windowCenter);
         if (!Number.isFinite(previousBaseCenter) || !Number.isFinite(nextBaseCenter)) {
             return false;
@@ -1223,10 +1235,14 @@
             return buildRenderInfo(decoded, windowCenter, windowWidth, { isBlank: true });
         }
 
+        if (!hasWindowLevel(wlOverride) || !getWindowLevelAnchor()) {
+            state.windowLevelAnchor = { center: windowCenter, width: windowWidth };
+        }
+
         if (shouldResetWindowLevelOverride(decoded, wlOverride)) {
             void emitDesktopDecodeTrace('wl-override-reset', {
-                previousBaseCenter: state.baseWindowLevel.center,
-                previousBaseWidth: state.baseWindowLevel.width,
+                previousBaseCenter: state.windowLevelAnchor.center,
+                previousBaseWidth: state.windowLevelAnchor.width,
                 requestedCenter: wlOverride?.center ?? null,
                 requestedWidth: wlOverride?.width ?? null,
                 nextBaseCenter: decoded.windowCenter,
@@ -1239,6 +1255,7 @@
                 transferSyntax: decoded.transferSyntax
             });
             state.windowLevel = { center: null, width: null };
+            state.windowLevelAnchor = { center: windowCenter, width: windowWidth };
             effectiveWindowLevelOverride = null;
         }
 

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -25,6 +25,280 @@
         ['1.2.840.10008.1.2.4.90', new Set(['RF', 'XA'])],
         ['1.2.840.10008.1.2.4.91', new Set(['RF', 'XA'])]
     ]);
+    const DEBUG_DECODE_MODE_STORAGE_KEY = 'dicom-viewer-debug-decode-mode';
+    const DEBUG_PRELOAD_MODE_STORAGE_KEY = 'dicom-viewer-debug-preload-mode';
+    let desktopDebugSettings = {
+        loaded: false,
+        decodeMode: 'auto',
+        preloadMode: 'auto',
+        frontendDecodeTrace: false,
+        nativeDecodeDebug: false
+    };
+    const INCOMPATIBLE_WINDOW_WIDTH_RATIO = 4;
+    let reusableRenderImageData = null;
+    let frontendDecodeTraceSequence = 0;
+
+    function normalizeDecodeMode(value) {
+        if (typeof value !== 'string') {
+            return 'auto';
+        }
+
+        switch (value.toLowerCase()) {
+            case 'js':
+            case 'native':
+            case 'auto':
+                return value.toLowerCase();
+            default:
+                return 'auto';
+        }
+    }
+
+    function normalizePreloadMode(value) {
+        if (typeof value !== 'string') {
+            return 'auto';
+        }
+
+        switch (value.toLowerCase()) {
+            case 'on':
+            case 'off':
+            case 'auto':
+                return value.toLowerCase();
+            default:
+                return 'auto';
+        }
+    }
+
+    function getStoredDecodeMode() {
+        try {
+            return normalizeDecodeMode(localStorage.getItem(DEBUG_DECODE_MODE_STORAGE_KEY));
+        } catch {
+            return 'auto';
+        }
+    }
+
+    function getStoredPreloadMode() {
+        try {
+            return normalizePreloadMode(localStorage.getItem(DEBUG_PRELOAD_MODE_STORAGE_KEY));
+        } catch {
+            return 'auto';
+        }
+    }
+
+    function getQueryDecodeMode() {
+        try {
+            return normalizeDecodeMode(new URLSearchParams(window.location.search).get('decodeMode'));
+        } catch {
+            return 'auto';
+        }
+    }
+
+    function getQueryPreloadMode() {
+        try {
+            return normalizePreloadMode(new URLSearchParams(window.location.search).get('preloadMode'));
+        } catch {
+            return 'auto';
+        }
+    }
+
+    function getRuntimeDebugSettings() {
+        const runtimeSettings = window.__DICOM_VIEWER_DEBUG__ || {};
+        return {
+            decodeMode: normalizeDecodeMode(runtimeSettings.decodeMode),
+            preloadMode: normalizePreloadMode(runtimeSettings.preloadMode),
+            frontendDecodeTrace: !!runtimeSettings.frontendDecodeTrace,
+            nativeDecodeDebug: !!runtimeSettings.nativeDecodeDebug
+        };
+    }
+
+    async function hydrateDebugSettings() {
+        const runtimeSettings = getRuntimeDebugSettings();
+        let decodeMode = getQueryDecodeMode();
+        let preloadMode = getQueryPreloadMode();
+        let frontendDecodeTrace = runtimeSettings.frontendDecodeTrace;
+        let nativeDecodeDebug = runtimeSettings.nativeDecodeDebug;
+        let nativeDecodeMode = 'auto';
+        let nativePreloadMode = 'auto';
+
+        if (config.deploymentMode === 'desktop') {
+            const invoke = window.__TAURI__?.core?.invoke;
+            if (typeof invoke === 'function') {
+                try {
+                    const nativeSettings = await invoke('get_debug_settings');
+                    nativeDecodeMode = normalizeDecodeMode(nativeSettings?.decodeMode);
+                    nativePreloadMode = normalizePreloadMode(nativeSettings?.preloadMode);
+                    frontendDecodeTrace = frontendDecodeTrace || !!nativeSettings?.frontendDecodeTrace;
+                    nativeDecodeDebug = nativeDecodeDebug || !!nativeSettings?.nativeDecodeDebug;
+                } catch (error) {
+                    console.warn('Failed to load desktop debug settings:', error);
+                }
+            }
+        }
+
+        if (decodeMode === 'auto') {
+            decodeMode = nativeDecodeMode;
+        }
+        if (preloadMode === 'auto') {
+            preloadMode = nativePreloadMode;
+        }
+
+        if (decodeMode === 'auto') {
+            decodeMode = runtimeSettings.decodeMode;
+        }
+        if (preloadMode === 'auto') {
+            preloadMode = runtimeSettings.preloadMode;
+        }
+
+        if (decodeMode === 'auto') {
+            decodeMode = getStoredDecodeMode();
+        }
+        if (preloadMode === 'auto') {
+            preloadMode = getStoredPreloadMode();
+        }
+
+        desktopDebugSettings = {
+            loaded: true,
+            decodeMode,
+            preloadMode,
+            frontendDecodeTrace,
+            nativeDecodeDebug
+        };
+        window.__DICOM_VIEWER_DEBUG__ = {
+            ...(window.__DICOM_VIEWER_DEBUG__ || {}),
+            ...desktopDebugSettings
+        };
+        return desktopDebugSettings;
+    }
+
+    function getActiveDecodeMode() {
+        const runtimeSettings = getRuntimeDebugSettings();
+        if (runtimeSettings.decodeMode !== 'auto') {
+            return runtimeSettings.decodeMode;
+        }
+        if (desktopDebugSettings.decodeMode !== 'auto') {
+            return desktopDebugSettings.decodeMode;
+        }
+        const queryMode = getQueryDecodeMode();
+        if (queryMode !== 'auto') {
+            return queryMode;
+        }
+        return getStoredDecodeMode();
+    }
+
+    function getActivePreloadMode() {
+        const runtimeSettings = getRuntimeDebugSettings();
+        if (runtimeSettings.preloadMode !== 'auto') {
+            return runtimeSettings.preloadMode;
+        }
+        if (desktopDebugSettings.preloadMode !== 'auto') {
+            return desktopDebugSettings.preloadMode;
+        }
+        const queryMode = getQueryPreloadMode();
+        if (queryMode !== 'auto') {
+            return queryMode;
+        }
+        return getStoredPreloadMode();
+    }
+
+    function isViewerPreloadEnabled() {
+        return getActivePreloadMode() !== 'off';
+    }
+
+    function isFrontendDecodeTraceEnabled() {
+        return !!(getRuntimeDebugSettings().frontendDecodeTrace || desktopDebugSettings.frontendDecodeTrace);
+    }
+
+    function normalizeTraceValue(value) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+            return value;
+        }
+        if (Array.isArray(value)) {
+            return value.map(normalizeTraceValue);
+        }
+        if (typeof value === 'object') {
+            return Object.fromEntries(
+                Object.entries(value)
+                    .map(([key, entryValue]) => [key, normalizeTraceValue(entryValue)])
+                    .filter(([, entryValue]) => entryValue !== undefined)
+            );
+        }
+        return String(value);
+    }
+
+    async function emitDesktopDecodeTrace(event, details = {}) {
+        if (!isFrontendDecodeTraceEnabled() || config.deploymentMode !== 'desktop') {
+            return;
+        }
+
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (typeof invoke !== 'function') {
+            return;
+        }
+
+        frontendDecodeTraceSequence += 1;
+        const payload = {
+            seq: frontendDecodeTraceSequence,
+            event,
+            ...normalizeTraceValue(details)
+        };
+
+        try {
+            await invoke('log_frontend_decode_event', {
+                message: JSON.stringify(payload)
+            });
+        } catch (error) {
+            console.warn('Failed to emit frontend decode trace:', error);
+        }
+    }
+
+    function getReusableRenderImageData(cols, rows) {
+        if (
+            !reusableRenderImageData ||
+            reusableRenderImageData.width !== cols ||
+            reusableRenderImageData.height !== rows
+        ) {
+            reusableRenderImageData = ctx.createImageData(cols, rows);
+        }
+        return reusableRenderImageData;
+    }
+
+    function hasWindowLevel(windowLevel) {
+        return Number.isFinite(windowLevel?.center) &&
+            Number.isFinite(windowLevel?.width) &&
+            windowLevel.width > 0;
+    }
+
+    function shouldResetWindowLevelOverride(decoded, wlOverride) {
+        if (!hasWindowLevel(wlOverride)) {
+            return false;
+        }
+
+        const previousBaseWidth = Number(state.baseWindowLevel.width);
+        const nextBaseWidth = Number(decoded.windowWidth);
+        if (
+            !Number.isFinite(previousBaseWidth) ||
+            previousBaseWidth <= 0 ||
+            !Number.isFinite(nextBaseWidth) ||
+            nextBaseWidth <= 0
+        ) {
+            return false;
+        }
+
+        const widthRatio = Math.max(previousBaseWidth, nextBaseWidth) / Math.min(previousBaseWidth, nextBaseWidth);
+        if (widthRatio > INCOMPATIBLE_WINDOW_WIDTH_RATIO) {
+            return true;
+        }
+
+        const previousBaseCenter = Number(state.baseWindowLevel.center);
+        const nextBaseCenter = Number(decoded.windowCenter);
+        if (!Number.isFinite(previousBaseCenter) || !Number.isFinite(nextBaseCenter)) {
+            return false;
+        }
+
+        return Math.abs(previousBaseCenter - nextBaseCenter) > Math.max(previousBaseWidth, nextBaseWidth);
+    }
 
     function getUncompressedFramePixelData(
         dataSet,
@@ -334,12 +608,44 @@
             typeof app.desktopDecode?.decodeFrameWithPixels === 'function';
     }
 
-    function getDecodeRoute(transferSyntax, modality) {
+    function shouldPreferNativeDesktopPathDecode(slice, modality, frameCount = 1) {
+        return canUseNativeDecode(slice) &&
+            frameCount > 1 &&
+            (modality === 'XA' || modality === 'RF');
+    }
+
+    function getDecodeRoute(transferSyntax, modality, slice = null, options = {}) {
+        const forcedDecodeMode = getActiveDecodeMode();
+        if (forcedDecodeMode === 'native') {
+            return 'native-first';
+        }
+        if (forcedDecodeMode === 'js') {
+            return 'js-first';
+        }
+        if (shouldPreferNativeDesktopPathDecode(slice, modality, options.frameCount)) {
+            return 'native-first';
+        }
         const riskyModalities = HIGH_RISK_SYNTAXES.get(transferSyntax);
         if (riskyModalities?.has(modality)) {
             return 'native-first';
         }
         return 'js-first';
+    }
+
+    function getJsDecoderKind(transferSyntax) {
+        if (isJpeg2000(transferSyntax)) {
+            return 'jpeg2000-worker';
+        }
+        if (isJpegLossless(transferSyntax)) {
+            return 'jpeg-lossless';
+        }
+        if (isJpegBaseline(transferSyntax)) {
+            return 'jpeg-baseline';
+        }
+        if (isCompressed(transferSyntax)) {
+            return 'unsupported-compressed';
+        }
+        return 'uncompressed-js';
     }
 
     function renderDecodeError(errorInfo, options = {}) {
@@ -649,60 +955,264 @@
     async function decodeWithFallback(dataSet, frameIndex = 0, slice = null) {
         const transferSyntax = getString(dataSet, 'x00020010');
         const modality = getString(dataSet, 'x00080060');
-        const route = getDecodeRoute(transferSyntax, modality);
         const nativeEligible = canUseNativeDecode(slice);
+        const forcedDecodeMode = getActiveDecodeMode();
+        const jsDecoderKind = getJsDecoderKind(transferSyntax);
+        const slicePath = slice?.source?.path || null;
+        const frameCount = getNumberOfFrames(dataSet);
+        const route = getDecodeRoute(transferSyntax, modality, slice, { frameCount });
         let nativeError = null;
+
+        const traceBase = {
+            path: slicePath,
+            frameIndex,
+            frameCount,
+            transferSyntax,
+            modality,
+            route,
+            forcedDecodeMode,
+            nativeEligible,
+            jsDecoderKind
+        };
+        const traceOutcome = (event, extra = {}) => {
+            void emitDesktopDecodeTrace(event, {
+                ...traceBase,
+                ...extra
+            });
+        };
+
+        traceOutcome('decode-route');
+
+        if (forcedDecodeMode === 'native') {
+            if (!nativeEligible) {
+                const fallback = buildFallbackDecodeError(
+                    dataSet,
+                    null,
+                    createStagedError('decode', 'Forced native decode is unavailable for this slice source.')
+                );
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: 'native',
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
+            }
+
+            try {
+                const decoded = await decodeNative(dataSet, slice.source.path, frameIndex);
+                traceOutcome('decode-result', {
+                    outcome: decoded?.error ? 'error' : 'success',
+                    decoder: 'native',
+                    stage: decoded?.stage || null,
+                    rows: decoded?.rows || null,
+                    cols: decoded?.cols || null
+                });
+                return decoded;
+            } catch (error) {
+                const fallback = buildFallbackDecodeError(dataSet, null, error);
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: 'native',
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
+            }
+        }
+
+        if (forcedDecodeMode === 'js') {
+            try {
+                const decoded = await decodeDicom(dataSet, frameIndex);
+                const result = decoded || buildFallbackDecodeError(dataSet, null, null);
+                traceOutcome('decode-result', {
+                    outcome: result?.error ? 'error' : 'success',
+                    decoder: jsDecoderKind,
+                    stage: result?.stage || null,
+                    rows: result?.rows || null,
+                    cols: result?.cols || null
+                });
+                return result;
+            } catch (jsError) {
+                const fallback = buildFallbackDecodeError(dataSet, jsError, null);
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: jsDecoderKind,
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
+            }
+        }
 
         if (route === 'native-first' && nativeEligible) {
             try {
-                return await decodeNative(dataSet, slice.source.path, frameIndex);
+                const decoded = await decodeNative(dataSet, slice.source.path, frameIndex);
+                traceOutcome('decode-result', {
+                    outcome: decoded?.error ? 'error' : 'success',
+                    decoder: 'native',
+                    stage: decoded?.stage || null,
+                    rows: decoded?.rows || null,
+                    cols: decoded?.cols || null
+                });
+                return decoded;
             } catch (error) {
                 nativeError = error;
                 console.warn('Native decode failed, falling back to JS:', error);
+                traceOutcome('decode-fallback', {
+                    from: 'native',
+                    to: jsDecoderKind,
+                    nativeErrorStage: getDecodeFailureStage(error),
+                    nativeErrorMessage: getDecodeFailureMessage(error)
+                });
             }
 
             try {
                 const decoded = await decodeDicom(dataSet, frameIndex);
                 if (decoded && !decoded.error) {
+                    traceOutcome('decode-result', {
+                        outcome: 'success',
+                        decoder: jsDecoderKind,
+                        stage: decoded.stage || null,
+                        rows: decoded.rows || null,
+                        cols: decoded.cols || null
+                    });
                     return decoded;
                 }
-                return buildFallbackDecodeError(dataSet, decoded, nativeError);
+                const fallback = buildFallbackDecodeError(dataSet, decoded, nativeError);
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: jsDecoderKind,
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
             } catch (jsError) {
-                return buildFallbackDecodeError(dataSet, jsError, nativeError);
+                const fallback = buildFallbackDecodeError(dataSet, jsError, nativeError);
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: jsDecoderKind,
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
             }
         }
 
         try {
             const decoded = await decodeDicom(dataSet, frameIndex);
             if (decoded && !decoded.error) {
+                traceOutcome('decode-result', {
+                    outcome: 'success',
+                    decoder: jsDecoderKind,
+                    stage: decoded.stage || null,
+                    rows: decoded.rows || null,
+                    cols: decoded.cols || null
+                });
                 return decoded;
             }
 
             if (!nativeEligible) {
-                return decoded || buildFallbackDecodeError(dataSet, null, null);
+                const fallback = decoded || buildFallbackDecodeError(dataSet, null, null);
+                traceOutcome('decode-result', {
+                    outcome: fallback?.error ? 'error' : 'success',
+                    decoder: jsDecoderKind,
+                    stage: fallback?.stage || null,
+                    errorMessage: fallback?.errorMessage || null,
+                    errorDetails: fallback?.errorDetails || null
+                });
+                return fallback;
             }
 
             try {
-                return await decodeNative(dataSet, slice.source.path, frameIndex);
+                traceOutcome('decode-fallback', {
+                    from: jsDecoderKind,
+                    to: 'native',
+                    jsErrorStage: decoded?.stage || null,
+                    jsErrorMessage: decoded?.errorDetails || decoded?.errorMessage || null
+                });
+                const nativeDecoded = await decodeNative(dataSet, slice.source.path, frameIndex);
+                traceOutcome('decode-result', {
+                    outcome: nativeDecoded?.error ? 'error' : 'success',
+                    decoder: 'native',
+                    stage: nativeDecoded?.stage || null,
+                    rows: nativeDecoded?.rows || null,
+                    cols: nativeDecoded?.cols || null
+                });
+                return nativeDecoded;
             } catch (error) {
-                return buildFallbackDecodeError(dataSet, decoded, error);
+                const fallback = buildFallbackDecodeError(dataSet, decoded, error);
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: 'native',
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
             }
         } catch (jsError) {
             if (!nativeEligible) {
-                return buildFallbackDecodeError(dataSet, jsError, null);
+                const fallback = buildFallbackDecodeError(dataSet, jsError, null);
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: jsDecoderKind,
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
             }
 
             try {
-                return await decodeNative(dataSet, slice.source.path, frameIndex);
+                traceOutcome('decode-fallback', {
+                    from: jsDecoderKind,
+                    to: 'native',
+                    jsErrorStage: getDecodeFailureStage(jsError),
+                    jsErrorMessage: getDecodeFailureMessage(jsError)
+                });
+                const nativeDecoded = await decodeNative(dataSet, slice.source.path, frameIndex);
+                traceOutcome('decode-result', {
+                    outcome: nativeDecoded?.error ? 'error' : 'success',
+                    decoder: 'native',
+                    stage: nativeDecoded?.stage || null,
+                    rows: nativeDecoded?.rows || null,
+                    cols: nativeDecoded?.cols || null
+                });
+                return nativeDecoded;
             } catch (nativeFallbackError) {
-                return buildFallbackDecodeError(dataSet, jsError, nativeFallbackError);
+                const fallback = buildFallbackDecodeError(dataSet, jsError, nativeFallbackError);
+                traceOutcome('decode-result', {
+                    outcome: 'error',
+                    decoder: 'native',
+                    stage: fallback.stage,
+                    errorMessage: fallback.errorMessage,
+                    errorDetails: fallback.errorDetails
+                });
+                return fallback;
             }
         }
+    }
+
+    async function decodeDesktopPathWithHeader(dataSet, frameIndex = 0, slice = null) {
+        if (!canUseNativeDecode(slice)) {
+            const error = new Error('Desktop path-backed native decode is unavailable for this slice.');
+            error.stage = 'decode';
+            throw error;
+        }
+
+        return decodeNative(dataSet, slice.source.path, frameIndex);
     }
 
     function renderPixels(decoded, wlOverride = null) {
         let windowCenter = decoded.windowCenter;
         let windowWidth = decoded.windowWidth;
+        let effectiveWindowLevelOverride = wlOverride;
 
         state.pixelSpacing = decoded.pixelSpacing || null;
         app.tools.updateCalibrationWarning();
@@ -713,23 +1223,43 @@
             return buildRenderInfo(decoded, windowCenter, windowWidth, { isBlank: true });
         }
 
-        // Store base W/L values for reset (only on first render, not re-renders)
-        if (state.baseWindowLevel.center === null) {
-            state.baseWindowLevel = { center: windowCenter, width: windowWidth };
+        if (shouldResetWindowLevelOverride(decoded, wlOverride)) {
+            void emitDesktopDecodeTrace('wl-override-reset', {
+                previousBaseCenter: state.baseWindowLevel.center,
+                previousBaseWidth: state.baseWindowLevel.width,
+                requestedCenter: wlOverride?.center ?? null,
+                requestedWidth: wlOverride?.width ?? null,
+                nextBaseCenter: decoded.windowCenter,
+                nextBaseWidth: decoded.windowWidth,
+                rows: decoded.rows,
+                cols: decoded.cols,
+                bitsAllocated: decoded.bitsAllocated,
+                bitsStored: decoded.bitsStored,
+                modality: decoded.modality,
+                transferSyntax: decoded.transferSyntax
+            });
+            state.windowLevel = { center: null, width: null };
+            effectiveWindowLevelOverride = null;
         }
+
+        // Track the current slice defaults so reset and the W/L HUD stay aligned while scrubbing.
+        state.baseWindowLevel = { center: windowCenter, width: windowWidth };
 
         // Apply W/L override if provided (from user drag adjustment)
-        if (wlOverride && wlOverride.center !== null && wlOverride.width !== null) {
-            windowCenter = wlOverride.center;
-            windowWidth = wlOverride.width;
+        if (hasWindowLevel(effectiveWindowLevelOverride)) {
+            windowCenter = effectiveWindowLevelOverride.center;
+            windowWidth = effectiveWindowLevelOverride.width;
         }
 
-        // Set canvas size to match image dimensions
-        canvas.width = decoded.cols;
-        canvas.height = decoded.rows;
+        // Avoid reallocating the canvas backing store for every same-sized slice.
+        if (canvas.width !== decoded.cols || canvas.height !== decoded.rows) {
+            canvas.width = decoded.cols;
+            canvas.height = decoded.rows;
+            reusableRenderImageData = null;
+        }
 
-        // Create image data buffer for canvas
-        const imageData = ctx.createImageData(decoded.cols, decoded.rows);
+        // Reuse the RGBA output buffer across same-sized renders to reduce churn during scrub.
+        const imageData = getReusableRenderImageData(decoded.cols, decoded.rows);
         const outputPixels = imageData.data;
 
         // Calculate window/level range (min/max displayable values)
@@ -821,10 +1351,16 @@
 
     app.rendering = {
         displayError,
+        hydrateDebugSettings,
         decodeDicom,
         decodeNative,
         decodeWithFallback,
+        decodeDesktopPathWithHeader,
+        emitDesktopDecodeTrace,
+        getActiveDecodeMode,
+        getActivePreloadMode,
         getDecodeRoute,
+        isViewerPreloadEnabled,
         renderDecodeError,
         renderPixels,
         renderDicom

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -4,6 +4,7 @@
     const {
         parseDicomMetadata,
         parseDicomMetadataDetailed,
+        parseDicomHeaderDataSet,
         isRenderableImageMetadata
     } = app.dicom;
     const DESKTOP_MAX_SCAN_DEPTH = 20;
@@ -297,6 +298,30 @@
         } catch {
             return null;
         }
+    }
+
+    async function readDesktopRenderHeaderDataSet(slice) {
+        const path = slice?.source?.path;
+        if (!path) {
+            return null;
+        }
+
+        for (const requestedBytes of DESKTOP_SCAN_HEADER_READ_SIZES) {
+            const headerBytes = await readDesktopScanHeader(path, requestedBytes);
+            if (!headerBytes) {
+                return null;
+            }
+
+            try {
+                return await parseDicomHeaderDataSet(headerBytes);
+            } catch (error) {
+                if (headerBytes.byteLength < requestedBytes) {
+                    return null;
+                }
+            }
+        }
+
+        return null;
     }
 
     async function parseDesktopScanBuffer(buffer, stats) {
@@ -1449,6 +1474,7 @@
         processFiles,
         processFilesFromSources,
         readSliceBuffer,
+        readDesktopRenderHeaderDataSet,
         normalizeStudiesPayload,
         loadStudiesFromApi,
         expandFrameSlices,

--- a/docs/js/app/state.js
+++ b/docs/js/app/state.js
@@ -53,7 +53,8 @@
      * @property {string} currentTool - Active tool ('wl', 'pan', 'zoom', or null)
      * @property {Object} viewTransform - Pan and zoom state
      * @property {Object} windowLevel - Current W/L override (null = use DICOM values)
-     * @property {Object} baseWindowLevel - Original W/L values for reset
+     * @property {Object} baseWindowLevel - Current slice default W/L values for reset/display
+     * @property {Object} windowLevelAnchor - The slice defaults that an active W/L override is anchored to
      */
     const state = {
         studies: {},
@@ -76,6 +77,7 @@
         viewTransform: { panX: 0, panY: 0, zoom: 1 },
         windowLevel: { center: null, width: null },
         baseWindowLevel: { center: null, width: null },
+        windowLevelAnchor: { center: null, width: null },
         isDragging: false,
         dragStart: { x: 0, y: 0 },
         measurements: new Map(),

--- a/docs/js/app/tools.js
+++ b/docs/js/app/tools.js
@@ -10,6 +10,7 @@
         canvasContainer
     } = app.dom;
     const { getString, generateUUID } = app.utils;
+    let pendingCurrentSliceRender = false;
 
     function getMeasurementSliceKey() {
         if (!state.currentStudy || !state.currentSeries) return null;
@@ -319,7 +320,7 @@
         }
     }
 
-    async function reRenderCurrentSlice() {
+    function performCurrentSliceRender() {
         if (!state.currentSeries) return;
         const slice = state.currentSeries.slices[state.currentSliceIndex];
         if (!slice) return;
@@ -336,6 +337,25 @@
             return;
         }
         app.rendering.renderPixels(decoded, wlOverride);
+    }
+
+    function reRenderCurrentSlice() {
+        if (pendingCurrentSliceRender) {
+            return;
+        }
+
+        pendingCurrentSliceRender = true;
+        const flush = () => {
+            pendingCurrentSliceRender = false;
+            performCurrentSliceRender();
+        };
+
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(flush);
+            return;
+        }
+
+        setTimeout(flush, 0);
     }
 
     function handleWLDrag(dx, dy) {

--- a/docs/js/app/tools.js
+++ b/docs/js/app/tools.js
@@ -386,6 +386,7 @@
     function resetView() {
         state.viewTransform = { panX: 0, panY: 0, zoom: 1 };
         state.windowLevel = { center: null, width: null };
+        state.windowLevelAnchor = { center: null, width: null };
         applyViewTransform();
         reRenderCurrentSlice();
         updateWLDisplay();
@@ -395,6 +396,7 @@
         state.viewTransform = { panX: 0, panY: 0, zoom: 1 };
         state.windowLevel = { center: null, width: null };
         state.baseWindowLevel = { center: null, width: null };
+        state.windowLevelAnchor = { center: null, width: null };
         state.measurements.clear();
         state.activeMeasurement = null;
         state.pixelSpacing = null;

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -19,6 +19,10 @@
     const { toDicomByteArray } = app.dicom;
     const {
         decodeWithFallback,
+        decodeDesktopPathWithHeader,
+        emitDesktopDecodeTrace,
+        getActiveDecodeMode,
+        isViewerPreloadEnabled,
         renderDecodeError,
         renderPixels
     } = app.rendering;
@@ -29,14 +33,45 @@
     } = app.tools;
 
     const VIEWER_PRELOAD_RADIUS = config?.deploymentMode === 'desktop' ? 1 : 3;
+    const MAX_SHARED_PATH_DATASETS = 1;
     let loadGeneration = 0;
     let activeLoadRequestId = 0;
     const inFlightLoads = new Map();
+    const sharedPathDataSets = new Map();
+    let foregroundLoadTask = null;
+    let pendingForegroundLoad = null;
+    let preloadTask = null;
+    let pendingPreloads = [];
+    let preloadContext = null;
+
+    function resolveQueuedLoad(request, value = null) {
+        if (typeof request?.resolve === 'function') {
+            request.resolve(value);
+            request.resolve = null;
+        }
+    }
+
+    function clearPendingForegroundLoad() {
+        resolveQueuedLoad(pendingForegroundLoad, null);
+        pendingForegroundLoad = null;
+    }
+
+    function clearPendingPreloads() {
+        pendingPreloads = [];
+        preloadContext = null;
+    }
+
+    function clearSharedPathDataSets() {
+        sharedPathDataSets.clear();
+    }
 
     function beginLoadGeneration() {
         loadGeneration += 1;
         activeLoadRequestId += 1;
         inFlightLoads.clear();
+        clearSharedPathDataSets();
+        clearPendingForegroundLoad();
+        clearPendingPreloads();
     }
 
     function isLoadStale(generation, requestId, series) {
@@ -63,35 +98,287 @@
         return renderPixels(decoded, wlOverride);
     }
 
-    async function getDecodedSlice(slice, index, purpose, generation, options = {}) {
+    function getSliceTraceDetails(slice, index = null, extra = {}) {
+        const { series = null, ...rest } = extra;
+        return {
+            path: slice?.source?.path || null,
+            sourceKind: slice?.source?.kind || null,
+            frameIndex: slice?.frameIndex || 0,
+            sliceIndex: Number.isInteger(index) ? index : null,
+            seriesInstanceUid: series?.seriesInstanceUid || state.currentSeries?.seriesInstanceUid || null,
+            ...rest
+        };
+    }
+
+    function traceViewerDecode(event, slice, index = null, extra = {}) {
+        void emitDesktopDecodeTrace(event, getSliceTraceDetails(slice, index, extra));
+    }
+
+    function canUseDesktopHeaderDecode(slice) {
+        return config?.deploymentMode === 'desktop' &&
+            slice?.source?.kind === 'path' &&
+            getActiveDecodeMode() !== 'js' &&
+            typeof app.sources.readDesktopRenderHeaderDataSet === 'function' &&
+            typeof decodeDesktopPathWithHeader === 'function';
+    }
+
+    function shouldReuseSharedPathDataSet(slice, series) {
+        if (slice?.source?.kind !== 'path') {
+            return false;
+        }
+
+        if ((slice?.frameIndex || 0) > 0) {
+            return true;
+        }
+
+        const sourcePath = slice?.source?.path;
+        if (!sourcePath || !Array.isArray(series?.slices)) {
+            return false;
+        }
+
+        return series.slices.some((candidate) =>
+            candidate !== slice &&
+            candidate?.source?.kind === 'path' &&
+            candidate.source.path === sourcePath
+        );
+    }
+
+    function rememberSharedPathDataSet(path, entry) {
+        if (!path) {
+            return entry;
+        }
+
+        if (sharedPathDataSets.has(path)) {
+            sharedPathDataSets.delete(path);
+        }
+        sharedPathDataSets.set(path, entry);
+
+        while (sharedPathDataSets.size > MAX_SHARED_PATH_DATASETS) {
+            const oldest = sharedPathDataSets.keys().next().value;
+            sharedPathDataSets.delete(oldest);
+        }
+
+        return entry;
+    }
+
+    async function getSharedPathDataSet(slice, purpose, generation, options = {}) {
+        const path = slice?.source?.path;
+        if (!path) {
+            return null;
+        }
+
         const { requestId = null, series = null } = options;
         const isStale = () => generation !== loadGeneration
             || (requestId !== null && requestId !== activeLoadRequestId)
             || (series && state.currentSeries !== series);
-        const cacheKey = getSliceCacheKey(slice, index);
-        if (cacheKey && state.sliceCache.has(cacheKey)) {
-            return state.sliceCache.get(cacheKey);
+
+        if (sharedPathDataSets.has(path)) {
+            const cached = sharedPathDataSets.get(path);
+            sharedPathDataSets.delete(path);
+            sharedPathDataSets.set(path, cached);
+            traceViewerDecode('shared-dataset-hit', slice, null, { purpose, generation, path, series });
+            return cached;
         }
 
-        if (cacheKey && inFlightLoads.has(cacheKey)) {
-            return inFlightLoads.get(cacheKey);
-        }
-
-        const loadPromise = (async () => {
+        traceViewerDecode('shared-dataset-miss', slice, null, { purpose, generation, path, series });
+        const dataSetPromise = (async () => {
             const buf = await readSliceBuffer(slice, purpose);
             if (isStale()) return null;
 
             const byteArray = await toDicomByteArray(buf);
             if (isStale()) return null;
 
-            const dataSet = dicomParser.parseDicom(byteArray);
+            return dicomParser.parseDicom(byteArray);
+        })();
+
+        rememberSharedPathDataSet(path, dataSetPromise);
+
+        try {
+            const dataSet = await dataSetPromise;
+            if (!dataSet || isStale()) {
+                traceViewerDecode('shared-dataset-stale', slice, null, { purpose, generation, path, series });
+                if (sharedPathDataSets.get(path) === dataSetPromise) {
+                    sharedPathDataSets.delete(path);
+                }
+                return null;
+            }
+
+            rememberSharedPathDataSet(path, Promise.resolve(dataSet));
+            traceViewerDecode('shared-dataset-store', slice, null, { purpose, generation, path, series });
+            return dataSet;
+        } catch (error) {
+            traceViewerDecode('shared-dataset-error', slice, null, {
+                purpose,
+                generation,
+                path,
+                series,
+                errorMessage: error?.message || String(error)
+            });
+            if (sharedPathDataSets.get(path) === dataSetPromise) {
+                sharedPathDataSets.delete(path);
+            }
+            throw error;
+        }
+    }
+
+    async function getDecodedSlice(slice, index, purpose, generation, options = {}) {
+        const { requestId = null, series = null } = options;
+        const isStale = () => generation !== loadGeneration
+            || (requestId !== null && requestId !== activeLoadRequestId)
+            || (series && state.currentSeries !== series);
+        if (isStale()) {
+            return null;
+        }
+        const cacheKey = getSliceCacheKey(slice, index);
+        if (cacheKey && state.sliceCache.has(cacheKey)) {
+            traceViewerDecode('slice-cache-hit', slice, index, { cacheKey, purpose, generation, requestId, series });
+            return state.sliceCache.get(cacheKey);
+        }
+
+        if (cacheKey && inFlightLoads.has(cacheKey)) {
+            traceViewerDecode('slice-inflight-join', slice, index, { cacheKey, purpose, generation, requestId, series });
+            return inFlightLoads.get(cacheKey);
+        }
+
+        const loadPromise = (async () => {
+            const decodeMode = getActiveDecodeMode();
+            if (canUseDesktopHeaderDecode(slice)) {
+                traceViewerDecode('header-decode-attempt', slice, index, {
+                    cacheKey,
+                    purpose,
+                    generation,
+                    requestId,
+                    series
+                });
+                const headerDataSet = await app.sources.readDesktopRenderHeaderDataSet(slice);
+                if (isStale()) return null;
+
+                if (headerDataSet) {
+                    try {
+                        const decoded = await decodeDesktopPathWithHeader(
+                            headerDataSet,
+                            slice.frameIndex || 0,
+                            slice
+                        );
+                        if (isStale()) return null;
+                        traceViewerDecode('header-decode-success', slice, index, {
+                            cacheKey,
+                            purpose,
+                            generation,
+                            requestId,
+                            series,
+                            rows: decoded?.rows || null,
+                            cols: decoded?.cols || null,
+                            decodeError: !!decoded?.error
+                        });
+                        if (decoded && !decoded.error && cacheKey) {
+                            state.sliceCache.set(cacheKey, decoded);
+                            traceViewerDecode('slice-cache-store', slice, index, {
+                                cacheKey,
+                                purpose,
+                                generation,
+                                requestId,
+                                series,
+                                rows: decoded.rows,
+                                cols: decoded.cols,
+                                cachedKind: 'decoded'
+                            });
+                        }
+                        return decoded || null;
+                    } catch (error) {
+                        traceViewerDecode('header-decode-fallback', slice, index, {
+                            cacheKey,
+                            purpose,
+                            generation,
+                            requestId,
+                            series,
+                            errorMessage: error?.message || String(error)
+                        });
+                        if (decodeMode === 'native') {
+                            throw error;
+                        }
+                        console.warn(
+                            `Desktop header decode fell back to full file read for ${slice?.source?.path || 'slice'}:`,
+                            error
+                        );
+                    }
+                } else if (decodeMode === 'native') {
+                    traceViewerDecode('header-decode-header-miss', slice, index, {
+                        cacheKey,
+                        purpose,
+                        generation,
+                        requestId,
+                        series
+                    });
+                    throw new Error(`Forced native decode could not read the DICOM header for ${slice?.source?.path || 'slice'}.`);
+                } else {
+                    traceViewerDecode('header-decode-skip-to-js', slice, index, {
+                        cacheKey,
+                        purpose,
+                        generation,
+                        requestId,
+                        series
+                    });
+                }
+            }
+
+            if (decodeMode === 'native') {
+                throw new Error(`Forced native decode did not complete for ${slice?.source?.path || 'slice'}.`);
+            }
+
+            let dataSet;
+            if (shouldReuseSharedPathDataSet(slice, series)) {
+                traceViewerDecode('js-source-shared-dataset', slice, index, {
+                    cacheKey,
+                    purpose,
+                    generation,
+                    requestId,
+                    series
+                });
+                dataSet = await getSharedPathDataSet(slice, purpose, generation, { requestId, series });
+            } else {
+                traceViewerDecode('js-source-full-read', slice, index, {
+                    cacheKey,
+                    purpose,
+                    generation,
+                    requestId,
+                    series
+                });
+                const buf = await readSliceBuffer(slice, purpose);
+                if (isStale()) return null;
+
+                const byteArray = await toDicomByteArray(buf);
+                if (isStale()) return null;
+
+                dataSet = dicomParser.parseDicom(byteArray);
+            }
             if (isStale()) return null;
+            if (!dataSet) return null;
 
             const decoded = await decodeWithFallback(dataSet, slice.frameIndex || 0, slice);
             if (isStale()) return null;
 
             if (decoded && !decoded.error && cacheKey) {
                 state.sliceCache.set(cacheKey, decoded);
+                traceViewerDecode('slice-cache-store', slice, index, {
+                    cacheKey,
+                    purpose,
+                    generation,
+                    requestId,
+                    series,
+                    rows: decoded.rows,
+                    cols: decoded.cols,
+                    cachedKind: 'decoded'
+                });
+            } else {
+                traceViewerDecode('slice-decode-not-cached', slice, index, {
+                    cacheKey,
+                    purpose,
+                    generation,
+                    requestId,
+                    series,
+                    decodeError: !!decoded?.error
+                });
             }
 
             return decoded || null;
@@ -109,11 +396,68 @@
         return loadPromise;
     }
 
+    function shouldPausePreloads(generation, requestId, series) {
+        return isLoadStale(generation, requestId, series) || !!pendingForegroundLoad;
+    }
+
+    async function drainPendingPreloads() {
+        if (!isViewerPreloadEnabled()) {
+            clearPendingPreloads();
+            return null;
+        }
+
+        if (preloadTask || !preloadContext) {
+            return preloadTask;
+        }
+
+        preloadTask = (async () => {
+            while (preloadContext && pendingPreloads.length > 0) {
+                const { generation, requestId, series } = preloadContext;
+                if (shouldPausePreloads(generation, requestId, series)) {
+                    break;
+                }
+
+                const nextPreload = pendingPreloads.shift();
+                if (!nextPreload) {
+                    break;
+                }
+
+                try {
+                    await getDecodedSlice(
+                        nextPreload.slice,
+                        nextPreload.index,
+                        'preload',
+                        generation,
+                        { requestId, series }
+                    );
+                } catch {}
+            }
+        })().finally(() => {
+            preloadTask = null;
+            if (!preloadContext || pendingPreloads.length === 0) {
+                return;
+            }
+
+            const { generation, requestId, series } = preloadContext;
+            if (!shouldPausePreloads(generation, requestId, series)) {
+                void drainPendingPreloads();
+            }
+        });
+
+        return preloadTask;
+    }
+
     function preloadNearbySlices(slices, index, generation, requestId, series) {
+        if (!isViewerPreloadEnabled()) {
+            clearPendingPreloads();
+            return;
+        }
+
         if (isLoadStale(generation, requestId, series)) {
             return;
         }
 
+        const preloadEntries = [];
         for (let i = index - VIEWER_PRELOAD_RADIUS; i <= index + VIEWER_PRELOAD_RADIUS; i++) {
             if (i < 0 || i >= slices.length) continue;
 
@@ -123,8 +467,17 @@
                 continue;
             }
 
-            getDecodedSlice(preloadSlice, i, 'preload', generation).catch(() => {});
+            preloadEntries.push({
+                slice: preloadSlice,
+                index: i
+            });
         }
+
+        pendingPreloads = preloadEntries;
+        preloadContext = preloadEntries.length > 0
+            ? { generation, requestId, series }
+            : null;
+        void drainPendingPreloads();
     }
 
     function updateSliceMetadata(info, slice, index, totalSlices) {
@@ -184,20 +537,20 @@
         }
     }
 
-    async function loadSlice(index) {
-        if (!state.currentSeries) return;
-        const series = state.currentSeries;
+    async function performSliceLoad(request) {
+        const { index, generation, requestId, series } = request;
+        if (!series || state.currentSeries !== series) return;
         const slices = series.slices;
         if (index < 0 || index >= slices.length) return;
-        const generation = loadGeneration;
-        const requestId = ++activeLoadRequestId;
 
+        clearPendingPreloads();
         state.currentSliceIndex = index;
         updateSliceInfo();
         imageLoading.style.display = 'block';
 
         try {
             const slice = slices[index];
+            traceViewerDecode('slice-load-start', slice, index, { generation, requestId, series });
             let decoded = await getDecodedSlice(slice, index, 'load', generation, { requestId, series });
             if (!decoded && !isLoadStale(generation, requestId, series)) {
                 decoded = await getDecodedSlice(slice, index, 'load', generation, { requestId, series });
@@ -210,6 +563,15 @@
                 ? state.windowLevel
                 : null;
             const info = renderDecodedSlice(decoded, wlOverride);
+            traceViewerDecode('slice-load-rendered', slice, index, {
+                generation,
+                requestId,
+                series,
+                renderError: !!info?.error,
+                isBlank: !!info?.isBlank,
+                rows: info?.rows || decoded?.rows || null,
+                cols: info?.cols || decoded?.cols || null
+            });
 
             updateWLDisplay();
             updateSliceMetadata(info, slice, index, slices.length);
@@ -219,6 +581,12 @@
             preloadNearbySlices(slices, index, generation, requestId, series);
         } catch (e) {
             console.error('Error loading slice:', e);
+            traceViewerDecode('slice-load-exception', slices[index], index, {
+                generation,
+                requestId,
+                series,
+                errorMessage: e?.message || String(e)
+            });
             if (!isLoadStale(generation, requestId, series)) {
                 const errorInfo = renderDecodedSlice(
                     {
@@ -235,6 +603,107 @@
                 imageLoading.style.display = 'none';
             }
         }
+    }
+
+    async function drainForegroundLoads() {
+        if (foregroundLoadTask) {
+            return foregroundLoadTask;
+        }
+
+        foregroundLoadTask = (async () => {
+            while (pendingForegroundLoad) {
+                const request = pendingForegroundLoad;
+                pendingForegroundLoad = null;
+                try {
+                    await performSliceLoad(request);
+                } finally {
+                    resolveQueuedLoad(request, null);
+                }
+            }
+        })().finally(() => {
+            foregroundLoadTask = null;
+            if (pendingForegroundLoad) {
+                void drainForegroundLoads();
+            }
+        });
+
+        return foregroundLoadTask;
+    }
+
+    async function loadSlice(index) {
+        if (!state.currentSeries) return null;
+        const series = state.currentSeries;
+        const slices = series.slices;
+        if (index < 0 || index >= slices.length) return null;
+        const targetSlice = slices[index];
+        const targetCacheKey = getSliceCacheKey(targetSlice, index);
+        const currentSlice = slices[state.currentSliceIndex];
+        const currentCacheKey = currentSlice
+            ? getSliceCacheKey(currentSlice, state.currentSliceIndex)
+            : null;
+
+        if (
+            state.isDragging &&
+            state.currentTool === 'wl' &&
+            currentSlice &&
+            currentCacheKey &&
+            state.sliceCache.has(currentCacheKey)
+        ) {
+            traceViewerDecode('slice-load-blocked-during-wl-drag', currentSlice, state.currentSliceIndex, {
+                requestedIndex: index,
+                requestedCacheKey: targetCacheKey,
+                currentCacheKey,
+                series
+            });
+            return null;
+        }
+
+        if (index === state.currentSliceIndex && targetCacheKey && state.sliceCache.has(targetCacheKey)) {
+            traceViewerDecode('slice-load-skip-cached-current', targetSlice, index, {
+                cacheKey: targetCacheKey,
+                series
+            });
+            imageLoading.style.display = 'none';
+            return null;
+        }
+
+        if (targetCacheKey && inFlightLoads.has(targetCacheKey)) {
+            traceViewerDecode('slice-load-join-inflight', targetSlice, index, {
+                cacheKey: targetCacheKey,
+                series
+            });
+            return inFlightLoads.get(targetCacheKey);
+        }
+
+        state.currentSliceIndex = index;
+        updateSliceInfo();
+        imageLoading.style.display = 'block';
+        clearPendingPreloads();
+
+        if (pendingForegroundLoad && pendingForegroundLoad.index === index && pendingForegroundLoad.series === series) {
+            return pendingForegroundLoad.promise;
+        }
+
+        clearPendingForegroundLoad();
+
+        const generation = loadGeneration;
+        const requestId = ++activeLoadRequestId;
+        let resolveRequest;
+        const request = {
+            index,
+            generation,
+            requestId,
+            series,
+            promise: new Promise((resolve) => {
+                resolveRequest = resolve;
+            }),
+            resolve: resolveRequest
+        };
+
+        traceViewerDecode('slice-load-queued', targetSlice, index, { generation, requestId, series });
+        pendingForegroundLoad = request;
+        void drainForegroundLoads();
+        return request.promise;
     }
 
     function updateSliceInfo() {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.py",
   "scripts": {
     "desktop:launch": "cd desktop && npm run dev:desktop",
-    "desktop:memory:capture": "python3 scripts/desktop-memory-capture.py",
+    "desktop:memory:capture": "python3 scripts/desktop-memory-capture.py --ensure-free-mb 1024 --cleanup-path desktop/src-tauri/target",
     "desktop:memory:report": "python3 scripts/desktop-memory-report.py",
     "test": "npx playwright test",
     "worktree:new": "./scripts/agent-worktree-new.sh",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "desktop:launch": "cd desktop && npm run dev:desktop",
     "desktop:memory:capture": "python3 scripts/desktop-memory-capture.py --ensure-free-mb 1024 --cleanup-path desktop/src-tauri/target",
+    "desktop:memory:session": "bash ./scripts/desktop-memory-session.sh",
     "desktop:memory:report": "python3 scripts/desktop-memory-report.py",
     "test": "npx playwright test",
     "worktree:new": "./scripts/agent-worktree-new.sh",

--- a/scripts/desktop-memory-capture.py
+++ b/scripts/desktop-memory-capture.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections import defaultdict
 from typing import Any
 
 
@@ -262,7 +263,7 @@ def ensure_free_space(
 
 def resolve_process(pid: int | None, process_name: str) -> tuple[int, str]:
     if pid is not None:
-        snapshot = sample_process(pid)
+        snapshot = sample_root_process(pid)
         if snapshot is None:
             raise SystemExit(f"Process with PID {pid} is not running.")
         return pid, snapshot["command"]
@@ -297,23 +298,105 @@ def resolve_process(pid: int | None, process_name: str) -> tuple[int, str]:
     return candidates[0]
 
 
-def sample_process(pid: int) -> dict[str, Any] | None:
-    result = run_command(["ps", "-o", "rss=,vsz=,%cpu=,etime=,comm=", "-p", str(pid)])
+def parse_ps_row(parts: list[str]) -> dict[str, Any] | None:
+    if len(parts) < 7:
+        return None
+
+    return {
+        "pid": int(parts[0]),
+        "ppid": int(parts[1]),
+        "rss_kb": int(parts[2]),
+        "vsz_kb": int(parts[3]),
+        "cpu_percent": float(parts[4]),
+        "elapsed": parts[5],
+        "command": parts[6],
+    }
+
+
+def sample_root_process(pid: int) -> dict[str, Any] | None:
+    result = run_command(["ps", "-o", "pid=,ppid=,rss=,vsz=,%cpu=,etime=,comm=", "-p", str(pid)])
     output = result.stdout.strip()
     if result.returncode != 0 or not output:
         return None
 
-    parts = output.split(None, 4)
-    if len(parts) < 5:
+    parts = output.split(None, 6)
+    return parse_ps_row(parts)
+
+
+def sample_process_tree(root_pid: int) -> dict[str, Any] | None:
+    result = run_command(["ps", "-axo", "pid=,ppid=,rss=,vsz=,%cpu=,etime=,comm="])
+    output = result.stdout
+    if result.returncode != 0 or not output.strip():
         return None
 
+    processes: dict[int, dict[str, Any]] = {}
+    children: dict[int, list[int]] = defaultdict(list)
+
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 6)
+        snapshot = parse_ps_row(parts)
+        if snapshot is None:
+            continue
+        pid = int(snapshot["pid"])
+        processes[pid] = snapshot
+        children[int(snapshot["ppid"])].append(pid)
+
+    if root_pid not in processes:
+        return None
+
+    stack = [root_pid]
+    seen: set[int] = set()
+    tree: list[dict[str, Any]] = []
+    while stack:
+        pid = stack.pop()
+        if pid in seen or pid not in processes:
+            continue
+        seen.add(pid)
+        tree.append(processes[pid])
+        stack.extend(children.get(pid, []))
+
+    root = processes[root_pid]
+    root_rss_kb = int(root["rss_kb"])
+    root_vsz_kb = int(root["vsz_kb"])
+    root_cpu_percent = float(root["cpu_percent"])
+    tree_rss_kb = sum(int(process["rss_kb"]) for process in tree)
+    tree_vsz_kb = sum(int(process["vsz_kb"]) for process in tree)
+    tree_cpu_percent = sum(float(process["cpu_percent"]) for process in tree)
+    top_processes = sorted(tree, key=lambda process: int(process["rss_kb"]), reverse=True)[:5]
+
     return {
-        "rss_kb": int(parts[0]),
-        "vsz_kb": int(parts[1]),
-        "cpu_percent": float(parts[2]),
-        "elapsed": parts[3],
-        "command": parts[4],
+        "rss_kb": tree_rss_kb,
+        "vsz_kb": tree_vsz_kb,
+        "cpu_percent": round(tree_cpu_percent, 1),
+        "elapsed": root["elapsed"],
+        "command": root["command"],
+        "root_pid": root_pid,
+        "process_count": len(tree),
+        "root_rss_kb": root_rss_kb,
+        "root_vsz_kb": root_vsz_kb,
+        "root_cpu_percent": root_cpu_percent,
+        "tree_rss_kb": tree_rss_kb,
+        "tree_vsz_kb": tree_vsz_kb,
+        "tree_cpu_percent": round(tree_cpu_percent, 1),
+        "helper_rss_kb": max(0, tree_rss_kb - root_rss_kb),
+        "helper_vsz_kb": max(0, tree_vsz_kb - root_vsz_kb),
+        "top_processes": [
+            {
+                "pid": int(process["pid"]),
+                "rss_kb": int(process["rss_kb"]),
+                "ppid": int(process["ppid"]),
+                "command": str(process["command"]),
+            }
+            for process in top_processes
+        ],
     }
+
+
+def sample_process(pid: int) -> dict[str, Any] | None:
+    return sample_process_tree(pid)
 
 
 def checkpoint_path_for(output_path: pathlib.Path) -> pathlib.Path:
@@ -371,6 +454,7 @@ def build_session_metadata(
         "pid": pid,
         "process_name": process_name,
         "resolved_command": resolved_command,
+        "sample_scope": "process-tree",
         "interval_seconds": args.interval,
         "duration_seconds": args.duration,
         "notes": args.notes,

--- a/scripts/desktop-memory-capture.py
+++ b/scripts/desktop-memory-capture.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import os
 import pathlib
 import queue
+import shutil
 import socket
 import subprocess
 import sys
@@ -70,6 +72,27 @@ def parse_args() -> argparse.Namespace:
         default=200.0,
         help="Target settled RSS shown in the report. Default: 200 MB",
     )
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=float,
+        default=5.0,
+        help="How often to checkpoint the capture to disk in seconds. Default: 5.0",
+    )
+    parser.add_argument(
+        "--ensure-free-mb",
+        type=float,
+        default=0.0,
+        help="Minimum free disk space required before capture starts. Default: 0",
+    )
+    parser.add_argument(
+        "--cleanup-path",
+        action="append",
+        default=[],
+        help=(
+            "Optional rebuildable path to delete if free disk space is below --ensure-free-mb. "
+            "Can be passed multiple times."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -98,6 +121,143 @@ def default_output_path() -> pathlib.Path:
 def ensure_parent(path: pathlib.Path) -> pathlib.Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def bytes_to_mb(value: int | float) -> float:
+    return float(value) / (1024.0 * 1024.0)
+
+
+def resolve_path(raw_path: str) -> pathlib.Path:
+    path = pathlib.Path(raw_path).expanduser()
+    if path.is_absolute():
+        return path
+    return pathlib.Path.cwd() / path
+
+
+def resolve_cleanup_paths(raw_paths: list[str]) -> list[pathlib.Path]:
+    resolved_paths: list[pathlib.Path] = []
+    seen: set[str] = set()
+    for raw_path in raw_paths:
+        path = resolve_path(raw_path).resolve(strict=False)
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved_paths.append(path)
+    return resolved_paths
+
+
+def existing_anchor(path: pathlib.Path) -> pathlib.Path:
+    current = path.resolve(strict=False)
+    while not current.exists() and current != current.parent:
+        current = current.parent
+    return current
+
+
+def free_space_bytes(path: pathlib.Path) -> int:
+    anchor = existing_anchor(path)
+    return shutil.disk_usage(anchor).free
+
+
+def estimate_path_size_bytes(path: pathlib.Path) -> int:
+    if not path.exists():
+        return 0
+
+    result = run_command(["du", "-sk", str(path)])
+    if result.returncode == 0:
+        output = result.stdout.strip()
+        if output:
+            size_kb = output.split()[0]
+            if size_kb.isdigit():
+                return int(size_kb) * 1024
+
+    if path.is_file():
+        return path.stat().st_size
+
+    total = 0
+    for child in path.rglob("*"):
+        try:
+            if child.is_file():
+                total += child.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def remove_path(path: pathlib.Path) -> None:
+    if not path.exists():
+        return
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+        return
+    shutil.rmtree(path)
+
+
+def ensure_free_space(
+    root: pathlib.Path,
+    minimum_free_mb: float,
+    cleanup_paths: list[pathlib.Path],
+) -> dict[str, Any]:
+    free_before_bytes = free_space_bytes(root)
+    summary: dict[str, Any] = {
+        "required_free_mb": round(minimum_free_mb, 1),
+        "free_before_mb": round(bytes_to_mb(free_before_bytes), 1),
+        "free_after_mb": round(bytes_to_mb(free_before_bytes), 1),
+        "cleanup_actions": [],
+        "satisfied": True,
+    }
+    if minimum_free_mb <= 0:
+        return summary
+
+    required_bytes = int(minimum_free_mb * 1024.0 * 1024.0)
+    if free_before_bytes >= required_bytes:
+        return summary
+
+    print(
+        "Free space is low "
+        f"({bytes_to_mb(free_before_bytes):.1f} MB available, {minimum_free_mb:.1f} MB required)."
+    )
+
+    for cleanup_path in cleanup_paths:
+        action: dict[str, Any] = {
+            "path": str(cleanup_path),
+            "status": "missing",
+        }
+        if cleanup_path.exists():
+            estimated_size_mb = round(bytes_to_mb(estimate_path_size_bytes(cleanup_path)), 1)
+            print(
+                f"Removing rebuildable path {cleanup_path} "
+                f"(about {estimated_size_mb:.1f} MB) to recover space..."
+            )
+            remove_path(cleanup_path)
+            free_after_action = free_space_bytes(root)
+            action = {
+                "path": str(cleanup_path),
+                "status": "removed",
+                "estimated_size_mb": estimated_size_mb,
+                "free_after_mb": round(bytes_to_mb(free_after_action), 1),
+            }
+            if free_after_action >= required_bytes:
+                summary["cleanup_actions"].append(action)
+                summary["free_after_mb"] = round(bytes_to_mb(free_after_action), 1)
+                return summary
+        summary["cleanup_actions"].append(action)
+
+    free_after_bytes = free_space_bytes(root)
+    summary["free_after_mb"] = round(bytes_to_mb(free_after_bytes), 1)
+    summary["satisfied"] = free_after_bytes >= required_bytes
+    if summary["satisfied"]:
+        return summary
+
+    cleanup_hint = ""
+    if cleanup_paths:
+        cleanup_hint = " Cleanup paths were attempted but did not free enough space."
+    raise SystemExit(
+        "Not enough free disk space to start capture. "
+        f"Available: {bytes_to_mb(free_after_bytes):.1f} MB. "
+        f"Required: {minimum_free_mb:.1f} MB."
+        f"{cleanup_hint}"
+    )
 
 
 def resolve_process(pid: int | None, process_name: str) -> tuple[int, str]:
@@ -156,9 +316,22 @@ def sample_process(pid: int) -> dict[str, Any] | None:
     }
 
 
-def print_instructions(pid: int, command: str, output_path: pathlib.Path, html_path: pathlib.Path | None) -> None:
+def checkpoint_path_for(output_path: pathlib.Path) -> pathlib.Path:
+    if output_path.suffix:
+        return output_path.with_name(f"{output_path.stem}.partial{output_path.suffix}")
+    return output_path.with_name(f"{output_path.name}.partial.json")
+
+
+def print_instructions(
+    pid: int,
+    command: str,
+    output_path: pathlib.Path,
+    checkpoint_path: pathlib.Path,
+    html_path: pathlib.Path | None,
+) -> None:
     print(f"Monitoring PID {pid}: {command}")
     print(f"Writing session data to {output_path}")
+    print(f"Checkpointing live data to {checkpoint_path}")
     if html_path is not None:
         print(f"Dashboard will be written to {html_path} after capture")
     if sys.stdin.isatty():
@@ -187,6 +360,7 @@ def build_session_metadata(
     process_name: str,
     resolved_command: str,
     args: argparse.Namespace,
+    disk_guard: dict[str, Any],
 ) -> dict[str, Any]:
     git = resolve_git_metadata()
     return {
@@ -203,13 +377,62 @@ def build_session_metadata(
         "target_plateau_mb": args.target_plateau_mb,
         "git_branch": git["branch"],
         "git_commit": git["commit"],
+        "disk_guard": disk_guard,
     }
 
 
 def write_session_file(path: pathlib.Path, session: dict[str, Any]) -> None:
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(session, handle, indent=2)
-        handle.write("\n")
+    temp_path = path.with_name(f".{path.name}.tmp")
+    try:
+        with temp_path.open("w", encoding="utf-8") as handle:
+            json.dump(session, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    finally:
+        if temp_path.exists():
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+
+
+class CheckpointWriter:
+    def __init__(self, output_path: pathlib.Path, interval_seconds: float) -> None:
+        self.output_path = output_path
+        self.checkpoint_path = checkpoint_path_for(output_path)
+        self.interval_seconds = max(interval_seconds, 0.0)
+        self.last_write_monotonic = 0.0
+        self.warning_emitted = False
+
+    def maybe_write(self, session: dict[str, Any], force: bool = False) -> None:
+        now = time.monotonic()
+        if not force and self.interval_seconds > 0 and (now - self.last_write_monotonic) < self.interval_seconds:
+            return
+        self._write_checkpoint(session, now)
+
+    def _write_checkpoint(self, session: dict[str, Any], now: float) -> None:
+        try:
+            write_session_file(self.checkpoint_path, session)
+        except OSError as exc:
+            if not self.warning_emitted:
+                print(
+                    f"Warning: failed to write checkpoint {self.checkpoint_path}: {exc}",
+                    file=sys.stderr,
+                )
+                self.warning_emitted = True
+            return
+
+        self.last_write_monotonic = now
+        self.warning_emitted = False
+
+    def finalize(self, session: dict[str, Any]) -> pathlib.Path:
+        write_session_file(self.checkpoint_path, session)
+        os.replace(self.checkpoint_path, self.output_path)
+        self.last_write_monotonic = time.monotonic()
+        self.warning_emitted = False
+        return self.output_path
 
 
 def maybe_generate_report(
@@ -242,25 +465,37 @@ def main() -> None:
     args = parse_args()
     output_path = ensure_parent(pathlib.Path(args.output) if args.output else default_output_path())
     html_path = ensure_parent(pathlib.Path(args.html)) if args.html else None
+    cleanup_paths = resolve_cleanup_paths(args.cleanup_path)
+    disk_guard = ensure_free_space(output_path, args.ensure_free_mb, cleanup_paths)
 
     pid, resolved_command = resolve_process(args.pid, args.process)
-    print_instructions(pid, resolved_command, output_path, html_path)
+    checkpoint_writer = CheckpointWriter(output_path, args.checkpoint_interval)
+    print_instructions(pid, resolved_command, output_path, checkpoint_writer.checkpoint_path, html_path)
 
     marker_queue: queue.Queue[str] = queue.Queue()
     start_marker_reader(marker_queue)
 
     started_at = time.time()
-    samples: list[dict[str, Any]] = []
-    markers: list[dict[str, Any]] = [
+    session = build_session_metadata(pid, args.process, resolved_command, args, disk_guard)
+    session.update(
         {
-            "time_seconds": 0.0,
-            "label": "Capture start",
-            "source": "system",
+            "stop_reason": "running",
+            "sample_count": 0,
+            "samples": [],
+            "markers": [
+                {
+                    "time_seconds": 0.0,
+                    "label": "Capture start",
+                    "source": "system",
+                }
+            ],
+            "checkpoint_path": str(checkpoint_writer.checkpoint_path),
+            "last_updated_at": utc_now_iso(),
         }
-    ]
+    )
+    checkpoint_writer.maybe_write(session, force=True)
 
     marker_count = 0
-    stop_reason = "manual-stop"
 
     try:
         while True:
@@ -268,8 +503,8 @@ def main() -> None:
             time_seconds = round(now - started_at, 3)
             snapshot = sample_process(pid)
             if snapshot is None:
-                stop_reason = "process-exited"
-                markers.append(
+                session["stop_reason"] = "process-exited"
+                session["markers"].append(
                     {
                         "time_seconds": time_seconds,
                         "label": "Process exited",
@@ -278,30 +513,34 @@ def main() -> None:
                 )
                 break
 
-            samples.append(
+            session["samples"].append(
                 {
                     "timestamp": utc_now_iso(),
                     "time_seconds": time_seconds,
                     **snapshot,
                 }
             )
+            session["sample_count"] = len(session["samples"])
+            session["last_updated_at"] = utc_now_iso()
 
+            wrote_marker = False
             while not marker_queue.empty():
                 raw_label = marker_queue.get_nowait().strip()
                 marker_count += 1
                 label = raw_label or f"Marker {marker_count}"
-                markers.append(
+                session["markers"].append(
                     {
                         "time_seconds": time_seconds,
                         "label": label,
                         "source": "manual",
                     }
                 )
+                wrote_marker = True
                 print(f"[marker @ {time_seconds:7.1f}s] {label}")
 
             if args.duration > 0 and time_seconds >= args.duration:
-                stop_reason = "duration-reached"
-                markers.append(
+                session["stop_reason"] = "duration-reached"
+                session["markers"].append(
                     {
                         "time_seconds": time_seconds,
                         "label": "Duration reached",
@@ -310,10 +549,11 @@ def main() -> None:
                 )
                 break
 
+            checkpoint_writer.maybe_write(session, force=wrote_marker)
             time.sleep(max(args.interval, 0.1))
     except KeyboardInterrupt:
-        stop_reason = "keyboard-interrupt"
-        markers.append(
+        session["stop_reason"] = "keyboard-interrupt"
+        session["markers"].append(
             {
                 "time_seconds": round(time.time() - started_at, 3),
                 "label": "Capture stopped",
@@ -322,20 +562,17 @@ def main() -> None:
         )
         print("\nStopping capture...")
 
-    session = build_session_metadata(pid, args.process, resolved_command, args)
-    session.update(
-        {
-            "stop_reason": stop_reason,
-            "sample_count": len(samples),
-            "samples": samples,
-            "markers": markers,
-        }
-    )
-    write_session_file(output_path, session)
-    maybe_generate_report(output_path, html_path, args.target_plateau_mb)
+    session["sample_count"] = len(session["samples"])
+    session["last_updated_at"] = utc_now_iso()
+    session["captured_finished_at"] = utc_now_iso()
+    checkpoint_writer.finalize(session)
+    if session["sample_count"] > 0:
+        maybe_generate_report(output_path, html_path, args.target_plateau_mb)
+    elif html_path is not None:
+        print("Skipped dashboard generation because the capture recorded no samples.", file=sys.stderr)
 
-    print(f"Saved {len(samples)} samples to {output_path}")
-    if html_path is not None:
+    print(f"Saved {session['sample_count']} samples to {output_path}")
+    if html_path is not None and session["sample_count"] > 0:
         print(f"Saved dashboard to {html_path}")
 
 

--- a/scripts/desktop-memory-report.py
+++ b/scripts/desktop-memory-report.py
@@ -333,6 +333,8 @@ def dashboard_html(
     peak_delta = peak_mb - baseline_mb
     final_delta = final_mb - baseline_mb
     plateau_text = fmt_mb(target_plateau_mb) if target_plateau_mb is not None else "None"
+    disk_guard = session.get("disk_guard") or {}
+    cleanup_actions = [action for action in disk_guard.get("cleanup_actions", []) if action.get("status") == "removed"]
 
     phase_rows_html = "".join(
         """
@@ -382,6 +384,33 @@ def dashboard_html(
         <section class="panel">
           <h2>Notes</h2>
           <p>{html.escape(session["notes"])}</p>
+        </section>
+        """
+
+    disk_guard_html = ""
+    required_free_mb = disk_guard.get("required_free_mb")
+    if required_free_mb:
+        disk_summary = (
+            f"Required at least {fmt_mb(float(required_free_mb))} free before capture. "
+            f"Started with {fmt_mb(float(disk_guard.get('free_before_mb', 0.0)))} "
+            f"and proceeded with {fmt_mb(float(disk_guard.get('free_after_mb', 0.0)))} available."
+        )
+        if cleanup_actions:
+            action_summary = "; ".join(
+                (
+                    f"Removed {html.escape(str(action.get('path', '')))} "
+                    f"(about {fmt_mb(float(action.get('estimated_size_mb', 0.0)))})"
+                )
+                for action in cleanup_actions
+            )
+            disk_summary += f" Auto-cleanup ran before capture: {action_summary}."
+        else:
+            disk_summary += " No preflight cleanup was needed."
+
+        disk_guard_html = f"""
+        <section class="panel">
+          <h2>Disk Guard</h2>
+          <p>{disk_summary}</p>
         </section>
         """
 
@@ -819,6 +848,7 @@ def dashboard_html(
     </section>
 
     {notes_html}
+    {disk_guard_html}
 
     <section class="panel">
       <h2>Session Metadata</h2>

--- a/scripts/desktop-memory-report.py
+++ b/scripts/desktop-memory-report.py
@@ -57,8 +57,34 @@ def ensure_output(path: pathlib.Path) -> pathlib.Path:
     return path
 
 
+def total_rss_mb(sample: dict[str, Any]) -> float:
+    return float(sample.get("tree_rss_kb", sample["rss_kb"])) / 1024.0
+
+
+def root_rss_mb(sample: dict[str, Any]) -> float:
+    return float(sample.get("root_rss_kb", sample.get("rss_kb", 0))) / 1024.0
+
+
+def helper_rss_mb(sample: dict[str, Any]) -> float:
+    if "helper_rss_kb" in sample:
+        return float(sample["helper_rss_kb"]) / 1024.0
+    return max(0.0, total_rss_mb(sample) - root_rss_mb(sample))
+
+
+def process_count(sample: dict[str, Any]) -> int:
+    return int(sample.get("process_count", 1))
+
+
+def peak_helper_sample(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    return max(samples, key=helper_rss_mb)
+
+
+def peak_process_count_sample(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    return max(samples, key=process_count)
+
+
 def rss_mb(sample: dict[str, Any]) -> float:
-    return float(sample["rss_kb"]) / 1024.0
+    return total_rss_mb(sample)
 
 
 def fmt_mb(value: float) -> str:
@@ -231,10 +257,15 @@ def svg_chart(
     chart_height = height - top - bottom
 
     xs = [float(sample["time_seconds"]) for sample in samples]
-    ys = [rss_mb(sample) for sample in samples]
+    ys = [total_rss_mb(sample) for sample in samples]
+    root_ys = [root_rss_mb(sample) for sample in samples]
+    show_root_breakout = any("root_rss_kb" in sample for sample in samples)
     max_time = max(xs[-1], 1.0)
-    min_y = min(ys + [baseline_mb, settled_mb] + ([target_plateau_mb] if target_plateau_mb is not None else []))
-    max_y = max(ys + [baseline_mb, settled_mb] + ([target_plateau_mb] if target_plateau_mb is not None else []))
+    y_values = ys + [baseline_mb, settled_mb] + ([target_plateau_mb] if target_plateau_mb is not None else [])
+    if show_root_breakout:
+        y_values.extend(root_ys)
+    min_y = min(y_values)
+    max_y = max(y_values)
     min_y = max(0.0, math.floor(max(min_y - 10.0, 0.0) / 10.0) * 10.0)
     max_y = math.ceil((max_y + 10.0) / 10.0) * 10.0
     if math.isclose(max_y, min_y):
@@ -248,6 +279,7 @@ def svg_chart(
         return top + chart_height - (ratio * chart_height)
 
     points = " ".join(f"{x_pos(x):.2f},{y_pos(y):.2f}" for x, y in zip(xs, ys))
+    root_points = " ".join(f"{x_pos(x):.2f},{y_pos(y):.2f}" for x, y in zip(xs, root_ys))
 
     horizontal_lines = []
     for index in range(6):
@@ -286,6 +318,9 @@ def svg_chart(
 
     baseline_y = y_pos(baseline_mb)
     settled_y = y_pos(settled_mb)
+    root_line = ""
+    if show_root_breakout:
+        root_line = f'<polyline points="{root_points}" class="root-rss-line" />'
     return f"""
 <svg viewBox="0 0 {width} {height}" class="chart-svg" role="img" aria-label="RSS over time">
   <rect x="0" y="0" width="{width}" height="{height}" rx="24" class="chart-bg" />
@@ -295,6 +330,7 @@ def svg_chart(
   <line x1="{left}" y1="{baseline_y:.2f}" x2="{width - right}" y2="{baseline_y:.2f}" class="baseline-line" />
   <line x1="{left}" y1="{settled_y:.2f}" x2="{width - right}" y2="{settled_y:.2f}" class="settled-line" />
   <polyline points="{points}" class="rss-line" />
+  {root_line}
   {''.join(marker_lines)}
 </svg>
 """
@@ -317,16 +353,26 @@ def dashboard_html(
     settled_samples = last_window(samples, settled_window_seconds)
     tail_samples = last_window(samples, tail_window_seconds)
 
-    baseline_mb = median([rss_mb(sample) for sample in baseline_samples])
-    settled_mb = median([rss_mb(sample) for sample in settled_samples])
-    final_mb = rss_mb(samples[-1])
-    peak_sample = max(samples, key=rss_mb)
-    peak_mb = rss_mb(peak_sample)
+    show_root_breakout = any("root_rss_kb" in sample for sample in samples)
+    baseline_mb = median([total_rss_mb(sample) for sample in baseline_samples])
+    settled_mb = median([total_rss_mb(sample) for sample in settled_samples])
+    final_mb = total_rss_mb(samples[-1])
+    peak_sample = max(samples, key=total_rss_mb)
+    peak_mb = total_rss_mb(peak_sample)
     peak_time_seconds = float(peak_sample["time_seconds"])
     tail_slope = slope_mb_per_minute(tail_samples)
     verdict_text, verdict_tone = classify_session(baseline_mb, settled_mb, tail_slope, target_plateau_mb)
     phases = build_phase_rows(samples, markers)
     marker_table = marker_rows(samples, markers)
+
+    peak_root_mb = root_rss_mb(peak_sample)
+    peak_helper_mb = helper_rss_mb(peak_sample)
+    peak_process_sample = peak_process_count_sample(samples)
+    peak_process_total = process_count(peak_process_sample)
+    peak_process_time_seconds = float(peak_process_sample["time_seconds"])
+    peak_helper_sample_value = peak_helper_sample(samples)
+    peak_helper_value_mb = helper_rss_mb(peak_helper_sample_value)
+    peak_helper_time_seconds = float(peak_helper_sample_value["time_seconds"])
 
     chart = svg_chart(samples, markers, baseline_mb, settled_mb, target_plateau_mb)
     baseline_delta = settled_mb - baseline_mb
@@ -335,6 +381,79 @@ def dashboard_html(
     plateau_text = fmt_mb(target_plateau_mb) if target_plateau_mb is not None else "None"
     disk_guard = session.get("disk_guard") or {}
     cleanup_actions = [action for action in disk_guard.get("cleanup_actions", []) if action.get("status") == "removed"]
+    metric_cards = [
+        """
+      <article class="metric-card">
+        <div class="metric-label">Baseline</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">Median of the first {window}</div>
+      </article>
+        """.format(value=fmt_mb(baseline_mb), window=fmt_seconds(baseline_window_seconds)),
+        """
+      <article class="metric-card">
+        <div class="metric-label">Peak total</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">At {timecode} ({delta} vs baseline)</div>
+      </article>
+        """.format(value=fmt_mb(peak_mb), timecode=fmt_timecode(peak_time_seconds), delta=fmt_delta_mb(peak_delta)),
+        """
+      <article class="metric-card">
+        <div class="metric-label">Settled total</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">Median of the last {window}</div>
+      </article>
+        """.format(value=fmt_mb(settled_mb), window=fmt_seconds(settled_window_seconds)),
+        """
+      <article class="metric-card">
+        <div class="metric-label">Final sample</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">{delta} vs baseline</div>
+      </article>
+        """.format(value=fmt_mb(final_mb), delta=fmt_delta_mb(final_delta)),
+        """
+      <article class="metric-card">
+        <div class="metric-label">Plateau delta</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">Settled minus baseline</div>
+      </article>
+        """.format(value=fmt_delta_mb(baseline_delta)),
+        """
+      <article class="metric-card">
+        <div class="metric-label">Tail slope</div>
+        <div class="metric-value">{value:+.1f} MB/min</div>
+        <div class="metric-note">Linear trend over the last {window}</div>
+      </article>
+        """.format(value=tail_slope, window=fmt_seconds(tail_window_seconds)),
+    ]
+
+    if show_root_breakout:
+        metric_cards.extend(
+            [
+                """
+      <article class="metric-card">
+        <div class="metric-label">Peak main process</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">Root PID share at the total peak</div>
+      </article>
+                """.format(value=fmt_mb(peak_root_mb)),
+                """
+      <article class="metric-card">
+        <div class="metric-label">Peak helper memory</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">Helpers peaked at {timecode}</div>
+      </article>
+                """.format(value=fmt_mb(peak_helper_value_mb), timecode=fmt_timecode(peak_helper_time_seconds)),
+                """
+      <article class="metric-card">
+        <div class="metric-label">Peak process count</div>
+        <div class="metric-value">{value}</div>
+        <div class="metric-note">At {timecode}</div>
+      </article>
+                """.format(value=peak_process_total, timecode=fmt_timecode(peak_process_time_seconds)),
+            ]
+        )
+
+    metric_cards_html = "".join(metric_cards)
 
     phase_rows_html = "".join(
         """
@@ -411,6 +530,54 @@ def dashboard_html(
         <section class="panel">
           <h2>Disk Guard</h2>
           <p>{disk_summary}</p>
+        </section>
+        """
+
+    process_tree_html = ""
+    if show_root_breakout:
+        top_process_rows = "".join(
+            """
+            <tr>
+              <td>{pid}</td>
+              <td>{rss}</td>
+              <td><code>{command}</code></td>
+            </tr>
+            """.format(
+                pid=process.get("pid"),
+                rss=fmt_mb(float(process.get("rss_kb", 0.0)) / 1024.0),
+                command=html.escape(str(process.get("command", ""))),
+            )
+            for process in peak_sample.get("top_processes", [])
+        )
+        process_tree_html = f"""
+        <section class="two-up">
+          <section class="panel">
+            <h2>Peak Composition</h2>
+            <p>
+              At {fmt_timecode(peak_time_seconds)}, total desktop RSS was {fmt_mb(peak_mb)}.
+              The root process accounted for {fmt_mb(peak_root_mb)} and helper processes accounted for {fmt_mb(peak_helper_mb)}.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>PID</th>
+                  <th>RSS</th>
+                  <th>Command</th>
+                </tr>
+              </thead>
+              <tbody>
+                {top_process_rows}
+              </tbody>
+            </table>
+          </section>
+
+          <section class="panel">
+            <h2>Scope</h2>
+            <p>
+              This session sampled the full desktop process tree rooted at PID <code>{session.get("pid")}</code>,
+              so the totals include the main Tauri process plus helper processes such as WebKit content workers.
+            </p>
+          </section>
         </section>
         """
 
@@ -597,6 +764,7 @@ def dashboard_html(
     }}
 
     .legend-rss::before {{ background: var(--accent); }}
+    .legend-root::before {{ background: #2563eb; }}
     .legend-baseline::before {{ background: #64748b; }}
     .legend-settled::before {{ background: var(--good); }}
     .legend-target::before {{ background: var(--warning); }}
@@ -637,6 +805,15 @@ def dashboard_html(
       stroke-width: 4;
       stroke-linejoin: round;
       stroke-linecap: round;
+    }}
+
+    .root-rss-line {{
+      fill: none;
+      stroke: #2563eb;
+      stroke-width: 2.5;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      opacity: 0.85;
     }}
 
     .target-line {{
@@ -741,61 +918,34 @@ def dashboard_html(
   <main class="shell">
     <section class="hero">
       <div class="eyebrow">Desktop Memory Validation</div>
-      <h1>RSS stayed {html.escape(verdict_text.lower())}</h1>
+      <h1>Total desktop RSS stayed {html.escape(verdict_text.lower())}</h1>
       <p>
         Session duration was {fmt_seconds(duration_seconds)} on host <code>{html.escape(str(session.get("host", "")))}</code>.
-        Baseline settled at {fmt_mb(baseline_mb)}, peak reached {fmt_mb(peak_mb)}, and the end-of-run plateau was {fmt_mb(settled_mb)}.
+        Total desktop memory started near {fmt_mb(baseline_mb)}, peaked at {fmt_mb(peak_mb)}, and the end-of-run plateau was {fmt_mb(settled_mb)}.
       </p>
       <div class="hero-meta">
         <span class="chip chip-{verdict_tone}">{html.escape(verdict_text)}</span>
         <span class="chip">PID {session.get("pid")}</span>
         <span class="chip">{html.escape(str(session.get("resolved_command", "")))}</span>
+        <span class="chip">Scope: {html.escape(str(session.get("sample_scope", "single-process")))}</span>
         <span class="chip">Target {plateau_text}</span>
         <span class="chip">Stop reason: {html.escape(str(session.get("stop_reason", "")))}</span>
       </div>
     </section>
 
     <section class="card-grid">
-      <article class="metric-card">
-        <div class="metric-label">Baseline</div>
-        <div class="metric-value">{fmt_mb(baseline_mb)}</div>
-        <div class="metric-note">Median of the first {fmt_seconds(baseline_window_seconds)}</div>
-      </article>
-      <article class="metric-card">
-        <div class="metric-label">Peak</div>
-        <div class="metric-value">{fmt_mb(peak_mb)}</div>
-        <div class="metric-note">At {fmt_timecode(peak_time_seconds)} ({fmt_delta_mb(peak_delta)} vs baseline)</div>
-      </article>
-      <article class="metric-card">
-        <div class="metric-label">Settled</div>
-        <div class="metric-value">{fmt_mb(settled_mb)}</div>
-        <div class="metric-note">Median of the last {fmt_seconds(settled_window_seconds)}</div>
-      </article>
-      <article class="metric-card">
-        <div class="metric-label">Final sample</div>
-        <div class="metric-value">{fmt_mb(final_mb)}</div>
-        <div class="metric-note">{fmt_delta_mb(final_delta)} vs baseline</div>
-      </article>
-      <article class="metric-card">
-        <div class="metric-label">Plateau delta</div>
-        <div class="metric-value">{fmt_delta_mb(baseline_delta)}</div>
-        <div class="metric-note">Settled minus baseline</div>
-      </article>
-      <article class="metric-card">
-        <div class="metric-label">Tail slope</div>
-        <div class="metric-value">{tail_slope:+.1f} MB/min</div>
-        <div class="metric-note">Linear trend over the last {fmt_seconds(tail_window_seconds)}</div>
-      </article>
+      {metric_cards_html}
     </section>
 
     <section class="panel chart-panel">
       <div class="chart-header">
         <div>
-          <h2>RSS Timeline</h2>
+          <h2>Total Memory Timeline</h2>
           <p class="footer-note">Use the numbered markers to map the chart to the manual test steps below.</p>
         </div>
         <div class="chart-legend">
-          <span class="legend-item legend-rss">RSS</span>
+          <span class="legend-item legend-rss">Total RSS</span>
+          {'<span class="legend-item legend-root">Root process</span>' if show_root_breakout else ''}
           <span class="legend-item legend-baseline">Baseline</span>
           <span class="legend-item legend-settled">Settled</span>
           <span class="legend-item legend-target">Target plateau</span>
@@ -837,7 +987,7 @@ def dashboard_html(
               <th>Label</th>
               <th>Time</th>
               <th>Source</th>
-              <th>RSS nearby</th>
+              <th>Total RSS nearby</th>
             </tr>
           </thead>
           <tbody>
@@ -849,6 +999,7 @@ def dashboard_html(
 
     {notes_html}
     {disk_guard_html}
+    {process_tree_html}
 
     <section class="panel">
       <h2>Session Metadata</h2>

--- a/scripts/desktop-memory-session.sh
+++ b/scripts/desktop-memory-session.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${REPO_ROOT}/artifacts/desktop-memory"
+LAUNCH_LOG_PATH="${ARTIFACT_DIR}/latest-launch.log"
+DEFAULT_HTML_PATH="${ARTIFACT_DIR}/latest.html"
+DEFAULT_MIN_FREE_MB="${DICOM_MEMORY_MIN_FREE_MB:-1024}"
+LAUNCH_TIMEOUT_SECONDS="${DICOM_MEMORY_LAUNCH_TIMEOUT_SECONDS:-300}"
+DESKTOP_BINARY_PATTERN="${DICOM_MEMORY_PROCESS_PATTERN:-src-tauri/target/debug/dicom-viewer-desktop}"
+LAUNCH_COMMAND="${DICOM_MEMORY_LAUNCH_COMMAND:-npm run desktop:launch}"
+REBUILDABLE_TARGET_PATH="${REPO_ROOT}/desktop/src-tauri/target"
+
+LAUNCH_PID=""
+OPEN_REPORT=0
+CAPTURE_ARGS=()
+
+usage() {
+  cat <<EOF
+Usage: npm run desktop:memory:session -- [capture options]
+
+Launch the desktop app, wait for the Tauri process, and start RSS capture automatically.
+
+Examples:
+  npm run desktop:memory:session
+  npm run desktop:memory:session -- --notes "rapid scrub run"
+  npm run desktop:memory:session -- --open-report
+
+Wrapper options:
+  --open-report   Open the generated HTML dashboard when the run finishes.
+  --help          Show this help message.
+
+All other arguments are passed through to scripts/desktop-memory-capture.py.
+EOF
+}
+
+free_space_mb() {
+  df -m "${REPO_ROOT}" | awk 'NR==2 {print $4}'
+}
+
+ensure_launch_headroom() {
+  local free_before free_after target_size
+  free_before="$(free_space_mb)"
+
+  if (( free_before >= DEFAULT_MIN_FREE_MB )); then
+    echo "Free disk OK: ${free_before} MB available."
+    return 0
+  fi
+
+  echo "Free disk is low: ${free_before} MB available, ${DEFAULT_MIN_FREE_MB} MB required before launch."
+
+  if [[ -e "${REBUILDABLE_TARGET_PATH}" ]]; then
+    target_size="$(du -sh "${REBUILDABLE_TARGET_PATH}" 2>/dev/null | awk '{print $1}')"
+    target_size="${target_size:-unknown}"
+    echo "Removing rebuildable ${REBUILDABLE_TARGET_PATH} (${target_size}) before launch..."
+    rm -rf "${REBUILDABLE_TARGET_PATH}"
+  fi
+
+  free_after="$(free_space_mb)"
+  echo "Free disk after cleanup: ${free_after} MB available."
+  if (( free_after < DEFAULT_MIN_FREE_MB )); then
+    echo "Still below the ${DEFAULT_MIN_FREE_MB} MB launch threshold. Free more disk space and try again." >&2
+    exit 1
+  fi
+}
+
+desktop_pid() {
+  pgrep -f "${DESKTOP_BINARY_PATTERN}" | head -n 1 || true
+}
+
+tail_launch_log() {
+  if [[ -f "${LAUNCH_LOG_PATH}" ]]; then
+    echo
+    echo "Recent launch log:"
+    tail -n 60 "${LAUNCH_LOG_PATH}" || true
+  fi
+}
+
+cleanup() {
+  local exit_code=$?
+
+  if [[ -n "${LAUNCH_PID}" ]] && kill -0 "${LAUNCH_PID}" >/dev/null 2>&1; then
+    kill "${LAUNCH_PID}" >/dev/null 2>&1 || true
+    wait "${LAUNCH_PID}" 2>/dev/null || true
+  fi
+
+  exit "${exit_code}"
+}
+
+wait_for_desktop_process() {
+  local elapsed=0
+  local pid=""
+
+  while (( elapsed < LAUNCH_TIMEOUT_SECONDS )); do
+    pid="$(desktop_pid)"
+    if [[ -n "${pid}" ]]; then
+      printf '%s\n' "${pid}"
+      return 0
+    fi
+
+    if [[ -n "${LAUNCH_PID}" ]] && ! kill -0 "${LAUNCH_PID}" >/dev/null 2>&1; then
+      echo "Desktop launch exited before the Tauri process appeared." >&2
+      tail_launch_log
+      exit 1
+    fi
+
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  echo "Timed out waiting ${LAUNCH_TIMEOUT_SECONDS}s for the desktop process." >&2
+  tail_launch_log
+  exit 1
+}
+
+trap cleanup EXIT TERM
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --open-report)
+      OPEN_REPORT=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      CAPTURE_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+mkdir -p "${ARTIFACT_DIR}"
+
+if [[ -n "$(desktop_pid)" ]]; then
+  echo "A desktop app process is already running for this worktree. Close it before starting a new memory session." >&2
+  exit 1
+fi
+
+ensure_launch_headroom
+
+echo "Starting desktop app..."
+echo "Launch log: ${LAUNCH_LOG_PATH}"
+(
+  cd "${REPO_ROOT}"
+  /bin/zsh -lc "${LAUNCH_COMMAND}"
+) >"${LAUNCH_LOG_PATH}" 2>&1 &
+LAUNCH_PID="$!"
+
+DESKTOP_PID="$(wait_for_desktop_process)"
+echo "Desktop app detected: PID ${DESKTOP_PID}"
+echo "Capture will stop automatically when you close the desktop app."
+
+python3 "${REPO_ROOT}/scripts/desktop-memory-capture.py" \
+  --pid "${DESKTOP_PID}" \
+  --html "${DEFAULT_HTML_PATH}" \
+  --ensure-free-mb 0 \
+  "${CAPTURE_ARGS[@]}"
+
+if [[ -n "${LAUNCH_PID}" ]]; then
+  wait "${LAUNCH_PID}" 2>/dev/null || true
+  LAUNCH_PID=""
+fi
+
+if (( OPEN_REPORT == 1 )) && [[ -f "${DEFAULT_HTML_PATH}" ]] && command -v open >/dev/null 2>&1; then
+  open "${DEFAULT_HTML_PATH}" >/dev/null 2>&1 || true
+fi
+
+echo
+echo "Dashboard: ${DEFAULT_HTML_PATH}"
+echo "Launch log: ${LAUNCH_LOG_PATH}"

--- a/scripts/desktop-memory-session.sh
+++ b/scripts/desktop-memory-session.sh
@@ -10,16 +10,17 @@ DEFAULT_HTML_PATH="${ARTIFACT_DIR}/latest.html"
 DEFAULT_MIN_FREE_MB="${DICOM_MEMORY_MIN_FREE_MB:-1024}"
 LAUNCH_TIMEOUT_SECONDS="${DICOM_MEMORY_LAUNCH_TIMEOUT_SECONDS:-300}"
 DESKTOP_BINARY_PATTERN="${DICOM_MEMORY_PROCESS_PATTERN:-src-tauri/target/debug/dicom-viewer-desktop}"
-LAUNCH_COMMAND="${DICOM_MEMORY_LAUNCH_COMMAND:-npm run desktop:launch}"
+DESKTOP_PROCESS_NAME="${DICOM_MEMORY_PROCESS_NAME:-dicom-viewer-desktop}"
 REBUILDABLE_TARGET_PATH="${REPO_ROOT}/desktop/src-tauri/target"
 
 LAUNCH_PID=""
 OPEN_REPORT=0
+LAUNCH_ARGS=()
 CAPTURE_ARGS=()
 
 usage() {
   cat <<EOF
-Usage: npm run desktop:memory:session -- [capture options]
+Usage: npm run desktop:memory:session -- [wrapper options] [capture options]
 
 Launch the desktop app, wait for the Tauri process, and start RSS capture automatically.
 
@@ -27,9 +28,17 @@ Examples:
   npm run desktop:memory:session
   npm run desktop:memory:session -- --notes "rapid scrub run"
   npm run desktop:memory:session -- --open-report
+  npm run desktop:memory:session -- --decode-mode js --notes "forced JS repro"
+  npm run desktop:memory:session -- --decode-mode native --decode-debug --notes "forced native repro"
+  npm run desktop:memory:session -- --decode-trace --notes "trace scrub repro"
+  npm run desktop:memory:session -- --preload-mode off --notes "viewer preload off repro"
 
 Wrapper options:
   --open-report   Open the generated HTML dashboard when the run finishes.
+  --decode-mode   Set desktop decode experiment mode: auto, js, or native.
+  --preload-mode Set viewer preload experiment mode: auto, on, or off.
+  --decode-trace Enable frontend viewer decode tracing in the desktop launch log.
+  --decode-debug  Enable verbose native decode logging in the launch log.
   --help          Show this help message.
 
 All other arguments are passed through to scripts/desktop-memory-capture.py.
@@ -67,6 +76,14 @@ ensure_launch_headroom() {
 }
 
 desktop_pid() {
+  local pid=""
+
+  pid="$(pgrep -x "${DESKTOP_PROCESS_NAME}" | head -n 1 || true)"
+  if [[ -n "${pid}" ]]; then
+    printf '%s\n' "${pid}"
+    return 0
+  fi
+
   pgrep -f "${DESKTOP_BINARY_PATTERN}" | head -n 1 || true
 }
 
@@ -123,6 +140,46 @@ while [[ $# -gt 0 ]]; do
       OPEN_REPORT=1
       shift
       ;;
+    --decode-mode)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --decode-mode (expected: auto, js, or native)." >&2
+        exit 1
+      fi
+      case "$2" in
+        auto|js|native)
+          LAUNCH_ARGS+=("--decode-mode" "$2")
+          shift 2
+          ;;
+        *)
+          echo "Unsupported --decode-mode value: $2 (expected: auto, js, or native)." >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    --decode-debug)
+      LAUNCH_ARGS+=("--decode-debug")
+      shift
+      ;;
+    --decode-trace)
+      LAUNCH_ARGS+=("--decode-trace")
+      shift
+      ;;
+    --preload-mode)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --preload-mode (expected: auto, on, or off)." >&2
+        exit 1
+      fi
+      case "$2" in
+        auto|on|off)
+          LAUNCH_ARGS+=("--preload-mode" "$2")
+          shift 2
+          ;;
+        *)
+          echo "Unsupported --preload-mode value: $2 (expected: auto, on, or off)." >&2
+          exit 1
+          ;;
+      esac
+      ;;
     --help)
       usage
       exit 0
@@ -146,8 +203,12 @@ ensure_launch_headroom
 echo "Starting desktop app..."
 echo "Launch log: ${LAUNCH_LOG_PATH}"
 (
-  cd "${REPO_ROOT}"
-  /bin/zsh -lc "${LAUNCH_COMMAND}"
+  cd "${REPO_ROOT}/desktop"
+  launch_cmd=(npm run dev:desktop)
+  if (( ${#LAUNCH_ARGS[@]} > 0 )); then
+    launch_cmd+=(-- "${LAUNCH_ARGS[@]}")
+  fi
+  "${launch_cmd[@]}"
 ) >"${LAUNCH_LOG_PATH}" 2>&1 &
 LAUNCH_PID="$!"
 

--- a/scripts/desktop-memory-session.sh
+++ b/scripts/desktop-memory-session.sh
@@ -155,11 +155,18 @@ DESKTOP_PID="$(wait_for_desktop_process)"
 echo "Desktop app detected: PID ${DESKTOP_PID}"
 echo "Capture will stop automatically when you close the desktop app."
 
-python3 "${REPO_ROOT}/scripts/desktop-memory-capture.py" \
-  --pid "${DESKTOP_PID}" \
-  --html "${DEFAULT_HTML_PATH}" \
-  --ensure-free-mb 0 \
-  "${CAPTURE_ARGS[@]}"
+capture_cmd=(
+  python3 "${REPO_ROOT}/scripts/desktop-memory-capture.py"
+  --pid "${DESKTOP_PID}"
+  --html "${DEFAULT_HTML_PATH}"
+  --ensure-free-mb 0
+)
+
+if (( ${#CAPTURE_ARGS[@]} > 0 )); then
+  capture_cmd+=("${CAPTURE_ARGS[@]}")
+fi
+
+"${capture_cmd[@]}"
 
 if [[ -n "${LAUNCH_PID}" ]]; then
   wait "${LAUNCH_PID}" 2>/dev/null || true

--- a/tests/desktop-import.spec.js
+++ b/tests/desktop-import.spec.js
@@ -235,6 +235,9 @@ async function installMockDesktop(page, options = {}) {
                             path: normalized,
                             maxBytes: Number(args.maxBytes) || 0
                         });
+                        if (Object.prototype.hasOwnProperty.call(state.readFileErrors, normalized)) {
+                            throw new Error(state.readFileErrors[normalized]);
+                        }
                         const bytes = state.headerReadBytes[normalized] || state.readFileBytes[normalized];
                         if (bytes) {
                             return Uint8Array.from(bytes.slice(0, Math.max(0, Number(args.maxBytes) || 0)));

--- a/tests/desktop-import.spec.js
+++ b/tests/desktop-import.spec.js
@@ -584,6 +584,49 @@ test.describe('Desktop import pipeline', () => {
         expect(result.readFileCalls).toHaveLength(0);
     });
 
+    test('importFromPaths: staged header reads continue until Study, Series, and SOP UIDs are available', async ({ page }) => {
+        const dicomBytes = buildSyntheticDicomBytes({
+            patientName: 'P'.repeat(65300),
+            studyInstanceUid: '1.2.study.staged',
+            seriesInstanceUid: '1.2.series.staged',
+            sopInstanceUid: '1.2.sop.staged'
+        });
+
+        const destPath = `${LIBRARY_ROOT}/1.2.study.staged/1.2.series.staged/1.2.sop.staged.dcm`;
+
+        await installMockDesktop(page, {
+            manifestEntries: [
+                { path: '/source/staged-header.dcm', name: 'staged-header.dcm', rootPath: '/source', size: dicomBytes.length, modifiedMs: 1000 }
+            ],
+            readFileBytes: {
+                '/source/staged-header.dcm': dicomBytes
+            },
+            existsOverrides: {
+                [destPath]: true
+            },
+            statOverrides: {
+                [destPath]: { size: dicomBytes.length }
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const pipeline = window.DicomViewerApp.importPipeline;
+            const importResult = await pipeline.importFromPaths(['/source']);
+            return {
+                importResult,
+                readFileCalls: window.__importMockState.readFileCalls.slice(),
+                headerReadCalls: window.__importMockState.headerReadCalls.slice()
+            };
+        });
+
+        expect(result.importResult.skipped).toBe(1);
+        expect(result.headerReadCalls.map((call) => call.maxBytes)).toEqual([64 * 1024, 256 * 1024]);
+        expect(result.readFileCalls).toHaveLength(0);
+    });
+
     // -----------------------------------------------------------------------
     // importFromPaths: size mismatch collision
     // -----------------------------------------------------------------------

--- a/tests/desktop-import.spec.js
+++ b/tests/desktop-import.spec.js
@@ -206,11 +206,14 @@ async function installMockDesktop(page, options = {}) {
         window.__importMockState = {
             mkdirCalls: [],
             writeFileCalls: [],
+            readFileCalls: [],
+            headerReadCalls: [],
             existsResults: Object.assign({}, opts.existsOverrides || {}),
             statResults: Object.assign({}, opts.statOverrides || {}),
             readFileBytes: Object.assign({}, opts.readFileBytes || {}),
             manifestEntries: opts.manifestEntries || [],
-            readFileErrors: Object.assign({}, opts.readFileErrors || {})
+            readFileErrors: Object.assign({}, opts.readFileErrors || {}),
+            headerReadBytes: Object.assign({}, opts.headerReadBytes || {})
         };
 
         window.__TAURI__ = {
@@ -224,6 +227,19 @@ async function installMockDesktop(page, options = {}) {
                     }
                     if (cmd === 'read_scan_manifest') {
                         return window.__importMockState.manifestEntries;
+                    }
+                    if (cmd === 'read_scan_header') {
+                        const normalized = normalizePath(args.path);
+                        const state = window.__importMockState;
+                        state.headerReadCalls.push({
+                            path: normalized,
+                            maxBytes: Number(args.maxBytes) || 0
+                        });
+                        const bytes = state.headerReadBytes[normalized] || state.readFileBytes[normalized];
+                        if (bytes) {
+                            return Uint8Array.from(bytes.slice(0, Math.max(0, Number(args.maxBytes) || 0)));
+                        }
+                        return Uint8Array.from([]);
                     }
                     throw new Error(`Unhandled core invoke: ${cmd}`);
                 }
@@ -252,6 +268,7 @@ async function installMockDesktop(page, options = {}) {
                 async readFile(filePath) {
                     const normalized = normalizePath(filePath);
                     const state = window.__importMockState;
+                    state.readFileCalls.push(normalized);
                     if (Object.prototype.hasOwnProperty.call(state.readFileErrors, normalized)) {
                         throw new Error(state.readFileErrors[normalized]);
                     }
@@ -525,6 +542,48 @@ test.describe('Desktop import pipeline', () => {
         expect(result.collisions).toBe(0);
     });
 
+    test('importFromPaths: dedup avoids full file reads when header metadata is sufficient', async ({ page }) => {
+        const dicomBytes = buildSyntheticDicomBytes({
+            studyInstanceUid: '1.2.study.headerdup',
+            seriesInstanceUid: '1.2.series.headerdup',
+            sopInstanceUid: '1.2.sop.headerdup'
+        });
+
+        const destPath = `${LIBRARY_ROOT}/1.2.study.headerdup/1.2.series.headerdup/1.2.sop.headerdup.dcm`;
+
+        await installMockDesktop(page, {
+            manifestEntries: [
+                { path: '/source/header-dup.dcm', name: 'header-dup.dcm', rootPath: '/source', size: dicomBytes.length, modifiedMs: 1000 }
+            ],
+            readFileBytes: {
+                '/source/header-dup.dcm': dicomBytes
+            },
+            existsOverrides: {
+                [destPath]: true
+            },
+            statOverrides: {
+                [destPath]: { size: dicomBytes.length }
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const pipeline = window.DicomViewerApp.importPipeline;
+            const importResult = await pipeline.importFromPaths(['/source']);
+            return {
+                importResult,
+                readFileCalls: window.__importMockState.readFileCalls.slice(),
+                headerReadCalls: window.__importMockState.headerReadCalls.slice()
+            };
+        });
+
+        expect(result.importResult.skipped).toBe(1);
+        expect(result.headerReadCalls).toHaveLength(1);
+        expect(result.readFileCalls).toHaveLength(0);
+    });
+
     // -----------------------------------------------------------------------
     // importFromPaths: size mismatch collision
     // -----------------------------------------------------------------------
@@ -597,6 +656,36 @@ test.describe('Desktop import pipeline', () => {
         expect(result.imported).toBe(0);
         expect(result.invalid).toBe(2);
         expect(result.errors).toBe(0);
+    });
+
+    test('importFromPaths: invalid files do not trigger full file reads', async ({ page }) => {
+        const junkBytes = Array.from({ length: 64 }, (_, index) => index);
+
+        await installMockDesktop(page, {
+            manifestEntries: [
+                { path: '/source/not-dicom.bin', name: 'not-dicom.bin', rootPath: '/source', size: junkBytes.length, modifiedMs: 1000 }
+            ],
+            readFileBytes: {
+                '/source/not-dicom.bin': junkBytes
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const pipeline = window.DicomViewerApp.importPipeline;
+            const importResult = await pipeline.importFromPaths(['/source']);
+            return {
+                importResult,
+                readFileCalls: window.__importMockState.readFileCalls.slice(),
+                headerReadCalls: window.__importMockState.headerReadCalls.slice()
+            };
+        });
+
+        expect(result.importResult.invalid).toBe(1);
+        expect(result.headerReadCalls).toHaveLength(1);
+        expect(result.readFileCalls).toHaveLength(0);
     });
 
     // -----------------------------------------------------------------------

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -2086,9 +2086,12 @@ test.describe('Desktop library scanning', () => {
                 seriesInstanceUid: 'series-1',
                 slices: [slice]
             };
-            app.state.currentSliceIndex = 0;
+            // Start "between" slices so loadSlice still renders the cached target instead of
+            // short-circuiting the already-current fast path.
+            app.state.currentSliceIndex = -1;
             app.state.windowLevel = { center: null, width: null };
             app.state.baseWindowLevel = { center: null, width: null };
+            app.state.windowLevelAnchor = { center: null, width: null };
             app.state.pixelSpacing = null;
             const originalReadFile = window.__TAURI__.fs.readFile;
             const originalNativeDecode = app.desktopDecode.decodeFrameWithPixels;

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -126,6 +126,8 @@ async function installMockDesktop(page, options = {}) {
             readFileFailures[normalizePath(path)] = Number(value || 0);
         }
 
+        window.__frontendDecodeTraceCalls = [];
+
         window.__TAURI__ = {
             core: {
                 async invoke(cmd, args) {
@@ -137,6 +139,18 @@ async function installMockDesktop(page, options = {}) {
                     }
                     if (cmd === 'read_scan_manifest') {
                         return options.nativeScanManifest || null;
+                    }
+                    if (cmd === 'get_debug_settings') {
+                        return options.debugSettings || {
+                            decodeMode: 'auto',
+                            preloadMode: 'auto',
+                            frontendDecodeTrace: false,
+                            nativeDecodeDebug: false
+                        };
+                    }
+                    if (cmd === 'log_frontend_decode_event') {
+                        window.__frontendDecodeTraceCalls.push(args?.message || '');
+                        return null;
                     }
                     throw new Error(`Unhandled core invoke: ${cmd}`);
                 }
@@ -1425,6 +1439,141 @@ test.describe('Desktop library scanning', () => {
         expect(result.alphaChannel).toEqual([255, 255, 255, 255]);
     });
 
+    test('renderPixels clears an incompatible W/L override when scrubbing into a different XA display domain', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const { state, rendering } = window.DicomViewerApp;
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+
+            const decoded12BitXa = {
+                pixelData: new Uint16Array([0, 1024, 2048, 4095]),
+                rows: 2,
+                cols: 2,
+                bitsAllocated: 16,
+                bitsStored: 12,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                planarConfiguration: 0,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 2048,
+                windowWidth: 4096,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                modality: 'XA',
+                transferSyntax: '1.2.840.10008.1.2.1',
+                mrMetadata: null,
+                pixelSpacing: null,
+                skipWindowLevel: false,
+                isBlank: false
+            };
+            const decoded8BitXa = {
+                pixelData: new Uint8Array([0, 128, 192, 255]),
+                rows: 2,
+                cols: 2,
+                bitsAllocated: 8,
+                bitsStored: 8,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                planarConfiguration: 0,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 128,
+                windowWidth: 171,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                modality: 'XA',
+                transferSyntax: '1.2.840.10008.1.2.1',
+                mrMetadata: null,
+                pixelSpacing: null,
+                skipWindowLevel: false,
+                isBlank: false
+            };
+
+            state.baseWindowLevel = { center: null, width: null };
+            state.windowLevel = { center: null, width: null };
+            state.pixelSpacing = null;
+
+            rendering.renderPixels(decoded12BitXa);
+            state.windowLevel = { center: 1928, width: 4694 };
+            const info = rendering.renderPixels(decoded8BitXa, state.windowLevel);
+            const firstChannel = Array.from(ctx.getImageData(0, 0, 2, 2).data)
+                .filter((_, index) => index % 4 === 0);
+
+            return {
+                info,
+                firstChannel,
+                baseWindowLevel: state.baseWindowLevel,
+                windowLevel: state.windowLevel
+            };
+        });
+
+        expect(result.info).toMatchObject({
+            wc: 128,
+            ww: 171
+        });
+        expect(result.firstChannel).toEqual([0, 128, 223, 255]);
+        expect(result.baseWindowLevel).toEqual({ center: 128, width: 171 });
+        expect(result.windowLevel).toEqual({ center: null, width: null });
+    });
+
+    test('renderPixels preserves a compatible W/L override across same-domain XA slices', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const { state, rendering } = window.DicomViewerApp;
+
+            const decodedA = {
+                pixelData: new Uint16Array([0, 1024, 2048, 4095]),
+                rows: 2,
+                cols: 2,
+                bitsAllocated: 16,
+                bitsStored: 12,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                planarConfiguration: 0,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 2048,
+                windowWidth: 4096,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                modality: 'XA',
+                transferSyntax: '1.2.840.10008.1.2.1',
+                mrMetadata: null,
+                pixelSpacing: null,
+                skipWindowLevel: false,
+                isBlank: false
+            };
+            const decodedB = {
+                ...decodedA,
+                pixelData: new Uint16Array([4095, 2048, 1024, 0])
+            };
+
+            state.baseWindowLevel = { center: null, width: null };
+            state.windowLevel = { center: null, width: null };
+            state.pixelSpacing = null;
+
+            rendering.renderPixels(decodedA);
+            state.windowLevel = { center: 1928, width: 4694 };
+            const info = rendering.renderPixels(decodedB, state.windowLevel);
+
+            return {
+                info,
+                baseWindowLevel: state.baseWindowLevel,
+                windowLevel: state.windowLevel
+            };
+        });
+
+        expect(result.info).toMatchObject({
+            wc: 1928,
+            ww: 4694
+        });
+        expect(result.baseWindowLevel).toEqual({ center: 2048, width: 4096 });
+        expect(result.windowLevel).toEqual({ center: 1928, width: 4694 });
+    });
+
     test('renderPixels normalizes RGB samples using Bits Stored instead of container size', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
@@ -2001,6 +2150,615 @@ test.describe('Desktop library scanning', () => {
         });
     });
 
+    test('viewer loadSlice uses desktop header decode before full file reads', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const slice = {
+                frameIndex: 0,
+                sliceLocation: 9.87,
+                sopInstanceUid: '1.2.826.0.1.3680043.2.1127.1',
+                source: {
+                    kind: 'path',
+                    path: '/library/native-header-success.dcm'
+                }
+            };
+            const cacheKey = app.sources.getSliceCacheKey(slice, 0);
+            let readFileCalls = 0;
+            let headerCalls = 0;
+            let nativeDecodeCalls = 0;
+
+            const originalReadFile = window.__TAURI__.fs.readFile;
+            const originalReadHeader = app.sources.readDesktopRenderHeaderDataSet;
+            const originalNativeDecode = app.desktopDecode.decodeFrameWithPixels;
+            app.state.currentStudy = {
+                studyInstanceUid: 'study-header'
+            };
+            app.state.currentSeries = {
+                seriesInstanceUid: 'series-header',
+                slices: [slice]
+            };
+            app.state.currentSliceIndex = 0;
+            app.state.windowLevel = { center: null, width: null };
+            app.state.baseWindowLevel = { center: null, width: null };
+            app.state.pixelSpacing = null;
+            app.state.sliceCache.clear();
+
+            window.__TAURI__.fs.readFile = async () => {
+                readFileCalls += 1;
+                return Uint8Array.from([1, 2, 3, 4]);
+            };
+            app.sources.readDesktopRenderHeaderDataSet = async () => {
+                headerCalls += 1;
+                return {
+                    string(tag) {
+                        const values = {
+                            x00020010: '1.2.840.10008.1.2.1',
+                            x00080060: 'CT',
+                            x00280004: 'MONOCHROME2',
+                            x00280030: '0.5\\0.25',
+                            x00281053: '1',
+                            x00281052: '-1024'
+                        };
+                        return values[tag] || '';
+                    },
+                    uint16(tag) {
+                        const values = {
+                            x00280101: 16
+                        };
+                        return values[tag] || 0;
+                    }
+                };
+            };
+            app.desktopDecode.decodeFrameWithPixels = async (path, frameIndex) => {
+                nativeDecodeCalls += 1;
+                return {
+                    rows: 1,
+                    cols: 2,
+                    bitsAllocated: 16,
+                    bitsStored: 16,
+                    pixelRepresentation: 0,
+                    samplesPerPixel: 1,
+                    planarConfiguration: 0,
+                    photometricInterpretation: 'MONOCHROME2',
+                    windowCenter: 40,
+                    windowWidth: 400,
+                    rescaleSlope: 1,
+                    rescaleIntercept: -1024,
+                    pixelData: new Uint16Array([1100, 1500])
+                };
+            };
+
+            try {
+                await app.viewer.loadSlice(0);
+            } finally {
+                window.__TAURI__.fs.readFile = originalReadFile;
+                app.sources.readDesktopRenderHeaderDataSet = originalReadHeader;
+                app.desktopDecode.decodeFrameWithPixels = originalNativeDecode;
+            }
+
+            const cached = app.state.sliceCache.get(cacheKey);
+            return {
+                readFileCalls,
+                headerCalls,
+                nativeDecodeCalls,
+                pixelSpacing: app.state.pixelSpacing,
+                metadataText: document.getElementById('metadataContent').textContent,
+                cachedSummary: {
+                    hasPixelData: ArrayBuffer.isView(cached?.pixelData),
+                    hasByteArray: !!cached?.byteArray,
+                    hasElements: !!cached?.elements
+                }
+            };
+        });
+
+        expect(result.readFileCalls).toBe(0);
+        expect(result.headerCalls).toBe(1);
+        expect(result.nativeDecodeCalls).toBe(1);
+        expect(result.pixelSpacing).toEqual({ row: 0.5, col: 0.25 });
+        expect(result.metadataText).toContain('CT');
+        expect(result.metadataText).toContain('2 x 1');
+        expect(result.cachedSummary).toEqual({
+            hasPixelData: true,
+            hasByteArray: false,
+            hasElements: false
+        });
+    });
+
+    test('viewer loadSlice coalesces rapid requests to the latest slice', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const paths = [
+                '/tmp/rapid-load-0.dcm',
+                '/tmp/rapid-load-1.dcm',
+                '/tmp/rapid-load-2.dcm'
+            ];
+            const slices = paths.map((path, index) => ({
+                source: { kind: 'path', path },
+                sopInstanceUid: `1.2.826.0.1.3680043.2.1125.${index}`
+            }));
+            const readResolvers = new Map();
+            const readCalls = [];
+            const decodeCalls = [];
+            const originalReadFile = window.__TAURI__.fs.readFile;
+            const originalNativeDecode = app.desktopDecode.decodeFrameWithPixels;
+            const originalDicomParser = window.dicomParser;
+
+            const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+            const waitFor = async (predicate, message) => {
+                for (let attempt = 0; attempt < 40; attempt += 1) {
+                    if (predicate()) return;
+                    await tick();
+                }
+                throw new Error(message);
+            };
+
+            app.state.currentStudy = {
+                studyInstanceUid: 'study-rapid'
+            };
+            app.state.currentSeries = {
+                seriesInstanceUid: 'series-rapid',
+                slices
+            };
+            app.state.currentSliceIndex = 0;
+            app.state.windowLevel = { center: null, width: null };
+            app.state.baseWindowLevel = { center: null, width: null };
+            app.state.pixelSpacing = null;
+            app.state.sliceCache.clear();
+
+            window.__TAURI__.fs.readFile = async (path) => new Promise(resolve => {
+                readCalls.push(path);
+                readResolvers.set(path, () => resolve(Uint8Array.from([1, 2, 3, 4])));
+            });
+            window.dicomParser = {
+                ...originalDicomParser,
+                parseDicom() {
+                    return {
+                        string(tag) {
+                            const values = {
+                                x00020010: '1.2.840.10008.1.2.4.90',
+                                x00080060: 'RF',
+                                x00280004: 'MONOCHROME2'
+                            };
+                            return values[tag] || '';
+                        },
+                        uint16(tag) {
+                            const values = {
+                                x00280101: 16
+                            };
+                            return values[tag] || 0;
+                        }
+                    };
+                }
+            };
+            app.desktopDecode.decodeFrameWithPixels = async (path) => {
+                decodeCalls.push(path);
+                const intensity = path.endsWith('0.dcm') ? 32 : path.endsWith('1.dcm') ? 96 : 224;
+                return {
+                    rows: 1,
+                    cols: 1,
+                    bitsAllocated: 16,
+                    bitsStored: 16,
+                    pixelRepresentation: 0,
+                    samplesPerPixel: 1,
+                    planarConfiguration: 0,
+                    photometricInterpretation: 'MONOCHROME2',
+                    windowCenter: 128,
+                    windowWidth: 256,
+                    rescaleSlope: 1,
+                    rescaleIntercept: 0,
+                    pixelData: new Uint16Array([intensity])
+                };
+            };
+
+            try {
+                const firstLoad = app.viewer.loadSlice(0);
+                const skippedLoad = app.viewer.loadSlice(1);
+                const latestLoad = app.viewer.loadSlice(2);
+
+                await waitFor(() => readResolvers.has(paths[2]), 'Latest slice read did not start.');
+                readResolvers.get(paths[2])();
+
+                await Promise.all([firstLoad, skippedLoad, latestLoad]);
+            } finally {
+                window.__TAURI__.fs.readFile = originalReadFile;
+                app.desktopDecode.decodeFrameWithPixels = originalNativeDecode;
+                window.dicomParser = originalDicomParser;
+            }
+
+            const canvas = document.getElementById('imageCanvas');
+            const renderedPixel = canvas.getContext('2d').getImageData(0, 0, 1, 1).data[0];
+
+            return {
+                readCalls,
+                decodeCalls,
+                currentSliceIndex: app.state.currentSliceIndex,
+                renderedPixel
+            };
+        });
+
+        expect(result.readCalls[0]).toBe('/tmp/rapid-load-2.dcm');
+        expect(result.decodeCalls).toEqual([
+            '/tmp/rapid-load-2.dcm'
+        ]);
+        expect(result.currentSliceIndex).toBe(2);
+    });
+
+    test('viewer preloads stop decoding after a newer request supersedes them', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const paths = [
+                '/tmp/preload-stop-0.dcm',
+                '/tmp/preload-stop-1.dcm',
+                '/tmp/preload-stop-2.dcm'
+            ];
+            const slices = paths.map((path, index) => ({
+                source: { kind: 'path', path },
+                sopInstanceUid: `1.2.826.0.1.3680043.2.1126.${index}`
+            }));
+            const readResolvers = new Map();
+            const readCalls = [];
+            const decodeCalls = [];
+            const originalReadFile = window.__TAURI__.fs.readFile;
+            const originalNativeDecode = app.desktopDecode.decodeFrameWithPixels;
+            const originalDicomParser = window.dicomParser;
+
+            const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+            const waitFor = async (predicate, message) => {
+                for (let attempt = 0; attempt < 40; attempt += 1) {
+                    if (predicate()) return;
+                    await tick();
+                }
+                throw new Error(message);
+            };
+
+            app.state.currentStudy = {
+                studyInstanceUid: 'study-preload'
+            };
+            app.state.currentSeries = {
+                seriesInstanceUid: 'series-preload',
+                slices
+            };
+            app.state.currentSliceIndex = 0;
+            app.state.windowLevel = { center: null, width: null };
+            app.state.baseWindowLevel = { center: null, width: null };
+            app.state.pixelSpacing = null;
+            app.state.sliceCache.clear();
+
+            window.__TAURI__.fs.readFile = async (path) => new Promise(resolve => {
+                readCalls.push(path);
+                readResolvers.set(path, () => resolve(Uint8Array.from([5, 6, 7, 8])));
+            });
+            window.dicomParser = {
+                ...originalDicomParser,
+                parseDicom() {
+                    return {
+                        string(tag) {
+                            const values = {
+                                x00020010: '1.2.840.10008.1.2.4.90',
+                                x00080060: 'RF',
+                                x00280004: 'MONOCHROME2'
+                            };
+                            return values[tag] || '';
+                        },
+                        uint16(tag) {
+                            const values = {
+                                x00280101: 16
+                            };
+                            return values[tag] || 0;
+                        }
+                    };
+                }
+            };
+            app.desktopDecode.decodeFrameWithPixels = async (path) => {
+                decodeCalls.push(path);
+                const intensity = path.endsWith('0.dcm') ? 48 : path.endsWith('1.dcm') ? 128 : 208;
+                return {
+                    rows: 1,
+                    cols: 1,
+                    bitsAllocated: 16,
+                    bitsStored: 16,
+                    pixelRepresentation: 0,
+                    samplesPerPixel: 1,
+                    planarConfiguration: 0,
+                    photometricInterpretation: 'MONOCHROME2',
+                    windowCenter: 128,
+                    windowWidth: 256,
+                    rescaleSlope: 1,
+                    rescaleIntercept: 0,
+                    pixelData: new Uint16Array([intensity])
+                };
+            };
+
+            try {
+                const initialLoad = app.viewer.loadSlice(0);
+                await waitFor(() => readResolvers.has(paths[0]), 'Initial slice read did not start.');
+                readResolvers.get(paths[0])();
+                await initialLoad;
+
+                await waitFor(() => readResolvers.has(paths[1]), 'Preload read did not start.');
+                const latestLoad = app.viewer.loadSlice(2);
+
+                readResolvers.get(paths[1])();
+                await waitFor(() => readResolvers.has(paths[2]), 'Latest slice read did not start.');
+                readResolvers.get(paths[2])();
+
+                await latestLoad;
+            } finally {
+                window.__TAURI__.fs.readFile = originalReadFile;
+                app.desktopDecode.decodeFrameWithPixels = originalNativeDecode;
+                window.dicomParser = originalDicomParser;
+            }
+
+            const canvas = document.getElementById('imageCanvas');
+            const renderedPixel = canvas.getContext('2d').getImageData(0, 0, 1, 1).data[0];
+
+            return {
+                readCalls,
+                decodeCalls,
+                currentSliceIndex: app.state.currentSliceIndex,
+                renderedPixel
+            };
+        });
+
+        expect(result.readCalls.slice(0, 3)).toEqual([
+            '/tmp/preload-stop-0.dcm',
+            '/tmp/preload-stop-1.dcm',
+            '/tmp/preload-stop-2.dcm'
+        ]);
+        expect(result.decodeCalls).toEqual([
+            '/tmp/preload-stop-0.dcm',
+            '/tmp/preload-stop-2.dcm'
+        ]);
+        expect(result.currentSliceIndex).toBe(2);
+    });
+
+    test('viewer reuses one parsed dataset while scrubbing frames from the same source file', async ({ page }) => {
+        await installMockDesktop(page, {
+            debugSettings: {
+                decodeMode: 'js',
+                preloadMode: 'off',
+                nativeDecodeDebug: false
+            }
+        });
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const sharedPath = '/tmp/multiframe-shared.dcm';
+            const slices = [
+                {
+                    source: { kind: 'path', path: sharedPath },
+                    frameIndex: 0,
+                    sopInstanceUid: '1.2.826.0.1.3680043.2.1128.0'
+                },
+                {
+                    source: { kind: 'path', path: sharedPath },
+                    frameIndex: 1,
+                    sopInstanceUid: '1.2.826.0.1.3680043.2.1128.1'
+                }
+            ];
+            const readCalls = [];
+            let parseCalls = 0;
+            const originalReadFile = window.__TAURI__.fs.readFile;
+            const originalDicomParser = window.dicomParser;
+
+            const frameBytes = new Uint8Array([
+                0x10, 0x00,
+                0x80, 0x00
+            ]);
+
+            app.state.currentStudy = {
+                studyInstanceUid: 'study-multiframe'
+            };
+            app.state.currentSeries = {
+                seriesInstanceUid: 'series-multiframe',
+                slices
+            };
+            app.state.currentSliceIndex = 0;
+            app.state.windowLevel = { center: null, width: null };
+            app.state.baseWindowLevel = { center: null, width: null };
+            app.state.pixelSpacing = null;
+            app.state.sliceCache.clear();
+
+            window.__TAURI__.fs.readFile = async (path) => {
+                readCalls.push(path);
+                return frameBytes;
+            };
+            window.dicomParser = {
+                ...originalDicomParser,
+                parseDicom() {
+                    parseCalls += 1;
+                    const byteArray = new Uint8Array([
+                        0x10, 0x00,
+                        0x80, 0x00
+                    ]);
+                    return {
+                        byteArray,
+                        elements: {
+                            x7fe00010: {
+                                dataOffset: 0,
+                                length: 4
+                            }
+                        },
+                        string(tag) {
+                            const values = {
+                                x00020010: '1.2.840.10008.1.2.1',
+                                x00080060: 'XA',
+                                x00280004: 'MONOCHROME2'
+                            };
+                            return values[tag] || '';
+                        },
+                        uint16(tag) {
+                            const values = {
+                                x00280008: 2,
+                                x00280010: 1,
+                                x00280011: 1,
+                                x00280100: 16,
+                                x00280101: 16,
+                                x00280103: 0,
+                                x00280002: 1
+                            };
+                            return values[tag] || 0;
+                        }
+                    };
+                }
+            };
+
+            try {
+                await app.viewer.loadSlice(0);
+                await app.viewer.loadSlice(1);
+            } finally {
+                window.__TAURI__.fs.readFile = originalReadFile;
+                window.dicomParser = originalDicomParser;
+            }
+
+            return {
+                readCalls,
+                parseCalls,
+                currentSliceIndex: app.state.currentSliceIndex
+            };
+        });
+
+        expect(result.readCalls).toEqual([
+            '/tmp/multiframe-shared.dcm'
+        ]);
+        expect(result.parseCalls).toBe(1);
+        expect(result.currentSliceIndex).toBe(1);
+    });
+
+    test('viewer preload mode off disables nearby slice preloads', async ({ page }) => {
+        await installMockDesktop(page, {
+            debugSettings: {
+                decodeMode: 'auto',
+                preloadMode: 'off',
+                nativeDecodeDebug: false
+            }
+        });
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const paths = [
+                '/tmp/preload-off-0.dcm',
+                '/tmp/preload-off-1.dcm'
+            ];
+            const slices = paths.map((path, index) => ({
+                source: { kind: 'path', path },
+                sopInstanceUid: `1.2.826.0.1.3680043.2.1127.${index}`
+            }));
+            const readResolvers = new Map();
+            const readCalls = [];
+            const decodeCalls = [];
+            const originalReadFile = window.__TAURI__.fs.readFile;
+            const originalNativeDecode = app.desktopDecode.decodeFrameWithPixels;
+            const originalDicomParser = window.dicomParser;
+
+            const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+            const waitFor = async (predicate, message) => {
+                for (let attempt = 0; attempt < 40; attempt += 1) {
+                    if (predicate()) return;
+                    await tick();
+                }
+                throw new Error(message);
+            };
+
+            app.state.currentStudy = {
+                studyInstanceUid: 'study-preload-off'
+            };
+            app.state.currentSeries = {
+                seriesInstanceUid: 'series-preload-off',
+                slices
+            };
+            app.state.currentSliceIndex = 0;
+            app.state.windowLevel = { center: null, width: null };
+            app.state.baseWindowLevel = { center: null, width: null };
+            app.state.pixelSpacing = null;
+            app.state.sliceCache.clear();
+
+            window.__TAURI__.fs.readFile = async (path) => new Promise(resolve => {
+                readCalls.push(path);
+                readResolvers.set(path, () => resolve(Uint8Array.from([9, 10, 11, 12])));
+            });
+            window.dicomParser = {
+                ...originalDicomParser,
+                parseDicom() {
+                    return {
+                        string(tag) {
+                            const values = {
+                                x00020010: '1.2.840.10008.1.2.4.90',
+                                x00080060: 'RF',
+                                x00280004: 'MONOCHROME2'
+                            };
+                            return values[tag] || '';
+                        },
+                        uint16(tag) {
+                            const values = {
+                                x00280101: 16
+                            };
+                            return values[tag] || 0;
+                        }
+                    };
+                }
+            };
+            app.desktopDecode.decodeFrameWithPixels = async (path) => {
+                decodeCalls.push(path);
+                return {
+                    rows: 1,
+                    cols: 1,
+                    bitsAllocated: 16,
+                    bitsStored: 16,
+                    pixelRepresentation: 0,
+                    samplesPerPixel: 1,
+                    planarConfiguration: 0,
+                    photometricInterpretation: 'MONOCHROME2',
+                    windowCenter: 128,
+                    windowWidth: 256,
+                    rescaleSlope: 1,
+                    rescaleIntercept: 0,
+                    pixelData: new Uint16Array([path.endsWith('0.dcm') ? 72 : 144])
+                };
+            };
+
+            try {
+                const initialLoad = app.viewer.loadSlice(0);
+                await waitFor(() => readResolvers.has(paths[0]), 'Initial slice read did not start.');
+                readResolvers.get(paths[0])();
+                await initialLoad;
+                await tick();
+                await tick();
+            } finally {
+                window.__TAURI__.fs.readFile = originalReadFile;
+                app.desktopDecode.decodeFrameWithPixels = originalNativeDecode;
+                window.dicomParser = originalDicomParser;
+            }
+
+            return {
+                preloadMode: app.rendering.getActivePreloadMode(),
+                preloadEnabled: app.rendering.isViewerPreloadEnabled(),
+                readCalls,
+                decodeCalls
+            };
+        });
+
+        expect(result.preloadMode).toBe('off');
+        expect(result.preloadEnabled).toBe(false);
+        expect(result.readCalls).toEqual([
+            '/tmp/preload-off-0.dcm'
+        ]);
+        expect(result.decodeCalls).toEqual([
+            '/tmp/preload-off-0.dcm'
+        ]);
+    });
+
     test('decodeWithFallback uses native-first routing for JPEG 2000 RF desktop slices', async ({ page }) => {
         const consoleMessages = [];
         page.on('console', (message) => {
@@ -2077,6 +2835,242 @@ test.describe('Desktop library scanning', () => {
         expect(result.modality).toBe('RF');
         expect(result.transferSyntax).toBe('1.2.840.10008.1.2.4.90');
         expect(consoleMessages.some((message) => message.includes('No pixel data element found'))).toBe(false);
+    });
+
+    test('decodeWithFallback uses native-first routing for uncompressed multi-frame XA desktop slices', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            const nativeCalls = [];
+            app.desktopDecode.decodeFrameWithPixels = async (path, frameIndex) => {
+                nativeCalls.push({ path, frameIndex });
+                return {
+                    rows: 2,
+                    cols: 2,
+                    bitsAllocated: 16,
+                    pixelRepresentation: 0,
+                    samplesPerPixel: 1,
+                    planarConfiguration: 0,
+                    photometricInterpretation: 'MONOCHROME2',
+                    windowCenter: 150,
+                    windowWidth: 300,
+                    rescaleSlope: 1,
+                    rescaleIntercept: 0,
+                    pixelDataLength: 8,
+                    pixelData: new Uint16Array([100, 200, 300, 400])
+                };
+            };
+
+            const dataSet = {
+                elements: {},
+                string(tag) {
+                    const values = {
+                        x00020010: '1.2.840.10008.1.2.1',
+                        x00080060: 'XA',
+                        x00280004: 'MONOCHROME2'
+                    };
+                    return values[tag] || '';
+                },
+                uint16(tag) {
+                    if (tag === 'x00280101') {
+                        return 16;
+                    }
+                    return 0;
+                },
+                intString(tag) {
+                    if (tag === 'x00280008') {
+                        return 37;
+                    }
+                    return undefined;
+                }
+            };
+
+            const slice = {
+                frameIndex: 12,
+                source: {
+                    kind: 'path',
+                    path: '/risk/xa-multiframe.dcm'
+                }
+            };
+
+            const decoded = await app.rendering.decodeWithFallback(dataSet, 12, slice);
+
+            return {
+                defaultRoute: app.rendering.getDecodeRoute('1.2.840.10008.1.2.1', 'XA'),
+                effectiveRoute: app.rendering.getDecodeRoute('1.2.840.10008.1.2.1', 'XA', slice, { frameCount: 37 }),
+                nativeCalls,
+                pixelValues: Array.from(decoded.pixelData)
+            };
+        });
+
+        expect(result.defaultRoute).toBe('js-first');
+        expect(result.effectiveRoute).toBe('native-first');
+        expect(result.nativeCalls).toEqual([
+            {
+                path: '/risk/xa-multiframe.dcm',
+                frameIndex: 12
+            }
+        ]);
+        expect(result.pixelValues).toEqual([100, 200, 300, 400]);
+    });
+
+    test('desktop debug settings can force JS decode routing', async ({ page }) => {
+        await installMockDesktop(page, {
+            debugSettings: {
+                decodeMode: 'js',
+                preloadMode: 'auto',
+                nativeDecodeDebug: false
+            }
+        });
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const app = window.DicomViewerApp;
+            return {
+                mode: app.rendering.getActiveDecodeMode(),
+                preloadMode: app.rendering.getActivePreloadMode(),
+                riskyRoute: app.rendering.getDecodeRoute('1.2.840.10008.1.2.4.90', 'RF'),
+                defaultRoute: app.rendering.getDecodeRoute('1.2.840.10008.1.2.1', 'CT')
+            };
+        });
+
+        expect(result).toEqual({
+            mode: 'js',
+            preloadMode: 'auto',
+            riskyRoute: 'js-first',
+            defaultRoute: 'js-first'
+        });
+    });
+
+    test('desktop debug settings can force native decode routing', async ({ page }) => {
+        await installMockDesktop(page, {
+            debugSettings: {
+                decodeMode: 'native',
+                preloadMode: 'auto',
+                nativeDecodeDebug: true
+            }
+        });
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const app = window.DicomViewerApp;
+            return {
+                mode: app.rendering.getActiveDecodeMode(),
+                preloadMode: app.rendering.getActivePreloadMode(),
+                riskyRoute: app.rendering.getDecodeRoute('1.2.840.10008.1.2.4.90', 'RF'),
+                defaultRoute: app.rendering.getDecodeRoute('1.2.840.10008.1.2.1', 'CT'),
+                nativeDecodeDebug: !!window.__DICOM_VIEWER_DEBUG__?.nativeDecodeDebug
+            };
+        });
+
+        expect(result).toEqual({
+            mode: 'native',
+            preloadMode: 'auto',
+            riskyRoute: 'native-first',
+            defaultRoute: 'native-first',
+            nativeDecodeDebug: true
+        });
+    });
+
+    test('desktop frontend decode trace emits events even when decode and preload are forced', async ({ page }) => {
+        await installMockDesktop(page, {
+            debugSettings: {
+                decodeMode: 'js',
+                preloadMode: 'off',
+                frontendDecodeTrace: true,
+                nativeDecodeDebug: false
+            }
+        });
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(async () => {
+            const app = window.DicomViewerApp;
+            await app.rendering.emitDesktopDecodeTrace('trace-smoke', {
+                path: '/tmp/trace.dcm',
+                frameIndex: 7,
+                note: 'forced-mode-smoke'
+            });
+
+            return {
+                debug: {
+                    decodeMode: window.__DICOM_VIEWER_DEBUG__?.decodeMode,
+                    preloadMode: window.__DICOM_VIEWER_DEBUG__?.preloadMode,
+                    frontendDecodeTrace: !!window.__DICOM_VIEWER_DEBUG__?.frontendDecodeTrace
+                },
+                calls: window.__frontendDecodeTraceCalls.map((message) => JSON.parse(message))
+            };
+        });
+
+        expect(result.debug).toEqual({
+            decodeMode: 'js',
+            preloadMode: 'off',
+            frontendDecodeTrace: true
+        });
+        expect(result.calls).toHaveLength(1);
+        expect(result.calls[0]).toMatchObject({
+            seq: 1,
+            event: 'trace-smoke',
+            path: '/tmp/trace.dcm',
+            frameIndex: 7,
+            note: 'forced-mode-smoke'
+        });
+    });
+
+    test('renderPixels reuses the same ImageData buffer for same-sized renders', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+
+        const result = await page.evaluate(() => {
+            const app = window.DicomViewerApp;
+            const canvas = document.getElementById('imageCanvas');
+            const ctx = canvas.getContext('2d');
+            const originalCreateImageData = ctx.createImageData.bind(ctx);
+            let createCalls = 0;
+
+            ctx.createImageData = (...args) => {
+                createCalls += 1;
+                return originalCreateImageData(...args);
+            };
+
+            const decodedA = {
+                pixelData: new Uint16Array([0, 1024, 2048, 4095]),
+                rows: 2,
+                cols: 2,
+                bitsAllocated: 16,
+                bitsStored: 12,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                planarConfiguration: 0,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 2048,
+                windowWidth: 4096,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                modality: 'XA',
+                transferSyntax: '1.2.840.10008.1.2.1',
+                mrMetadata: null,
+                pixelSpacing: null,
+                skipWindowLevel: false
+            };
+            const decodedB = {
+                ...decodedA,
+                pixelData: new Uint16Array([4095, 2048, 1024, 0])
+            };
+
+            app.state.baseWindowLevel = { center: null, width: null };
+            app.state.windowLevel = { center: null, width: null };
+            app.rendering.renderPixels(decodedA);
+            app.rendering.renderPixels(decodedB);
+
+            ctx.createImageData = originalCreateImageData;
+            return {
+                createCalls
+            };
+        });
+
+        expect(result.createCalls).toBe(1);
     });
 
     test('encapsulated frame extraction falls back for single-frame files with an empty basic offset table', async ({ page }) => {

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -1493,6 +1493,7 @@ test.describe('Desktop library scanning', () => {
 
             state.baseWindowLevel = { center: null, width: null };
             state.windowLevel = { center: null, width: null };
+            state.windowLevelAnchor = { center: null, width: null };
             state.pixelSpacing = null;
 
             rendering.renderPixels(decoded12BitXa);
@@ -1553,6 +1554,7 @@ test.describe('Desktop library scanning', () => {
 
             state.baseWindowLevel = { center: null, width: null };
             state.windowLevel = { center: null, width: null };
+            state.windowLevelAnchor = { center: null, width: null };
             state.pixelSpacing = null;
 
             rendering.renderPixels(decodedA);

--- a/tests/desktop-native-decode.spec.js
+++ b/tests/desktop-native-decode.spec.js
@@ -168,7 +168,7 @@ test('desktop decode bridge coerces LE bytes into unsigned 16-bit samples', asyn
             pixelDataType: decoded.pixelData.constructor.name,
             pixelSamples: Array.from(decoded.pixelData),
             invokeCalls: window.__desktopDecodeInvokeCalls
-                .filter(call => !call.cmd.startsWith('plugin:'))
+                .filter(call => call.cmd === 'decode_frame_with_pixels')
                 .map(call => ({ cmd: call.cmd, args: call.args }))
         };
     });

--- a/tests/desktop-native-decode.spec.js
+++ b/tests/desktop-native-decode.spec.js
@@ -213,6 +213,114 @@ test('desktop decode bridge preserves signed sample types', async ({ page }) => 
     expect(result.pixelSamples).toEqual([-2, -32768]);
 });
 
+test('desktop decode bridge keeps waiters attached to the correct frame request', async ({ page }) => {
+    await installMockDesktopDecode(page);
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate(async () => {
+        const originalInvoke = window.__TAURI__.core.invoke;
+        const invokeCalls = [];
+        const pending = [];
+
+        function buildPayload(sample) {
+            const metadata = {
+                rows: 1,
+                cols: 1,
+                bitsAllocated: 16,
+                pixelRepresentation: 0,
+                samplesPerPixel: 1,
+                planarConfiguration: 0,
+                photometricInterpretation: 'MONOCHROME2',
+                windowCenter: 128,
+                windowWidth: 256,
+                rescaleSlope: 1,
+                rescaleIntercept: 0,
+                pixelDataLength: 2
+            };
+            const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata));
+            const pixelBytes = new Uint8Array(2);
+            new DataView(pixelBytes.buffer).setUint16(0, sample, true);
+            const payload = new Uint8Array(4 + metadataBytes.byteLength + pixelBytes.byteLength);
+            new DataView(payload.buffer).setUint32(0, metadataBytes.byteLength, true);
+            payload.set(metadataBytes, 4);
+            payload.set(pixelBytes, 4 + metadataBytes.byteLength);
+            return payload;
+        }
+
+        window.__TAURI__.core.invoke = (cmd, args) => {
+            if (cmd !== 'decode_frame_with_pixels') {
+                return originalInvoke(cmd, args);
+            }
+
+            invokeCalls.push({ cmd, args });
+            return new Promise((resolve) => {
+                pending.push({
+                    path: args.path,
+                    frameIndex: args.frameIndex,
+                    resolve
+                });
+            });
+        };
+
+        const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+        try {
+            const frameA = window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/frame-a.dcm', 0);
+            await tick();
+            const frameB = window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/frame-b.dcm', 1);
+            const frameC = window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/frame-c.dcm', 2);
+            await tick();
+
+            pending.find((entry) => entry.path.endsWith('frame-a.dcm')).resolve(buildPayload(0x1111));
+            await tick();
+            await tick();
+
+            pending.find((entry) => entry.path.endsWith('frame-b.dcm')).resolve(buildPayload(0x2222));
+            await tick();
+            await tick();
+
+            pending.find((entry) => entry.path.endsWith('frame-c.dcm')).resolve(buildPayload(0x3333));
+
+            const [decodedA, decodedB, decodedC] = await Promise.all([frameA, frameB, frameC]);
+            return {
+                invokeCalls,
+                pixelSamples: [
+                    decodedA.pixelData[0],
+                    decodedB.pixelData[0],
+                    decodedC.pixelData[0]
+                ]
+            };
+        } finally {
+            window.__TAURI__.core.invoke = originalInvoke;
+        }
+    });
+
+    expect(result.invokeCalls).toEqual([
+        {
+            cmd: 'decode_frame_with_pixels',
+            args: {
+                path: '/mock/study/frame-a.dcm',
+                frameIndex: 0
+            }
+        },
+        {
+            cmd: 'decode_frame_with_pixels',
+            args: {
+                path: '/mock/study/frame-b.dcm',
+                frameIndex: 1
+            }
+        },
+        {
+            cmd: 'decode_frame_with_pixels',
+            args: {
+                path: '/mock/study/frame-c.dcm',
+                frameIndex: 2
+            }
+        }
+    ]);
+    expect(result.pixelSamples).toEqual([0x1111, 0x2222, 0x3333]);
+});
+
 test('desktop decode bridge surfaces a runtime-ready error when invoke is unavailable', async ({ page }) => {
     await page.goto(HOME_URL);
 

--- a/tests/desktop-native-decode.spec.js
+++ b/tests/desktop-native-decode.spec.js
@@ -30,6 +30,36 @@ async function installMockDesktopDecode(page, options = {}) {
         );
         const invokeCalls = [];
         const binaryResponseMode = opts.binaryResponseMode || 'data-object';
+        const combinedMetadata = {
+            rows: metadata.rows,
+            cols: metadata.cols,
+            bitsAllocated: metadata.bitsAllocated,
+            pixelRepresentation: metadata.pixelRepresentation,
+            samplesPerPixel: metadata.samplesPerPixel,
+            planarConfiguration: metadata.planarConfiguration,
+            photometricInterpretation: metadata.photometricInterpretation,
+            windowCenter: metadata.windowCenter,
+            windowWidth: metadata.windowWidth,
+            rescaleSlope: metadata.rescaleSlope,
+            rescaleIntercept: metadata.rescaleIntercept,
+            pixelDataLength: metadata.pixelDataLength
+        };
+
+        function createCombinedDecodePayload() {
+            const decodeId = metadata.decodeId;
+            const frame = decodedFrames.get(decodeId);
+            if (!frame) {
+                throw new Error(`Decoded frame not found: ${decodeId}`);
+            }
+
+            const metadataBytes = new TextEncoder().encode(JSON.stringify(combinedMetadata));
+            const pixelBytes = new Uint8Array(frame);
+            const payload = new Uint8Array(4 + metadataBytes.byteLength + pixelBytes.byteLength);
+            new DataView(payload.buffer).setUint32(0, metadataBytes.byteLength, true);
+            payload.set(metadataBytes, 4);
+            payload.set(pixelBytes, 4 + metadataBytes.byteLength);
+            return payload;
+        }
 
         window.__desktopDecodeInvokeCalls = invokeCalls;
 
@@ -61,6 +91,25 @@ async function installMockDesktopDecode(page, options = {}) {
                         return args.handler;
                     case 'plugin:event|unlisten':
                         return null;
+                    case 'decode_frame_with_pixels': {
+                        if (opts.decodeFrameError) {
+                            throw opts.decodeFrameError;
+                        }
+                        const payload = createCombinedDecodePayload();
+                        if (binaryResponseMode === 'uint8array') {
+                            return payload;
+                        }
+                        if (binaryResponseMode === 'arraybuffer') {
+                            return payload.buffer;
+                        }
+                        if (binaryResponseMode === 'data-object') {
+                            return { data: Array.from(payload) };
+                        }
+                        if (binaryResponseMode === 'invalid-object') {
+                            return { bogus: [1, 2, 3] };
+                        }
+                        throw new Error(`Unhandled binaryResponseMode: ${binaryResponseMode}`);
+                    }
                     case 'decode_frame':
                         if (opts.decodeFrameError) {
                             throw opts.decodeFrameError;
@@ -111,7 +160,6 @@ test('desktop decode bridge coerces LE bytes into unsigned 16-bit samples', asyn
         const decoded = await window.DicomViewerApp.desktopDecode.decodeFrameWithPixels('/mock/study/MR2_J2KI.dcm', 3);
         return {
             metadata: {
-                decodeId: decoded.decodeId,
                 rows: decoded.rows,
                 cols: decoded.cols,
                 bitsAllocated: decoded.bitsAllocated,
@@ -126,7 +174,6 @@ test('desktop decode bridge coerces LE bytes into unsigned 16-bit samples', asyn
     });
 
     expect(result.metadata).toEqual({
-        decodeId: 'decode-1',
         rows: 2,
         cols: 1,
         bitsAllocated: 16,
@@ -136,16 +183,10 @@ test('desktop decode bridge coerces LE bytes into unsigned 16-bit samples', asyn
     expect(result.pixelSamples).toEqual([0x1234, 0x5678]);
     expect(result.invokeCalls).toEqual([
         {
-            cmd: 'decode_frame',
+            cmd: 'decode_frame_with_pixels',
             args: {
                 path: '/mock/study/MR2_J2KI.dcm',
                 frameIndex: 3
-            }
-        },
-        {
-            cmd: 'take_decoded_frame',
-            args: {
-                decodeId: 'decode-1'
             }
         }
     ]);

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -390,15 +390,7 @@ test('desktop runtime shim augments a partial global Tauri object', async ({ pag
 test('desktop runtime ready promise waits for a partial global Tauri object to finish initializing', async ({ page }) => {
     await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
     await page.addInitScript(() => {
-        window.__TAURI__ = {
-            core: {
-                invoke() {
-                    return Promise.resolve('native-invoke');
-                }
-            }
-        };
-
-        setTimeout(() => {
+        window.__finishMockPartialTauriInitialization = () => {
             window.__TAURI__.dialog = {
                 async open() {
                     return null;
@@ -424,7 +416,15 @@ test('desktop runtime ready promise waits for a partial global Tauri object to f
                     };
                 }
             };
-        }, 150);
+        };
+
+        window.__TAURI__ = {
+            core: {
+                invoke() {
+                    return Promise.resolve('native-invoke');
+                }
+            }
+        };
     });
 
     await page.goto(HOME_URL);
@@ -434,6 +434,7 @@ test('desktop runtime ready promise waits for a partial global Tauri object to f
             window.__DICOM_VIEWER_TAURI_READY__.then(() => true),
             new Promise((resolve) => setTimeout(() => resolve(false), 25))
         ]);
+        window.__finishMockPartialTauriInitialization();
         const runtime = await window.__DICOM_VIEWER_TAURI_READY__;
         return {
             settledEarly,


### PR DESCRIPTION
## Summary
- add desktop memory capture/report/session tooling with a dashboard, auto-recovery safeguards, and a dedicated diagnostics home under `docs/diagnostics/`
- avoid full-file desktop reads during import duplicate/invalid screening by using header-first checks and manifest metadata before copying
- harden desktop viewer scrubbing with decode-route tracing, native cache I/O locking, desktop scrub debouncing, and W/L safeguards for mixed-domain XA slices so stale 12-bit overrides do not darken 8-bit frames

## Testing
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml --no-default-features`
- `node --check docs/js/app/rendering.js`
- `node --check docs/js/app/viewer.js`
- `node --check docs/js/app/tools.js`
- `node --check docs/js/app/main.js`
- `node --check docs/js/app/desktop-decode.js`
- `node --check tests/desktop-library.spec.js`
- `node --check tests/desktop-native-decode.spec.js`
- `node --check tests/desktop-import.spec.js`
- `python3 -m py_compile scripts/desktop-memory-capture.py scripts/desktop-memory-report.py`
- `bash -n scripts/desktop-memory-session.sh`
- manual desktop validation on March 29, 2026:
  - import-heavy repro dropped from multi-GB growth to roughly `390 MB` baseline / `424 MB` peak / `390 MB` settled
  - final XA scrub + W/L repro no longer darkened after the mixed-domain W/L fix

## Root Cause Notes
- import duplicate/invalid scanning was still pulling full files across the Tauri bridge unnecessarily
- the XA dark-image regression came from carrying a W/L override tuned for `16-bit` / `2048-4096` style frames onto `8-bit` / `128-171` style frames in the same series
- native decode is still attempted first for desktop path-backed high-risk multi-frame `XA` / `RF` slices, but fallback tracing is now explicit and easier to reason about when a vendor-specific frame drops back to JS
