### PR TITLE
Simplify decode fallback, remove passthrough, tighten LRU

### DIFF
--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -658,7 +658,7 @@
             row.onclick = e => {
                 if (e.target.closest('.comment-toggle')) return;
                 const item = row.closest('.series-dropdown-item');
-                viewer.openViewerWithSeries(item.dataset.studyUid, item.dataset.seriesUid);
+                viewer.openViewer(item.dataset.studyUid, item.dataset.seriesUid);
             };
         });
 

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -36,7 +36,7 @@
     const {
         closeViewer,
         loadSlice,
-        openViewerWithSeries
+        openViewer
     } = app.viewer;
     const {
         loadDroppedStudies,
@@ -229,7 +229,7 @@
             console.log(
                 `Auto-opening test series ${selection.seriesUid} from study ${selection.studyUid} (${selection.sliceCount} slices)`
             );
-            openViewerWithSeries(selection.studyUid, selection.seriesUid);
+            openViewer(selection.studyUid, selection.seriesUid);
 
             const maxSkip = 50;
             for (let i = 0; i < maxSkip && state.currentSeries; i++) {

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -219,8 +219,8 @@
         }
         if (typeof value === 'string') {
             // Redact absolute paths to filename only (may contain patient names in directory structure)
-            if (value.startsWith('/') && value.includes('/', 1)) {
-                return '.../' + value.split('/').pop();
+            if ((value.startsWith('/') && value.includes('/', 1)) || /^[A-Z]:\\/.test(value)) {
+                return '.../' + value.split(/[\\/]/).pop();
             }
             return value;
         }
@@ -1012,6 +1012,25 @@
         });
     }
 
+    async function tryNativeFallback(dataSet, slice, frameIndex, jsFailure, jsStage, jsMessage, traceOutcome, jsDecoderKind) {
+        traceOutcome('decode-fallback', {
+            from: jsDecoderKind,
+            to: 'native',
+            jsErrorStage: jsStage,
+            jsErrorMessage: jsMessage
+        });
+        const { result: nativeDecoded, error: nativeFallbackError } = await attemptDecode(
+            () => decodeNative(dataSet, slice.source.path, frameIndex)
+        );
+        if (nativeDecoded) {
+            traceDecodeResult(traceOutcome, 'native', nativeDecoded);
+            return nativeDecoded;
+        }
+        const fallback = buildFallbackDecodeError(dataSet, jsFailure, nativeFallbackError);
+        traceFallbackError(traceOutcome, 'native', fallback);
+        return fallback;
+    }
+
     async function decodeWithFallback(dataSet, frameIndex = 0, slice = null) {
         const transferSyntax = getString(dataSet, 'x00020010');
         const modality = getString(dataSet, 'x00080060');
@@ -1143,22 +1162,12 @@
                 return fallback;
             }
 
-            traceOutcome('decode-fallback', {
-                from: jsDecoderKind,
-                to: 'native',
-                jsErrorStage: jsDecoded?.stage || null,
-                jsErrorMessage: jsDecoded?.errorDetails || jsDecoded?.errorMessage || null
-            });
-            const { result: nativeDecoded, error: nativeFallbackError } = await attemptDecode(
-                () => decodeNative(dataSet, slice.source.path, frameIndex)
+            return tryNativeFallback(
+                dataSet, slice, frameIndex, jsDecoded,
+                jsDecoded?.stage || null,
+                jsDecoded?.errorDetails || jsDecoded?.errorMessage || null,
+                traceOutcome, jsDecoderKind
             );
-            if (nativeDecoded) {
-                traceDecodeResult(traceOutcome, 'native', nativeDecoded);
-                return nativeDecoded;
-            }
-            const fallback = buildFallbackDecodeError(dataSet, jsDecoded, nativeFallbackError);
-            traceFallbackError(traceOutcome, 'native', fallback);
-            return fallback;
         }
 
         // JS decode threw an exception
@@ -1168,22 +1177,12 @@
             return fallback;
         }
 
-        traceOutcome('decode-fallback', {
-            from: jsDecoderKind,
-            to: 'native',
-            jsErrorStage: getDecodeFailureStage(jsError),
-            jsErrorMessage: getDecodeFailureMessage(jsError)
-        });
-        const { result: nativeDecoded, error: nativeFallbackError } = await attemptDecode(
-            () => decodeNative(dataSet, slice.source.path, frameIndex)
+        return tryNativeFallback(
+            dataSet, slice, frameIndex, jsError,
+            getDecodeFailureStage(jsError),
+            getDecodeFailureMessage(jsError),
+            traceOutcome, jsDecoderKind
         );
-        if (nativeDecoded) {
-            traceDecodeResult(traceOutcome, 'native', nativeDecoded);
-            return nativeDecoded;
-        }
-        const fallback = buildFallbackDecodeError(dataSet, jsError, nativeFallbackError);
-        traceFallbackError(traceOutcome, 'native', fallback);
-        return fallback;
     }
 
     async function decodeDesktopPathWithHeader(dataSet, frameIndex = 0, slice = null) {

--- a/docs/js/app/state.js
+++ b/docs/js/app/state.js
@@ -26,7 +26,7 @@
                 this._map.delete(key);
             }
             this._map.set(key, value);
-            while (this._map.size > this._maxSize) {
+            if (this._map.size > this._maxSize) {
                 const oldest = this._map.keys().next().value;
                 this._map.delete(oldest);
             }

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -144,20 +144,10 @@
     }
 
     function rememberSharedPathDataSet(path, entry) {
-        if (!path) {
-            return entry;
-        }
-
-        if (sharedPathDataSets.has(path)) {
-            sharedPathDataSets.delete(path);
-        }
+        if (!path) return entry;
+        // MAX_SHARED_PATH_DATASETS is 1, so just keep the latest
+        sharedPathDataSets.clear();
         sharedPathDataSets.set(path, entry);
-
-        while (sharedPathDataSets.size > MAX_SHARED_PATH_DATASETS) {
-            const oldest = sharedPathDataSets.keys().next().value;
-            sharedPathDataSets.delete(oldest);
-        }
-
         return entry;
     }
 
@@ -706,10 +696,6 @@
         }
     }
 
-    function openViewerWithSeries(studyUid, seriesUid) {
-        openViewer(studyUid, seriesUid);
-    }
-
     function closeViewer() {
         beginLoadGeneration();
         viewerView.style.display = 'none';
@@ -729,7 +715,6 @@
         closeViewer,
         loadSlice,
         openViewer,
-        openViewerWithSeries,
         selectSeries
     };
 })();


### PR DESCRIPTION
## Summary

Address high + medium hardener findings from post-PR #54-#57 audit.

- **tryNativeFallback helper**: Extract duplicated native-fallback pattern from `decodeWithFallback` (two 15-line branches -> one-liner each). Caller extracts trace values to preserve exact semantics per branch.
- **Remove openViewerWithSeries**: Pure passthrough to `openViewer`. Updated 2 callers.
- **Windows path redaction**: `normalizeTraceValue` now catches `C:\...` paths in addition to Unix paths.
- **LRU while -> if**: `set()` can only exceed max by 1 entry. Communicates the invariant.
- **Simplify sharedPathDataSets**: With `MAX_SHARED_PATH_DATASETS=1`, the delete-reinsert-while pattern is replaced by `clear()` + `set()`.

Two findings dropped after critique:
- Rust struct dedup: serde shapes differ, would change wire format
- Retry-on-null removal: second call can take fresh path after shared dataset cleanup

## Test plan

- [x] Full Playwright suite: 416 passed, 0 failures

Generated with [Claude Code](https://claude.com/claude-code)