### PR TITLE
Fix sync regressions and stabilize navigation tests

### DIFF
--- a/docs/js/app/sync-engine.js
+++ b/docs/js/app/sync-engine.js
@@ -606,6 +606,8 @@ const _SyncEngine = (() => {
                     if (data.name !== undefined) report.name = data.name;
                     if (data.type !== undefined) report.type = data.type;
                     if (data.size !== undefined) report.size = data.size;
+                    if (data.added_at !== undefined) report.addedAt = new Date(data.added_at).toISOString();
+                    if (data.updated_at !== undefined) report.updatedAt = new Date(data.updated_at).toISOString();
                     report.sync_version = syncVersion;
                     delete report.deletedAt;
                     delete report.deleted_at;
@@ -616,7 +618,8 @@ const _SyncEngine = (() => {
                         name: data.name || '',
                         type: data.type || '',
                         size: data.size || 0,
-                        addedAt: data.created_at ? new Date(data.created_at).toISOString() : new Date().toISOString(),
+                        addedAt: data.added_at ? new Date(data.added_at).toISOString() : new Date().toISOString(),
+                        updatedAt: data.updated_at ? new Date(data.updated_at).toISOString() : new Date().toISOString(),
                         sync_version: syncVersion
                     });
                 }

--- a/docs/js/persistence/sync.js
+++ b/docs/js/persistence/sync.js
@@ -23,6 +23,45 @@ const _SyncOutbox = (() => {
         syncState: {}
     };
 
+    function mapDesktopOutboxRow(row) {
+        return {
+            id: String(row.id),
+            operation_uuid: row.operation_uuid,
+            table_name: row.table_name,
+            record_key: row.record_key,
+            operation: row.operation,
+            base_sync_version: row.base_sync_version,
+            created_at: row.created_at,
+            synced_at: row.synced_at,
+            attempts: row.attempts || 0,
+            last_error: row.last_error
+        };
+    }
+
+    function mergeHydratedSyncState(stateRows) {
+        for (const row of stateRows) {
+            if (!Object.prototype.hasOwnProperty.call(desktopCache.syncState, row.key)) {
+                desktopCache.syncState[row.key] = row.value;
+            }
+        }
+    }
+
+    function mergeHydratedOutbox(outboxRows) {
+        const existingOperationIds = new Set(
+            desktopCache.outbox
+                .map((entry) => entry?.operation_uuid)
+                .filter(Boolean)
+        );
+
+        for (const row of outboxRows) {
+            if (!existingOperationIds.has(row.operation_uuid)) {
+                desktopCache.outbox.push(mapDesktopOutboxRow(row));
+            }
+        }
+
+        desktopCache.outbox.sort((a, b) => (a.created_at || 0) - (b.created_at || 0));
+    }
+
     function isDesktopMode() {
         if (typeof window === 'undefined') return false;
         if (typeof window.CONFIG !== 'undefined') {
@@ -222,23 +261,8 @@ const _SyncOutbox = (() => {
                  ORDER BY created_at ASC`
             );
 
-            desktopCache.syncState = {};
-            for (const row of stateRows) {
-                desktopCache.syncState[row.key] = row.value;
-            }
-
-            desktopCache.outbox = outboxRows.map((row) => ({
-                id: String(row.id),
-                operation_uuid: row.operation_uuid,
-                table_name: row.table_name,
-                record_key: row.record_key,
-                operation: row.operation,
-                base_sync_version: row.base_sync_version,
-                created_at: row.created_at,
-                synced_at: row.synced_at,
-                attempts: row.attempts || 0,
-                last_error: row.last_error
-            }));
+            mergeHydratedSyncState(stateRows);
+            mergeHydratedOutbox(outboxRows);
 
             desktopCache.hydrated = true;
             scheduleLegacyDesktopStorageCleanup();

--- a/server/routes/maintenance.py
+++ b/server/routes/maintenance.py
@@ -10,7 +10,7 @@ Copyright (c) 2026 Divergent Health Technologies
 
 import os
 
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, g, jsonify, request
 
 from server import db as db_module
 from server.maintenance import (
@@ -73,7 +73,7 @@ def trigger_restore():
     backup_path = os.path.join(backups_dir, backup_name)
 
     # Close the per-request DB connection before restoring
-    db_conn = getattr(request, "_db", None)
+    db_conn = g.pop("db", None)
     if db_conn:
         db_conn.close()
 

--- a/server/sync/delta.py
+++ b/server/sync/delta.py
@@ -95,16 +95,7 @@ def process_change(db, user_id, device_id, change):
             "current_data": current_data,
         }
 
-    new_version = _next_sync_version(db, table, key, device_id, user_id)
-    now = int(time.time() * 1000)
-
-    if operation == "insert":
-        _apply_insert(db, table, user_id, key, data, device_id, new_version, now)
-    elif operation == "update":
-        _apply_update(db, table, user_id, key, data, device_id, new_version, now)
-    elif operation == "delete":
-        _apply_delete(db, table, user_id, key, device_id, new_version, now)
-    else:
+    if operation not in {"insert", "update", "delete"}:
         return {
             "status": "rejected",
             "operation_uuid": operation_uuid,
@@ -113,6 +104,16 @@ def process_change(db, user_id, device_id, change):
             "current_sync_version": current_version,
             "current_data": {},
         }
+
+    new_version = _next_sync_version(db, table, key, device_id, user_id)
+    now = int(time.time() * 1000)
+
+    if operation == "insert":
+        _apply_insert(db, table, user_id, key, data, device_id, new_version, now)
+    elif operation == "update":
+        _apply_update(db, table, user_id, key, data, device_id, new_version, now)
+    else:
+        _apply_delete(db, table, user_id, key, device_id, new_version, now)
 
     db.execute(
         """

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -13,6 +13,31 @@ async function installMockTauri(page, options = {}) {
         const SECURE_AUTH_STORAGE_KEY = 'mock-tauri-secure-auth-state';
         const failRemoveAll = !!options.failRemoveAll;
         const failWritePatterns = Array.isArray(options.failWritePatterns) ? options.failWritePatterns : [];
+        const selectDelayMs = Number.isFinite(Number(options.selectDelayMs)) ? Number(options.selectDelayMs) : 0;
+        const selectDelayPatterns = Array.isArray(options.selectDelayPatterns)
+            ? options.selectDelayPatterns.map((pattern) => String(pattern).toLowerCase())
+            : [];
+        const sqlPlugin = window.__createMockTauriSql(options);
+
+        if (selectDelayMs > 0) {
+            const originalLoad = sqlPlugin.load.bind(sqlPlugin);
+            sqlPlugin.load = async (db) => {
+                const connection = await originalLoad(db);
+                const originalSelect = connection.select.bind(connection);
+                connection.select = async (query, values) => {
+                    const normalizedQuery = String(query || '').toLowerCase();
+                    const shouldDelay = !selectDelayPatterns.length
+                        || selectDelayPatterns.some((pattern) => normalizedQuery.includes(pattern));
+
+                    if (shouldDelay) {
+                        await new Promise((resolve) => setTimeout(resolve, selectDelayMs));
+                    }
+
+                    return originalSelect(query, values);
+                };
+                return connection;
+            };
+        }
 
         if (options.initialSecureAuthState) {
             localStorage.setItem(
@@ -115,7 +140,7 @@ async function installMockTauri(page, options = {}) {
                     return joinPaths(path);
                 }
             },
-            sql: window.__createMockTauriSql(options),
+            sql: sqlPlugin,
             webview: {
                 getCurrentWebview() {
                     return {
@@ -702,6 +727,75 @@ test.describe('Desktop report persistence', () => {
         );
         expect(restored.legacySyncState).toBeNull();
         expect(restored.legacyOutbox).toBeNull();
+    });
+
+    test('desktop hydration merges pre-hydration sync writes instead of clobbering them', async ({ page }) => {
+        await installMockTauri(page, {
+            selectDelayMs: 150,
+            selectDelayPatterns: ['sync_state', 'sync_outbox'],
+            initialState: {
+                'sqlite:viewer.db': {
+                    sync_state: [
+                        { key: 'delta_cursor', value: 'legacy-cursor', updated_at: 1000 },
+                        { key: 'device_id', value: 'legacy-device', updated_at: 1001 }
+                    ],
+                    sync_outbox: [
+                        {
+                            id: 1,
+                            operation_uuid: 'legacy-op-1',
+                            table_name: 'comments',
+                            record_key: 'legacy-comment-1',
+                            operation: 'insert',
+                            base_sync_version: 0,
+                            created_at: 1000,
+                            synced_at: null,
+                            attempts: 0,
+                            last_error: null
+                        }
+                    ],
+                    meta: {
+                        lastCommentId: 0,
+                        lastOutboxId: 1,
+                        loadCalls: 0
+                    }
+                }
+            }
+        });
+        await page.goto(HOME_URL);
+        await page.waitForFunction(() => !!window._SyncOutbox);
+
+        const raced = await page.evaluate(async () => {
+            const hydration = window._SyncOutbox.hydrateFromSqlite();
+            window._SyncOutbox.setCursor('cursor-race');
+            window._SyncOutbox.setDeviceId('device-race');
+            const queued = window._SyncOutbox.enqueueChange('comments', 'uuid-race', 'insert', 0);
+
+            await hydration;
+            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            return {
+                cursor: window._SyncOutbox.getCursor(),
+                deviceId: window._SyncOutbox.getDeviceId(),
+                queuedOperationUuid: queued?.operation_uuid || null,
+                pending: await window._SyncOutbox.readPendingChangesAsync()
+            };
+        });
+
+        expect(raced.cursor).toBe('cursor-race');
+        expect(raced.deviceId).toBe('device-race');
+        expect(raced.pending).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    operation_uuid: 'legacy-op-1',
+                    record_key: 'legacy-comment-1'
+                }),
+                expect.objectContaining({
+                    operation_uuid: raced.queuedOperationUuid,
+                    record_key: 'uuid-race',
+                    operation: 'insert'
+                })
+            ])
+        );
     });
 
     test('desktop backend persists report files and metadata across reloads', async ({ page }) => {

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -91,6 +91,14 @@ async function waitForSliceCurrent(page, expectedCurrent, timeout = 10000) {
     );
 }
 
+async function jumpToSlice(page, zeroBasedIndex) {
+    await page.locator(SLICE_SLIDER_SELECTOR).evaluate((slider, nextIndex) => {
+        slider.value = String(nextIndex);
+        slider.dispatchEvent(new Event('input', { bubbles: true }));
+        slider.dispatchEvent(new Event('change', { bubbles: true }));
+    }, zeroBasedIndex);
+}
+
 async function isButtonActive(page, selector) {
     const button = page.locator(selector);
     const classList = await button.getAttribute('class');
@@ -507,12 +515,9 @@ test.describe('Test Suite 16: Viewer Navigation Controls', () => {
     test('Next slice button is disabled at last slice', async ({ page }) => {
         const initialSlice = await getSliceInfo(page);
 
-        // Navigate to last slice
-        const stepsToEnd = initialSlice.total - initialSlice.current;
-        for (let i = 0; i < stepsToEnd; i++) {
-            await page.click(NEXT_SLICE_SELECTOR);
-            await page.waitForTimeout(100);
-        }
+        // Jump directly to the final slice and wait for the viewer state to catch up.
+        await jumpToSlice(page, initialSlice.total - 1);
+        await waitForSliceCurrent(page, initialSlice.total, 30000);
 
         // At last slice, next button should be disabled
         await expect(page.locator(NEXT_SLICE_SELECTOR)).toBeDisabled();
@@ -1219,41 +1224,103 @@ test.describe('Test Suite 24: API Endpoint Health', () => {
             expect(body.error).toContain('Directory does not exist');
         });
 
-        test('POST /api/library/config updates active config or stays overridden by env', async ({ page }) => {
-            const beforeResponse = await page.request.get('http://127.0.0.1:5001/api/library/config');
-            expect(beforeResponse.status()).toBe(200);
-            const before = await beforeResponse.json();
+        test.describe('Library Config Mutation Coverage', () => {
+            test.describe.configure({ mode: 'serial' });
 
-            const nextFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'dicom-library-config-'));
-            const saveResponse = await page.request.post('http://127.0.0.1:5001/api/library/config', {
-                data: { folder: nextFolder }
+            test('POST /api/library/config updates active config or stays overridden by env', async ({ page }) => {
+                const beforeResponse = await page.request.get('http://127.0.0.1:5001/api/library/config');
+                expect(beforeResponse.status()).toBe(200);
+                const before = await beforeResponse.json();
+
+                const nextFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'dicom-library-config-'));
+                try {
+                    const saveResponse = await page.request.post('http://127.0.0.1:5001/api/library/config', {
+                        data: { folder: nextFolder }
+                    });
+                    expect(saveResponse.status()).toBe(200);
+                    const saveBody = await saveResponse.json();
+
+                    expect(saveBody).toHaveProperty('overridden');
+                    expect(typeof saveBody.overridden).toBe('boolean');
+                    expect(saveBody).toHaveProperty('studies');
+                    expect(Array.isArray(saveBody.studies)).toBe(true);
+
+                    const afterResponse = await page.request.get('http://127.0.0.1:5001/api/library/config');
+                    expect(afterResponse.status()).toBe(200);
+                    const after = await afterResponse.json();
+
+                    if (before.source === 'env') {
+                        expect(saveBody.overridden).toBe(true);
+                        expect(saveBody.source).toBe('env');
+                        expect(saveBody.folderResolved).toBe(before.folderResolved);
+                        expect(after.source).toBe('env');
+                        expect(after.folderResolved).toBe(before.folderResolved);
+                    } else {
+                        expect(saveBody.overridden).toBe(false);
+                        expect(saveBody.source).toBe('settings');
+                        expect(saveBody.folderResolved).toBe(nextFolder);
+                        expect(after.source).toBe('settings');
+                        expect(after.folderResolved).toBe(nextFolder);
+                        expect(after.folder).toBe(nextFolder);
+                    }
+                } finally {
+                    if (before.folderResolved || before.folder) {
+                        await page.request.post('http://127.0.0.1:5001/api/library/config', {
+                            data: { folder: before.folderResolved || before.folder }
+                        });
+                    }
+                    fs.rmSync(nextFolder, { recursive: true, force: true });
+                }
             });
-            expect(saveResponse.status()).toBe(200);
-            const saveBody = await saveResponse.json();
 
-            expect(saveBody).toHaveProperty('overridden');
-            expect(typeof saveBody.overridden).toBe('boolean');
-            expect(saveBody).toHaveProperty('studies');
-            expect(Array.isArray(saveBody.studies)).toBe(true);
+            test('library API preserves deterministic collision keys and serves slash-bearing composite series IDs', async ({ page }) => {
+                const fixture = createSyntheticDicomFolder([
+                    { description: '' },
+                    { description: 'AP/Upper' }
+                ]);
 
-            const afterResponse = await page.request.get('http://127.0.0.1:5001/api/library/config');
-            expect(afterResponse.status()).toBe(200);
-            const after = await afterResponse.json();
+                const configResponse = await page.request.get('http://127.0.0.1:5001/api/library/config');
+                const previousConfig = await configResponse.json();
 
-            if (before.source === 'env') {
-                expect(saveBody.overridden).toBe(true);
-                expect(saveBody.source).toBe('env');
-                expect(saveBody.folderResolved).toBe(before.folderResolved);
-                expect(after.source).toBe('env');
-                expect(after.folderResolved).toBe(before.folderResolved);
-            } else {
-                expect(saveBody.overridden).toBe(false);
-                expect(saveBody.source).toBe('settings');
-                expect(saveBody.folderResolved).toBe(nextFolder);
-                expect(after.source).toBe('settings');
-                expect(after.folderResolved).toBe(nextFolder);
-                expect(after.folder).toBe(nextFolder);
-            }
+                try {
+                    expect(previousConfig.overridden).toBe(false);
+
+                    const saveResponse = await page.request.post('http://127.0.0.1:5001/api/library/config', {
+                        data: { folder: fixture.folder }
+                    });
+                    expect(saveResponse.status()).toBe(200);
+
+                    const savePayload = await saveResponse.json();
+                    expect(savePayload.available).toBe(true);
+                    expect(savePayload.studies).toHaveLength(1);
+
+                    const study = savePayload.studies[0];
+                    const seriesIds = study.series.map((series) => series.seriesInstanceUid).sort();
+                    expect(seriesIds).toEqual([
+                        `${fixture.seriesUid}|`,
+                        `${fixture.seriesUid}|AP/Upper`
+                    ]);
+
+                    const slashSeries = study.series.find((series) => series.seriesDescription === 'AP/Upper');
+                    expect(slashSeries).toBeDefined();
+
+                    const dicomResponse = await page.request.get(
+                        `http://127.0.0.1:5001/api/library/dicom/${encodeURIComponent(study.studyInstanceUid)}/${encodeURIComponent(slashSeries.seriesInstanceUid)}/0`
+                    );
+                    expect(dicomResponse.status()).toBe(200);
+                    expect(dicomResponse.headers()['content-type']).toContain('dicom');
+
+                    const body = await dicomResponse.body();
+                    expect(body.length).toBeGreaterThan(132);
+                } finally {
+                    if (previousConfig.folderResolved || previousConfig.folder) {
+                        await page.request.post('http://127.0.0.1:5001/api/library/config', {
+                            data: { folder: previousConfig.folderResolved || previousConfig.folder }
+                        });
+                    }
+                    removeSyntheticDicomFolder(fixture.folder);
+                }
+            });
         });
     });
 
