### PR TITLE
Fix font self-hosting: add @font-face, remove Google Fonts, add licenses

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -43,6 +43,26 @@
  */
 
 /* ==========================================================================
+   SELF-HOSTED FONTS (Tauri CSP blocks Google Fonts CDN)
+   ========================================================================== */
+
+@font-face {
+    font-family: 'Lora';
+    font-style: normal;
+    font-weight: 400 700;
+    font-display: block;
+    src: url('../fonts/lora/Lora-variable.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 400 700;
+    font-display: block;
+    src: url('../fonts/inter/Inter-variable.woff2') format('woff2');
+}
+
+/* ==========================================================================
    0. DESIGN TOKENS
    ========================================================================== */
 

--- a/docs/decisions/009-brand-design-system.md
+++ b/docs/decisions/009-brand-design-system.md
@@ -64,7 +64,7 @@ Fonts are self-hosted under `docs/fonts/` because Tauri's CSP blocks Google Font
 
 ### myRadOne App Icon Candidates
 
-Explored extensively. Current favorites use amber gradient background with Lora "mR" + Inter superscript/inline "1" in white. Final selection pending.
+**Selected**: Amber gradient background (145deg, #F5A83A -> #F08C00 -> #D67D00), Lora 400 white "mR" + Inter 600 superscript white "1". Rounded rect (22% radius). Generated at 1024px RGBA base, resized to all Tauri-required sizes.
 
 ### Divergent Health Logo
 

--- a/docs/fonts/inter/OFL.txt
+++ b/docs/fonts/inter/OFL.txt
@@ -1,0 +1,4 @@
+Copyright 2020 The Inter Project Authors (https://github.com/rsms/inter)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is available with a FAQ at: https://openfontlicense.org

--- a/docs/fonts/lora/OFL.txt
+++ b/docs/fonts/lora/OFL.txt
@@ -1,0 +1,4 @@
+Copyright 2011 The Lora Project Authors (https://github.com/cyrealtype/Lora-Cyrillic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is available with a FAQ at: https://openfontlicense.org

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,10 +32,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>myradone</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lora:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/style.css?v=5">
+    <link rel="stylesheet" href="css/style.css?v=7">
 
     <!-- DICOM parsing library -->
     <script src="js/vendor/dicomParser.min.js"></script>


### PR DESCRIPTION
## Summary
Follow-up to PR #64 review findings:
- Add @font-face declarations for self-hosted Lora and Inter variable fonts (font-display: block)
- Remove Google Fonts preconnect and stylesheet links from index.html
- Add OFL license files for both font families
- Update ADR 009: app icon status from "pending" to "selected"

## Test plan
- [ ] Fonts load from local files (no Google Fonts network requests)
- [ ] Logo and UI text render correctly in Chrome and Tauri
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)