@@ -1356,55 +1423,6 @@ test.describe('Test Suite 24: API Endpoint Health', () => {
             'http://127.0.0.1:5001/api/library/dicom/nonexistent-study-id/nonexistent-series-id/0'
         );
         expect(response.status()).toBe(404);
-    });
-
-    test('library API preserves deterministic collision keys and serves slash-bearing composite series IDs', async ({ page }) => {
-        const fixture = createSyntheticDicomFolder([
-            { description: '' },
-            { description: 'AP/Upper' }
-        ]);
-
-        const configResponse = await page.request.get('http://127.0.0.1:5001/api/library/config');
-        const previousConfig = await configResponse.json();
-
-        try {
-            expect(previousConfig.overridden).toBe(false);
-
-            const saveResponse = await page.request.post('http://127.0.0.1:5001/api/library/config', {
-                data: { folder: fixture.folder }
-            });
-            expect(saveResponse.status()).toBe(200);
-
-            const savePayload = await saveResponse.json();
-            expect(savePayload.available).toBe(true);
-            expect(savePayload.studies).toHaveLength(1);
-
-            const study = savePayload.studies[0];
-            const seriesIds = study.series.map((series) => series.seriesInstanceUid).sort();
-            expect(seriesIds).toEqual([
-                `${fixture.seriesUid}|`,
-                `${fixture.seriesUid}|AP/Upper`
-            ]);
-
-            const slashSeries = study.series.find((series) => series.seriesDescription === 'AP/Upper');
-            expect(slashSeries).toBeDefined();
-
-            const dicomResponse = await page.request.get(
-                `http://127.0.0.1:5001/api/library/dicom/${encodeURIComponent(study.studyInstanceUid)}/${encodeURIComponent(slashSeries.seriesInstanceUid)}/0`
-            );
-            expect(dicomResponse.status()).toBe(200);
-            expect(dicomResponse.headers()['content-type']).toContain('dicom');
-
-            const body = await dicomResponse.body();
-            expect(body.length).toBeGreaterThan(132);
-        } finally {
-            if (previousConfig.folderResolved || previousConfig.folder) {
-                await page.request.post('http://127.0.0.1:5001/api/library/config', {
-                    data: { folder: previousConfig.folderResolved || previousConfig.folder }
-                });
-            }
-            removeSyntheticDicomFolder(fixture.folder);
-        }
     });
 
     test('GET / serves the main application HTML', async ({ page }) => {

--- a/tests/maintenance.spec.js
+++ b/tests/maintenance.spec.js
@@ -1,0 +1,196 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+const { once } = require('events');
+const { test, expect, request: playwrightRequest } = require('@playwright/test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test.use({ extraHTTPHeaders: {} });
+test.setTimeout(60000);
+
+function uniqueStudyUid() {
+    return `maintenance-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function sameOriginHeaders(baseUrl, extra = {}) {
+    return {
+        Origin: baseUrl,
+        ...extra,
+    };
+}
+
+function resolvePythonCommand() {
+    const venvPython = path.join(REPO_ROOT, 'venv', 'bin', 'python');
+    if (fs.existsSync(venvPython)) {
+        return venvPython;
+    }
+    return process.env.PYTHON || 'python3';
+}
+
+async function getFreePort() {
+    return await new Promise((resolve, reject) => {
+        const server = net.createServer();
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            const port = typeof address === 'object' && address ? address.port : null;
+            server.close((error) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve(port);
+            });
+        });
+    });
+}
+
+async function waitForServer(baseUrl, proc, logs, timeoutMs = 20000) {
+    const api = await playwrightRequest.newContext({ extraHTTPHeaders: {} });
+    const deadline = Date.now() + timeoutMs;
+
+    try {
+        while (Date.now() < deadline) {
+            if (proc.exitCode !== null) {
+                throw new Error(`Isolated Flask server exited early with code ${proc.exitCode}\n${logs.join('')}`);
+            }
+
+            try {
+                const response = await api.get(`${baseUrl}/api/session`, { failOnStatusCode: false });
+                if (response.status() === 200) {
+                    return;
+                }
+            } catch {
+                // Server still starting.
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+    } finally {
+        await api.dispose();
+    }
+
+    throw new Error(`Timed out waiting for isolated Flask server\n${logs.join('')}`);
+}
+
+async function stopServer(proc) {
+    if (!proc || proc.exitCode !== null) {
+        return;
+    }
+
+    proc.kill('SIGTERM');
+    try {
+        await Promise.race([
+            once(proc, 'exit'),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000))
+        ]);
+    } catch {
+        proc.kill('SIGKILL');
+        await once(proc, 'exit');
+    }
+}
+
+async function launchIsolatedServer() {
+    const python = resolvePythonCommand();
+    const port = await getFreePort();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dicom-viewer-maintenance-'));
+    const logs = [];
+    const script = `
+from app import app
+from flask import request
+from server.db import get_db
+
+@app.before_request
+def _lock_restore_connection():
+    if request.path == "/api/maintenance/restore":
+        get_db().execute("BEGIN IMMEDIATE")
+
+app.run(host="127.0.0.1", port=${port})
+`;
+
+    const proc = spawn(python, ['-c', script], {
+        cwd: REPO_ROOT,
+        env: {
+            ...process.env,
+            DICOM_VIEWER_DATA_DIR: dataDir,
+            FLASK_DEBUG: 'false',
+            PYTHONUNBUFFERED: '1'
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    proc.stdout.on('data', (chunk) => {
+        logs.push(String(chunk));
+    });
+    proc.stderr.on('data', (chunk) => {
+        logs.push(String(chunk));
+    });
+
+    await waitForServer(baseUrl, proc, logs);
+    const api = await playwrightRequest.newContext({ extraHTTPHeaders: {} });
+
+    return { api, baseUrl, dataDir, logs, proc };
+}
+
+async function getSessionToken(api, baseUrl) {
+    const response = await api.get(`${baseUrl}/api/session`);
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    return body.token;
+}
+
+test.describe('Maintenance restore', () => {
+    test('restore closes the request-scoped DB handle before applying the backup', async () => {
+        const server = await launchIsolatedServer();
+
+        try {
+            const token = await getSessionToken(server.api, server.baseUrl);
+
+            const backupResponse = await server.api.post(`${server.baseUrl}/api/maintenance/backup`, {
+                headers: sameOriginHeaders(server.baseUrl, { 'X-Session-Token': token }),
+                data: {}
+            });
+            expect(backupResponse.status()).toBe(200);
+            const backupBody = await backupResponse.json();
+            const backupName = path.basename(backupBody.backup_path);
+
+            const studyUid = uniqueStudyUid();
+            const writeResponse = await server.api.put(`${server.baseUrl}/api/notes/${studyUid}/description`, {
+                headers: sameOriginHeaders(server.baseUrl, { 'X-Session-Token': token }),
+                data: { description: 'rolled back by restore' }
+            });
+            expect(writeResponse.status()).toBe(200);
+
+            const beforeRestore = await server.api.get(`${server.baseUrl}/api/notes/?studies=${studyUid}`, {
+                headers: { 'X-Session-Token': token }
+            });
+            expect(beforeRestore.status()).toBe(200);
+            const beforeBody = await beforeRestore.json();
+            expect(beforeBody.studies[studyUid].description).toBe('rolled back by restore');
+
+            const restoreResponse = await server.api.post(`${server.baseUrl}/api/maintenance/restore`, {
+                headers: sameOriginHeaders(server.baseUrl, { 'X-Session-Token': token }),
+                data: { backup_name: backupName }
+            });
+            expect(restoreResponse.status()).toBe(200);
+
+            const afterRestore = await server.api.get(`${server.baseUrl}/api/notes/?studies=${studyUid}`, {
+                headers: { 'X-Session-Token': token }
+            });
+            expect(afterRestore.status()).toBe(200);
+            const afterBody = await afterRestore.json();
+            expect(afterBody.studies).not.toHaveProperty(studyUid);
+        } finally {
+            await server.api.dispose();
+            await stopServer(server.proc);
+            fs.rmSync(server.dataDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/sync-engine.spec.js
+++ b/tests/sync-engine.spec.js
@@ -158,4 +158,85 @@ test.describe('Sync Engine', () => {
         expect(result.accessToken).toBe(result.snapshot.accessToken);
         expect(result.refreshToken).toBe('refresh-token-123');
     });
+
+    test('remote report metadata uses added_at and updated_at when applying sync data', async ({ page }) => {
+        await page.goto(BASE_URL);
+        await page.waitForFunction(() => !!window._SyncEngine && !!window._NotesInternals);
+
+        const result = await page.evaluate(() => {
+            const studyUid = '1.2.840.sync-engine.report-study';
+            const existingReportId = 'report-existing';
+            const insertedReportId = 'report-inserted';
+            const insertedAddedAt = 1700000000000;
+            const insertedUpdatedAt = 1700000005000;
+            const updatedAddedAt = 1700000010000;
+            const updatedUpdatedAt = 1700000015000;
+
+            window._NotesInternals.saveStore({
+                studies: {
+                    [studyUid]: {
+                        description: '',
+                        comments: [],
+                        series: {},
+                        reports: [
+                            {
+                                id: existingReportId,
+                                name: 'Original',
+                                type: 'pdf',
+                                size: 1,
+                                addedAt: new Date(1).toISOString(),
+                                updatedAt: new Date(2).toISOString(),
+                                sync_version: 1
+                            }
+                        ]
+                    }
+                }
+            });
+
+            const engine = new window._SyncEngine.SyncEngine({
+                getAccessToken: async () => 'valid-access-token',
+                onAuthRequired: () => {}
+            });
+
+            engine._applyRemoteData('reports', insertedReportId, {
+                study_uid: studyUid,
+                name: 'Inserted Remote',
+                type: 'pdf',
+                size: 42,
+                added_at: insertedAddedAt,
+                updated_at: insertedUpdatedAt
+            }, 5);
+
+            engine._applyRemoteData('reports', existingReportId, {
+                study_uid: studyUid,
+                name: 'Updated Remote',
+                type: 'png',
+                size: 84,
+                added_at: updatedAddedAt,
+                updated_at: updatedUpdatedAt
+            }, 6);
+
+            const reports = window._NotesInternals.loadStore().studies[studyUid].reports;
+            return {
+                inserted: reports.find((report) => report.id === insertedReportId),
+                updated: reports.find((report) => report.id === existingReportId),
+                insertedAddedAt,
+                insertedUpdatedAt,
+                updatedAddedAt,
+                updatedUpdatedAt
+            };
+        });
+
+        expect(new Date(result.inserted.addedAt).getTime()).toBe(result.insertedAddedAt);
+        expect(new Date(result.inserted.updatedAt).getTime()).toBe(result.insertedUpdatedAt);
+        expect(result.inserted.sync_version).toBe(5);
+        expect(new Date(result.updated.addedAt).getTime()).toBe(result.updatedAddedAt);
+        expect(new Date(result.updated.updatedAt).getTime()).toBe(result.updatedUpdatedAt);
+        expect(result.updated.sync_version).toBe(6);
+        expect(result.updated).toMatchObject({
+            name: 'Updated Remote',
+            type: 'png',
+            size: 84
+        });
+    });
 });

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -341,6 +341,53 @@ test.describe('Sync Push - Rejected Changes (Stale base_sync_version)', () => {
         expect(rej.current_data).toHaveProperty('description');
         expect(rej.current_data.description).toBe('Second');
     });
+
+    test('unknown operation does not advance sync_version for the next valid write', async ({ request }) => {
+        const { access_token, device_id } = await setupSyncUser(request);
+        const studyUid = uniqueStudyUid();
+
+        const insert = studyNoteUpdateChange(studyUid, {
+            description: 'Initial version',
+            baseSyncVersion: 0,
+        });
+        const inserted = await syncAndExpectOk(
+            request, BASE_URL, access_token, device_id, null, [insert]
+        );
+        const currentVersion = inserted.accepted[0].sync_version;
+
+        const invalid = {
+            ...studyNoteUpdateChange(studyUid, {
+                description: 'Invalid operation should be rejected',
+                baseSyncVersion: currentVersion,
+            }),
+            operation: 'invalid_op',
+        };
+        const invalidResult = await syncAndExpectOk(
+            request, BASE_URL, access_token, device_id, inserted.delta_cursor, [invalid]
+        );
+
+        expect(invalidResult.accepted).toEqual([]);
+        expect(invalidResult.rejected).toHaveLength(1);
+        expect(invalidResult.rejected[0]).toMatchObject({
+            operation_uuid: invalid.operation_uuid,
+            key: studyUid,
+            reason: 'unknown_operation',
+            current_sync_version: currentVersion,
+        });
+
+        const validUpdate = studyNoteUpdateChange(studyUid, {
+            description: 'Valid update after rejection',
+            baseSyncVersion: currentVersion,
+        });
+        const updated = await syncAndExpectOk(
+            request, BASE_URL, access_token, device_id, inserted.delta_cursor, [validUpdate]
+        );
+
+        expect(updated.rejected).toEqual([]);
+        expect(updated.accepted).toHaveLength(1);
+        expect(updated.accepted[0].operation_uuid).toBe(validUpdate.operation_uuid);
+        expect(updated.accepted[0].sync_version).toBeGreaterThan(currentVersion);
+    });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- prevent sync version bumps on rejected unknown operations and close the correct request-scoped DB handle during restore
- preserve desktop sync cache entries written before SQLite hydration completes and apply remote report timestamps from `added_at` / `updated_at`
- add regression coverage for the sync fixes and stabilize the flaky library/navigation specs by isolating library-config mutations and waiting on actual slice state

## Testing
- `npx playwright test tests/sync-protocol.spec.js tests/sync-engine.spec.js tests/sync-outbox.spec.js tests/desktop-report-persistence.spec.js tests/maintenance.spec.js`
- `npx playwright test tests/library-and-navigation.spec.js`
- `npx playwright test`