### PR TITLE
Add persistent design handbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ For benchmark, planning, and competitive research:
 
 - Workflow rules: `docs/AGENT_WORKTREES.md`
 - Full explanation: `docs/AGENT_WORKTREES_EXPLAINER.md`
+- For design work: start with `docs/design/core.md` and `docs/design/README.md`
 - Research docs policy: `docs/RESEARCH_POLICY.md`
 
 ## Workspace Structure

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ Master index of all project documentation, organized by audience and purpose.
 | [Agent Launchers](./AGENT_LAUNCHERS.md) | docs/ | Session launcher scripts for creating worktrees and starting AI sessions safely |
 | [Parallel Execution Process](./PARALLEL_EXECUTION.md) | docs/ | Process for planning, staging, and executing large features using parallel AI agents |
 | [Research Documentation Policy](./RESEARCH_POLICY.md) | docs/ | Policy for what benchmark and planning research belongs in git, what should stay local, and when research docs should be PRs |
+| [Design Handbook](./design/README.md) | docs/design/ | Persistent product and brand design canon: bootstrap, brand system, surfaces, decisions, and closeout workflow |
 | [Deployment Guide](./DEPLOY.md) | docs/ | Local development, GitHub Pages, custom domains, troubleshooting |
 | [Contributing](../CONTRIBUTING.md) | Root | Code style, git workflow, pull request process, issue templates |
 | [Bug Tracking](./BUGS.md) | docs/ | Known issues, resolved bugs with root cause analysis, bug template |
@@ -119,6 +120,7 @@ docs/
 ├── AGENT_LAUNCHERS.md     # Session launcher scripts for worktree creation
 ├── PARALLEL_EXECUTION.md  # Parallel agent execution process for large features
 ├── RESEARCH_POLICY.md     # Policy for benchmark/planning research docs and PRs
+├── design/                # Persistent design handbook and session closeout template
 ├── INDEX.md               # This file - master documentation index
 ├── API.md                 # REST API reference
 ├── CONFIG.md              # Configuration reference
@@ -262,6 +264,11 @@ Beginner-friendly walkthrough of the cleanup that led to the current workflow. E
 **BUGS.md**
 Bug tracking with full context. Each bug includes how it was encountered, root cause analysis, solution, why that solution was chosen, and prevention controls. Uses a standard template for consistency.
 
+**docs/design/**
+Persistent design handbook. Holds the canonical design bootstrap, brand system,
+surface guidance, durable decisions, open questions, and the session closeout
+template used to flush design context before handoff or compaction.
+
 ### Planning Documentation
 
 **SITEMAP.md**
@@ -310,4 +317,4 @@ Architecture Decision Records for significant choices. ADRs capture context, dec
 
 ---
 
-*Last updated: 2026-03-26*
+*Last updated: 2026-04-06*

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -42,6 +42,9 @@ This handbook covers:
 The current design system has been assembled from a mix of committed files and
 local exploration artifacts, especially:
 
+- `design/colors/tokens.css`
+- `design/colors/design-system-emerald.html`
+- `design/brand/brand-archive.html`
 - `~/claude 0/colors/tokens.css`
 - `~/claude 0/colors/logo-final/README.md`
 - `~/claude 0/divergent-landing/brand-archive.html`

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,51 @@
+# Design Handbook
+
+This directory is the canonical design memory for Divergent Health Technologies
+and myRadOne inside this repository.
+
+The repo owns durable design knowledge. The designer agent operationalizes it.
+Private agent memory is reserved for collaboration preferences and session
+scratch, not for brand rules.
+
+## Read Order
+
+1. [`core.md`](./core.md) - compact bootstrap for every design session
+2. [`brand-system.md`](./brand-system.md) - tokens, logos, typography, and hard constraints
+3. [`principles.md`](./principles.md) - taste, product feel, and anti-goals
+4. Relevant surface doc under [`surfaces/`](./surfaces/)
+5. [`workflow.md`](./workflow.md) - how to explore, review, and promote decisions
+
+## File Roles
+
+- `core.md` keeps the always-load summary short and current.
+- `brand-system.md` holds durable visual rules.
+- `principles.md` captures the product's taste and emotional target.
+- `decisions.md` records accepted and rejected choices with rationale.
+- `open-questions.md` keeps unresolved issues visible between sessions.
+- `archive.md` points to the exploration corpus and explains what matters there.
+- `session-closeout-template.md` is the standard shape for saving session state
+  before compaction or handoff.
+- `surfaces/` documents page- or shell-specific guidance.
+- `patterns/` stores reusable UI conventions only after they stabilize.
+
+## Scope
+
+This handbook covers:
+
+- Divergent Health parent-brand expression
+- myRadOne product branding
+- Library, viewer, landing page, and desktop shell direction
+- Durable interaction patterns that should survive across sessions
+
+## Source Notes
+
+The current design system has been assembled from a mix of committed files and
+local exploration artifacts, especially:
+
+- `~/claude 0/colors/tokens.css`
+- `~/claude 0/colors/logo-final/README.md`
+- `~/claude 0/divergent-landing/brand-archive.html`
+- the current app shell in `docs/index.html`
+
+Those exploration assets are useful context, but this directory is the source of
+truth going forward.

--- a/docs/design/archive.md
+++ b/docs/design/archive.md
@@ -6,18 +6,30 @@ external artifacts.
 The archive is useful history, not the source of truth. Once a decision is
 durable, the rule should live in `docs/design/`.
 
-## Primary Archive Entry Point
+## Primary Archive Entry Points
+
+### Committed In-Repo Archive
+
+- `design/brand/brand-archive.html`
+
+This is the best committed overview of the historical exploration corpus already
+in git. Use it first when you want a reviewable, shareable archive source inside
+the repository.
+
+### Local Extended Archive
 
 - `~/claude 0/divergent-landing/brand-archive.html`
 
-This is the best single overview of the exploration corpus. It has a `Current`
-section for the latest chosen direction and a `Full History` section for prior
-rounds and rejected paths.
+This local archive includes additional exploration history outside the repo. Use
+it as supplemental context, not as a substitute for committed canon.
 
 ## Important Exploration Sources
 
 ### Tokens and System Files
 
+- `design/colors/tokens.css`
+- `design/colors/design-system-emerald.html`
+- `design/colors/design-system-sage.html`
 - `~/claude 0/colors/tokens.css`
 - `~/claude 0/colors/design-system.html`
 - `~/claude 0/colors/design-system-sage.html`
@@ -27,6 +39,8 @@ system diverged from the earlier sage direction.
 
 ### myRadOne Logo Work
 
+- `design/colors/logo-variants-v2.html`
+- `design/colors/logo-variants-v3.html`
 - `~/claude 0/colors/logo-final/README.md`
 - `~/claude 0/colors/logo-final/myRadOne-preview.html`
 - `~/claude 0/colors/logo-myRadOne-v10.html`
@@ -37,6 +51,10 @@ spacing decision.
 
 ### App Icon Work
 
+- `design/colors/app-icon-variants-v1.html`
+- `design/colors/app-icon-variants-v2.html`
+- `design/colors/app-icon-mr1.html`
+- `design/colors/app-icon-mr1-v2.html`
 - `~/claude 0/colors/app-icon-variants.html`
 - `~/claude 0/colors/app-icon-variants-v2.html`
 - `~/claude 0/colors/app-icon-mR1-amber.html`
@@ -48,6 +66,9 @@ desktop icon choice.
 
 ### Parent Brand / Landing
 
+- `design/brand/landing.html`
+- `design/brand/logos.html`
+- `design/brand/logos-integrated.html`
 - `~/claude 0/divergent-landing/index.html`
 - `~/claude 0/colors/landing-logo-variants-v11.html`
 - `~/claude 0/colors/landing-logo-slanted-fonts.html`

--- a/docs/design/archive.md
+++ b/docs/design/archive.md
@@ -1,0 +1,71 @@
+# Design Archive
+
+This file summarizes the exploration archive and points to the most important
+external artifacts.
+
+The archive is useful history, not the source of truth. Once a decision is
+durable, the rule should live in `docs/design/`.
+
+## Primary Archive Entry Point
+
+- `~/claude 0/divergent-landing/brand-archive.html`
+
+This is the best single overview of the exploration corpus. It has a `Current`
+section for the latest chosen direction and a `Full History` section for prior
+rounds and rejected paths.
+
+## Important Exploration Sources
+
+### Tokens and System Files
+
+- `~/claude 0/colors/tokens.css`
+- `~/claude 0/colors/design-system.html`
+- `~/claude 0/colors/design-system-sage.html`
+
+Use these when you need raw token values or to confirm how the warm / amber
+system diverged from the earlier sage direction.
+
+### myRadOne Logo Work
+
+- `~/claude 0/colors/logo-final/README.md`
+- `~/claude 0/colors/logo-final/myRadOne-preview.html`
+- `~/claude 0/colors/logo-myRadOne-v10.html`
+- `~/claude 0/colors/subtitle-spacing.html`
+
+These files capture the selected wordmark, supporting previews, and the tagline
+spacing decision.
+
+### App Icon Work
+
+- `~/claude 0/colors/app-icon-variants.html`
+- `~/claude 0/colors/app-icon-variants-v2.html`
+- `~/claude 0/colors/app-icon-mR1-amber.html`
+- `~/claude 0/colors/app-icon-mR1-inline.html`
+- `~/claude 0/colors/app-icon-myRad1-v4.html`
+
+These are the key icon exploration files. Consult them when revisiting the final
+desktop icon choice.
+
+### Parent Brand / Landing
+
+- `~/claude 0/divergent-landing/index.html`
+- `~/claude 0/colors/landing-logo-variants-v11.html`
+- `~/claude 0/colors/landing-logo-slanted-fonts.html`
+- `~/claude 0/colors/landing-logo-dot-spacing.html`
+
+These files cover the Divergent landing page, parent-brand lockup, and the
+spacing / serif explorations behind the final parent brand choice.
+
+### Folder Icon
+
+- `~/claude 0/colors/folder-icon-fill-sweep.html`
+- `~/claude 0/colors/folder-icon-in-context.html`
+
+These support the selected amber folder icon direction.
+
+## Archive Usage Rules
+
+- Use the archive to understand how a decision was reached.
+- Do not treat archive HTML files as canonical specification.
+- When a new exploration round produces a durable outcome, promote the rule into
+  `docs/design/` and add only a concise pointer here.

--- a/docs/design/brand-system.md
+++ b/docs/design/brand-system.md
@@ -36,17 +36,18 @@ This file captures the durable visual system for Divergent Health and myRadOne.
 
 ### Viewer-Dark Atmosphere
 
-Current token file values:
+Current approved values:
 
 | Token | Value |
 | --- | --- |
-| `--color-viewer-bg` | `#161E17` |
-| `--color-viewer-panel` | `#1C261E` |
-| `--color-viewer-header` | `#0F160F` |
+| `--color-viewer-bg` | `#0F1E14` |
+| `--color-viewer-panel` | `#14281A` |
+| `--color-viewer-header` | `#0A160E` |
 | `--color-viewer-text` | `#EEEEEE` |
 
-Use these as the present working values for dark surfaces while the older navy
-CSS is retired.
+These values match ADR 009 and the committed app CSS. Older exploration files
+under `design/colors/` still contain nearby but superseded dark values from the
+sage branch of the system.
 
 ## Typography
 
@@ -126,7 +127,9 @@ The icon should feel like a product asset, not a generic emoji substitute.
 ## Known Migration Gaps
 
 - The current repo still contains older blue / navy styling in checked-in CSS.
-- The font strategy in code has not fully caught up to the self-hosted target.
-- Some selected brand assets currently exist only in local exploration folders.
+- The font strategy in code has not fully caught up to the self-hosted target,
+  and some surfaces still fall back to system fonts.
+- Some selected brand assets still have both committed and local exploration
+  homes that should be rationalized over time.
 
 Those gaps are implementation debt, not unresolved brand direction.

--- a/docs/design/brand-system.md
+++ b/docs/design/brand-system.md
@@ -1,0 +1,132 @@
+# Brand System
+
+This file captures the durable visual system for Divergent Health and myRadOne.
+
+## Brand Hierarchy
+
+- **Divergent Health Technologies** is the parent company and should appear on
+  company-facing surfaces such as `divergent.health`, legal copy, and parent
+  brand moments.
+- **myRadOne** is the product brand and should lead inside the application,
+  desktop shell, and product marketing.
+
+## Color System
+
+### Warm Neutrals
+
+| Token | Value | Role |
+| --- | --- | --- |
+| `--color-light` | `#FFF8F3` | primary light background |
+| `--color-dawn` | `#F2F0E2` | secondary background |
+| `--color-sand` | `#E5E0D4` | borders and muted surfaces |
+| `--color-stone` | `#C4BFB3` | softened brand contrast |
+| `--color-drift` | `#A09B8F` | muted text and tagline |
+| `--color-ash` | `#6B6660` | secondary text |
+| `--color-charcoal` | `#3D3A36` | primary text |
+| `--color-night` | `#1E1C1A` | deepest neutral |
+
+### Accent and Support
+
+| Token | Value | Role |
+| --- | --- | --- |
+| `--color-amber-400` | `#F08C00` | primary brand accent |
+| `--color-amber-500` | `#D67D00` | accent hover / stronger emphasis |
+| `--color-amber-50` | `#FFF4E6` | subtle accent wash |
+| `--color-success` | `#7A9966` in current token file | success/status green |
+
+### Viewer-Dark Atmosphere
+
+Current token file values:
+
+| Token | Value |
+| --- | --- |
+| `--color-viewer-bg` | `#161E17` |
+| `--color-viewer-panel` | `#1C261E` |
+| `--color-viewer-header` | `#0F160F` |
+| `--color-viewer-text` | `#EEEEEE` |
+
+Use these as the present working values for dark surfaces while the older navy
+CSS is retired.
+
+## Typography
+
+| Role | Typeface | Notes |
+| --- | --- | --- |
+| UI / body | Inter | functional UI sans |
+| Brand / headings | Lora | warmth and literary contrast |
+| Divergent `.health` | Source Serif 4 italic | more distinctive than Lora italic |
+
+### Typography Rules
+
+- Serif is for brand voice, hero copy, and logo expression.
+- Sans is for controls, tables, metadata, and dense application UI.
+- Final shipped product surfaces should prefer self-hosted fonts because Tauri
+  CSP and offline support are hard requirements.
+
+## myRadOne Logo
+
+Selected direction: `v10 #07`
+
+- Font family: Lora
+- `myRad`: Lora 400, `#F08C00`
+- `One`: Lora 500, `#C4BFB3`
+- Tagline: Inter 400, `#A09B8F`
+- Tagline text: `One place for all your medical imaging`
+- Preferred tagline gap: `1.5rem` / `24px`
+- Preferred background: `#FFF8F3`
+- Dark variant: `myRad` stays amber; `One` shifts to `rgba(255,255,255,0.4)`
+
+### Asset Rule
+
+Final app-facing logo assets should be outlined SVG paths rather than SVG text.
+This avoids runtime font-loading failures in WKWebView / Tauri contexts.
+
+## Divergent Health Logo
+
+Selected direction:
+
+- `DIVERGENT`: Inter 500, uppercase, `rgba(107,102,96,0.6)`
+- `.`: upright Inter dot, amber, pulled left by `-0.08em`
+- `health`: Source Serif 4 italic 400, amber, `0.08em` after the dot
+
+Associated taglines explored:
+
+- `We think differently`
+- `So we can make a real difference for your health.`
+
+## App Icon Direction
+
+The app icon direction is narrowed but not final:
+
+- amber or amber-gradient background only
+- light foreground only
+- Lora-based `mR` / `myR` letterform family with an Inter `1`
+- the numeral must read clearly as `1`, not `l`
+
+Dark icon backgrounds were explored and rejected.
+
+## Folder Icon
+
+Selected direction:
+
+- fill: `rgba(240,140,0,0.15)`
+- stroke: `rgba(240,140,0,0.55)` at `2px`
+- tab: `rgba(240,140,0,0.65)`
+
+The icon should feel like a product asset, not a generic emoji substitute.
+
+## Implementation Constraints
+
+- Desktop surfaces must tolerate Tauri CSP and offline mode.
+- Self-hosted fonts are the target even if some exploration files still load
+  Google Fonts.
+- Durable design documentation in this directory outranks old CSS values when
+  the code has not caught up yet.
+
+## Known Migration Gaps
+
+- The current repo still contains older blue / navy styling in checked-in CSS.
+- The font strategy in code has not fully caught up to the self-hosted target.
+- Some selected brand assets currently exist only in local exploration folders.
+
+Those gaps are implementation debt, not unresolved brand direction.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -1,0 +1,58 @@
+# Design Core
+
+Use this file as the first read for design work in this repository.
+
+## Brand Essence
+
+- Divergent Health should feel calm, rigorous, warm, and quietly premium.
+- myRadOne should feel like a trustworthy medical imaging library, not a cold
+  radiology workstation and not a generic startup dashboard.
+- The product voice is professional and humane: clear, confident, and never
+  flashy for its own sake.
+
+## Current Direction
+
+- Warm neutral foundation for the library and marketing surfaces.
+- Amber is the primary brand accent and the clearest interactive signal.
+- The viewer gets a darker, calmer atmosphere with restrained warm accents.
+- Serif typography carries brand warmth; sans-serif typography carries UI clarity.
+
+## Selected Brand Moves
+
+- myRadOne wordmark: Lora with amber `myRad` and stone `One`
+- Divergent Health lockup: Inter `DIVERGENT`, upright amber dot, italic Source
+  Serif 4 `health`
+- Folder icon: amber-tinted outlined SVG
+- App icon direction: amber-background lettermark, final candidate still pending
+
+## Hard Constraints
+
+- Durable brand rules live in `docs/design/`, not in private memory.
+- Desktop assets must work offline and under Tauri CSP.
+- Prefer self-hosted fonts for shipped product surfaces.
+- Prefer outlined SVG for final brand marks used in app chrome or desktop
+  packaging.
+- Do not silently make broad visual direction changes after a direction has been
+  approved.
+
+## Known Implementation Lag
+
+- The checked-in `docs/css/style.css` still reflects an older navy/blue visual
+  system in several places.
+- Some branded assets and fonts currently exist only in local exploration
+  directories or an uncommitted checkout.
+- Treat those mismatches as migration work, not as evidence that the old visual
+  system is still preferred.
+
+## Active Questions
+
+- Which app icon candidate becomes the shipped desktop icon?
+- Should the desktop shell and bundle metadata switch from `DICOM Viewer` to
+  `myRadOne` now or later?
+- What is the final outlined-SVG export path for the Divergent Health logo?
+- Which viewer-dark token values are final once the old blue CSS is retired?
+
+## Session Reminder
+
+Read `brand-system.md` next, then the relevant `surfaces/*.md` file, then
+`workflow.md` if the task involves exploration or promotion of new decisions.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1,0 +1,101 @@
+# Design Decisions
+
+This file records durable accepted and rejected design choices.
+
+## Accepted
+
+### 2026-03-28 - Warm-Neutral Brand Base
+
+Adopted a warm-neutral base for brand and library surfaces instead of a cold or
+clinical palette. This gives the product a calmer, more humane posture.
+
+### 2026-03-28 - Amber As Primary Brand Accent
+
+Amber became the primary accent color for brand emphasis, calls to action, and
+human warmth. It gives the system a recognizable signal without drifting into
+generic blue SaaS styling.
+
+### 2026-04-01 - myRadOne Wordmark Direction
+
+Selected `v10 #07` as the product lockup:
+
+- `myRad`: Lora 400 in amber
+- `One`: Lora 500 in stone
+- tagline in Inter drift
+
+The split keeps the mark warm and distinctive without overcomplicating it.
+
+### 2026-04-01 - Tagline Spacing
+
+Selected a `1.5rem` / `24px` gap between the wordmark and the tagline. Tighter
+spacing felt cramped; wider spacing weakened the lockup.
+
+### 2026-04-01 - Light-Only App Icon Backgrounds
+
+Constrained app icon exploration to light or amber-family backgrounds. Dark icon
+backgrounds were explicitly rejected during exploration.
+
+### 2026-04-06 - Folder Icon
+
+Selected the amber outlined folder treatment:
+
+- fill 15%
+- stroke 55% at 2px
+- tab 65%
+
+This gives the import zone a branded product asset instead of relying on a stock
+emoji or browser-default feel.
+
+### 2026-04-06 - Divergent Health Parent Lockup
+
+Selected the parent-brand lockup using:
+
+- Inter 500 uppercase `DIVERGENT`
+- upright amber dot
+- Source Serif 4 italic `health`
+
+This preserved professionalism while keeping the `.health` suffix distinctive.
+
+### 2026-04-06 - Exploration Review Format
+
+Each option in a design exploration must include a short **Why this works** /
+**Why this loses** comparison. This makes tradeoffs explicit at review time
+instead of relying on implicit preference signals.
+
+## Rejected / Closed
+
+### Sage Primary Palette
+
+Rejected as the main brand direction because it felt too muted for the intended
+product presence. Green remains supportive, but amber plus warm neutrals is the
+main system.
+
+### Teal / Dark Pre-Rebrand Direction
+
+Early teal-on-dark landing and mark explorations were superseded by the warmer
+system. They are useful history, not the current direction.
+
+### Dark App Icon Backgrounds
+
+Rejected after exploration rounds. The preferred icon family lives on light or
+amber backgrounds only.
+
+### SVG Text For Shipped App Marks
+
+Rejected for production use because text-based SVG marks are unreliable in
+desktop embedding contexts that do not guarantee font availability.
+
+### Kalam For Divergent `.health`
+
+Rejected after exploration because it added personality at the expense of
+professional confidence. Source Serif 4 italic won.
+
+### Full Charcoal `One`
+
+Rejected because the darker `One` felt too heavy and made the lockup harsher
+than intended. Stone kept the mark softer and more balanced.
+
+## Notes
+
+When a new decision is approved, update this file first, then promote the same
+rule into the relevant canonical doc.

--- a/docs/design/open-questions.md
+++ b/docs/design/open-questions.md
@@ -21,7 +21,8 @@ and the window title. Decide when the shipped shell should become `myRadOne`.
 ## Self-Hosted Font Completion
 
 The durable rule is self-hosted fonts for shipped surfaces, but the current repo
-state is incomplete. Decide the final font packaging plan and timing.
+state is incomplete and some desktop-facing surfaces still fall back to system
+fonts. Decide the final packaging plan, migration order, and timing.
 
 ## Viewer-Dark Finalization
 

--- a/docs/design/open-questions.md
+++ b/docs/design/open-questions.md
@@ -1,0 +1,30 @@
+# Open Questions
+
+These issues are intentionally unresolved and should stay visible between design
+sessions.
+
+## App Icon Final Selection
+
+The icon family is narrowed to amber-background lettermarks, but the final
+shipped candidate is still pending. The numeral `1` must read clearly.
+
+## Divergent Health Production Asset Export
+
+The parent-brand lockup direction is chosen, but the final outlined-SVG export
+pipeline for app-safe use is not yet captured here.
+
+## Desktop Naming Cutover
+
+`desktop/src-tauri/tauri.conf.json` still uses `DICOM Viewer` for `productName`
+and the window title. Decide when the shipped shell should become `myRadOne`.
+
+## Self-Hosted Font Completion
+
+The durable rule is self-hosted fonts for shipped surfaces, but the current repo
+state is incomplete. Decide the final font packaging plan and timing.
+
+## Viewer-Dark Finalization
+
+The durable direction is a calmer dark viewer with warm accents, but the checked
+in CSS still reflects an older navy system. Decide the final dark token values
+when the migration happens.

--- a/docs/design/patterns/actions.md
+++ b/docs/design/patterns/actions.md
@@ -1,0 +1,21 @@
+# Action Patterns
+
+## Hierarchy
+
+- Primary actions use amber.
+- Secondary actions use ghost or low-chroma treatments.
+- Utility actions inside the viewer stay quieter than primary library actions.
+- Success / confirmation states may use green, but green is not the primary CTA
+  color.
+
+## Application
+
+- Import, choose-folder, and major calls to action should read as the clearest
+  actionable elements on a surface.
+- Viewer tool buttons should communicate state cleanly without becoming bright
+  accent blocks across the entire toolbar.
+- Destructive or risky actions should not reuse the brand-primary treatment.
+
+## Principle
+
+Accent carries meaning only if it is used selectively.

--- a/docs/design/patterns/empty-states.md
+++ b/docs/design/patterns/empty-states.md
@@ -1,0 +1,19 @@
+# Empty State Patterns
+
+## Library Empty State
+
+- Pair the empty table state with the import invitation.
+- Keep the language simple and confident.
+- Use the branded folder treatment to imply readiness and purpose.
+
+## No Metadata / No Selection States
+
+- Explain what the user should do next.
+- Avoid error language when nothing is actually wrong.
+- Keep these states visually quiet so they do not compete with real content.
+
+## Blank Viewer States
+
+- Blank slices, loading states, and missing selections should feel controlled and
+  deliberate, not broken.
+- In the clinical viewer, neutral clarity matters more than decorative flourish.

--- a/docs/design/patterns/navigation.md
+++ b/docs/design/patterns/navigation.md
@@ -1,0 +1,20 @@
+# Navigation Patterns
+
+## Library
+
+- Put the myRadOne lockup at the top as the orientation anchor.
+- Keep help, sync, and account affordances secondary to the main workflow.
+- Study navigation should rely on a table plus expandable detail rows rather than
+  stacking too many cards.
+
+## Viewer
+
+- Use a clear back-to-library affordance in the header.
+- Keep the series list on the left and metadata on the right so the image stays
+  central.
+- Keep navigation controls visible without visually overpowering the image.
+
+## Principle
+
+Navigation should feel obvious and low-friction. The user should always know
+where they are and how to return to the library.

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -1,0 +1,50 @@
+# Design Principles
+
+## Desired Feel
+
+- Calm, not sterile
+- Professional, not corporate
+- Premium, not luxurious
+- Warm, not sugary
+- Focused, not dense
+
+The product should feel clinically trustworthy without inheriting the harshness
+or visual fatigue of many legacy medical interfaces.
+
+## Visual Posture
+
+- Use warm neutrals as the baseline mood for library and marketing surfaces.
+- Use serif typography for brand warmth and memorability.
+- Use sans-serif typography for functional UI, data, and controls.
+- Let amber carry brand emphasis, calls to action, and moments of human warmth.
+- Keep darker viewer surfaces quiet and low-glare so the image remains primary.
+
+## Product Character
+
+- myRadOne is a library first, then a viewer.
+- The interface should suggest ownership, continuity, and safekeeping.
+- Design should reduce anxiety for patients and clinicians rather than perform
+  technical sophistication.
+- Empty states should feel invitational and capable, not apologetic.
+
+## Motion and Atmosphere
+
+- Motion should be sparse and meaningful.
+- Marketing pages can use subtle atmospheric animation such as scan-line or glow.
+- The diagnostic viewer should avoid decorative motion around the image plane.
+- Transition work should support orientation, not novelty.
+
+## Interaction Biases
+
+- Prefer a few strong choices over many weak ones.
+- Make hierarchy obvious at a glance.
+- Keep utility controls visually disciplined; reserve drama for brand moments.
+- Use accent color with restraint so it still means something.
+
+## Anti-Goals
+
+- Do not drift back toward generic blue SaaS styling.
+- Do not make the product look playful or toy-like.
+- Do not overload screens with badges, pills, or competing accents.
+- Do not make the viewer feel like a marketing page.
+- Do not hide durable design decisions in private agent memory.

--- a/docs/design/session-closeout-template.md
+++ b/docs/design/session-closeout-template.md
@@ -11,7 +11,11 @@ The goal is simple:
 
 ## Private Scratch Location
 
-Write or update:
+Write or update the active workspace scratch note:
+
+`<workspace-private-memory>/sessions/YYYY-MM-DD.md`
+
+For this project, the default path is:
 
 `~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/sessions/YYYY-MM-DD.md`
 
@@ -71,7 +75,7 @@ Write or update:
 
 ```text
 Before this session compacts, run design closeout:
-1. Write or update today's session scratch note under ~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/sessions/YYYY-MM-DD.md using docs/design/session-closeout-template.md.
+1. Write or update today's session scratch note at <workspace-private-memory>/sessions/YYYY-MM-DD.md (for this project: ~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/sessions/YYYY-MM-DD.md) using docs/design/session-closeout-template.md.
 2. Promote approved durable decisions into the right docs/design files.
 3. Save only collaboration preferences to private memory.
 4. Tell me exactly what you saved and where.

--- a/docs/design/session-closeout-template.md
+++ b/docs/design/session-closeout-template.md
@@ -1,0 +1,78 @@
+# Design Session Closeout Template
+
+Use this before auto-compaction, handoff, or thread end after meaningful design
+work.
+
+The goal is simple:
+
+- save ephemeral session state to private scratch
+- promote durable project knowledge into `docs/design/`
+- make the next design session easy to resume
+
+## Private Scratch Location
+
+Write or update:
+
+`~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/sessions/YYYY-MM-DD.md`
+
+## Template
+
+```md
+# Design Session - YYYY-MM-DD
+
+## Scope
+
+- surface or asset:
+- task type: exploration / critique / implementation / consolidation
+
+## What Was Reviewed
+
+- files, artifacts, or mockups reviewed:
+- key options or directions compared:
+
+## Approved Durable Decisions
+
+- decision:
+  promote to:
+- decision:
+  promote to:
+
+## Still Unresolved
+
+- unresolved issue:
+  promote to: docs/design/open-questions.md
+
+## Patterns Promoted
+
+- pattern:
+  promote to:
+
+## Collaboration / Process Notes
+
+- private-memory-only observation:
+
+## Current Frontier
+
+- best next starting point:
+- first files to read next time:
+
+## Artifacts
+
+- external exploration files or screenshots worth reopening:
+```
+
+## Classification Rule
+
+- If it changes project truth, put it in `docs/design/`.
+- If it is only about how the user likes to work, put it in private memory.
+- If it is just today's in-progress state, put it in session scratch.
+
+## Copy-Paste Flush Prompt
+
+```text
+Before this session compacts, run design closeout:
+1. Write or update today's session scratch note under ~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/sessions/YYYY-MM-DD.md using docs/design/session-closeout-template.md.
+2. Promote approved durable decisions into the right docs/design files.
+3. Save only collaboration preferences to private memory.
+4. Tell me exactly what you saved and where.
+```

--- a/docs/design/surfaces/desktop-shell.md
+++ b/docs/design/surfaces/desktop-shell.md
@@ -1,0 +1,27 @@
+# Desktop Shell
+
+## Role
+
+The desktop shell turns the web core into a product. Branding here should feel
+shipped, not improvised.
+
+## Durable Direction
+
+- app identity should ultimately align with `myRadOne`
+- desktop icon should come from the approved amber lettermark family
+- window chrome should stay minimal and let the app UI carry the personality
+- bundled assets must respect Tauri CSP and offline use
+
+## Current Technical Constraints
+
+- `desktop/src-tauri/tauri.conf.json` still uses `DICOM Viewer` for
+  `productName` and the main window title.
+- Tauri CSP favors self-hosted fonts and local assets.
+- Final desktop-facing marks should prefer outlined SVG or equivalent
+  production-safe assets.
+
+## Packaging Notes
+
+- DMG styling, app icon, and shell metadata should be treated as one coherent
+  branding pass rather than scattered follow-up tweaks.
+- The desktop shell should never depend on live font CDNs.

--- a/docs/design/surfaces/landing.md
+++ b/docs/design/surfaces/landing.md
@@ -1,0 +1,27 @@
+# Landing Surface
+
+## Role
+
+The landing page expresses the Divergent Health parent brand and frames the
+company's point of view before the product is opened.
+
+## Durable Direction
+
+- warm light background
+- refined serif / sans interplay
+- amber accent instead of tech-blue
+- subtle atmospheric motion such as the scan-line sweep
+- concise copy that signals thoughtfulness and clinical ambition
+
+## Signature Elements
+
+- Divergent Health lockup
+- italic serif headline or supporting line
+- restrained divider / accent treatment
+- single primary call to action
+- subtle glow and scan-line motion on load
+
+## Tone
+
+The landing page should feel composed and intelligent, not loud. It can carry
+more atmosphere than the app, but it should still feel medically credible.

--- a/docs/design/surfaces/library.md
+++ b/docs/design/surfaces/library.md
@@ -1,0 +1,36 @@
+# Library Surface
+
+## Role
+
+The library is the emotional home of the product. It should feel safe, orderly,
+and human before the user ever opens a study.
+
+## Durable Direction
+
+- Warm light background system
+- myRadOne lockup as the primary brand moment
+- Branded import affordance with the amber folder icon
+- Clean study table with strong hierarchy and restrained chrome
+- Accent color used sparingly so import and key actions stay legible
+
+## Key Elements
+
+- library header with brand lockup, sync/account status, and help affordance
+- import zone for drag-and-drop or folder selection
+- sample-study actions for quick evaluation
+- studies table with expandable detail rows
+- notes, comments, and reports access inside the library workflow
+
+## Interaction Notes
+
+- The import zone should feel like an invitation, not a technical warning panel.
+- The empty state should reassure the user that the product is ready and capable.
+- Table density should favor clarity over maximum compression.
+- Secondary actions should stay quiet so the import path and study selection stay
+  obvious.
+
+## Implementation Note
+
+The checked-in CSS in this branch still reflects older dark / blue styling in
+many library components. The durable direction is the warmer myRadOne system
+shown in the current `docs/index.html` shell and design archive.

--- a/docs/design/surfaces/viewer.md
+++ b/docs/design/surfaces/viewer.md
@@ -1,0 +1,39 @@
+# Viewer Surface
+
+## Role
+
+The viewer is the focused clinical workspace. The image must remain primary.
+
+## Durable Direction
+
+- dark, low-glare atmosphere
+- restrained warm accents instead of blue neon
+- clear utility hierarchy for window/level, pan, zoom, measure, and reset
+- strong separation between series navigation, image plane, and metadata
+
+## Layout Model
+
+- header with back navigation, study title, and help
+- left series panel
+- central image panel with compact toolbar and slice controls
+- right metadata panel
+
+## Visual Rules
+
+- Keep the image plane visually quiet.
+- Do not let decorative backgrounds or gradients compete with the scan itself.
+- Amber should be used for emphasis and state, not to wash the whole viewer.
+- Viewer chrome should feel calm and serious, not flashy or consumer-app bright.
+
+## Clinical Usability Biases
+
+- Calibration warnings and window/level readouts must remain legible.
+- Tool states should be clear even in peripheral vision.
+- Metadata should be easy to scan without overpowering the image.
+- Future advanced modes should inherit the same disciplined chrome.
+
+## Implementation Note
+
+The checked-in CSS still uses an older navy/blue system for the viewer. Treat the
+warmer dark direction in `docs/design/brand-system.md` as the intended future
+state when visual work resumes here.

--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -1,0 +1,115 @@
+# Design Workflow
+
+This workflow exists so future design sessions improve the system instead of
+rediscovering it.
+
+## Read Order
+
+Before making design recommendations or changes:
+
+1. Read `docs/design/core.md`
+2. Read `docs/design/brand-system.md`
+3. Read the relevant surface doc under `docs/design/surfaces/`
+4. Read private collaboration preferences for the workspace
+5. Review `docs/design/open-questions.md` if the task touches unresolved areas
+
+## Standard Session Cadence
+
+### 1. Orient
+
+- Confirm the surface and decision scope.
+- Distinguish durable brand rules from local exploration ideas.
+- Check whether the task is a new direction, a refinement, or productionization
+  of an already approved direction.
+
+### 2. Explore
+
+- Prefer HTML/CSS exploration pages for visual rounds when the work is still
+  divergent.
+- Offer a small number of strong options rather than a sprawling grid.
+- Show realistic context when it helps evaluation, especially for icons, logos,
+  and shell chrome.
+
+### 3. Review
+
+- Summarize the strongest differences between options.
+- Under each option, include a short **Why this works** / **Why this loses**
+  comparison so the tradeoff is explicit and reviewable.
+- Capture what was preferred and what was rejected.
+- Call out when the codebase is visually behind the selected direction.
+
+### 4. Produce
+
+- If a direction is clearly approved and scoped, proceed to implementation.
+- If the decision changes broad visual direction, pause for confirmation before
+  replacing a large surface.
+- Final brand assets intended for the shipped app should prefer outlined SVG or
+  equivalent production-safe assets.
+
+### 5. Close Out
+
+- Before compaction, handoff, or thread end after meaningful design work, write
+  or update a scratch note in
+  `~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/sessions/YYYY-MM-DD.md`.
+- Use `docs/design/session-closeout-template.md` to keep closeout notes
+  consistent and resumable.
+- Promote durable project knowledge into `docs/design/` before saving anything
+  privately.
+- If nothing was approved yet, still capture the current frontier and the best
+  next starting point in session scratch.
+- Report back what was saved to repo docs and what was saved to private memory.
+
+## Promotion Loop
+
+Use this after each real design session.
+
+1. Capture rough working notes in private session scratch if needed.
+2. If a choice was approved, promote it into `docs/design/decisions.md` and the
+   relevant canonical doc.
+3. If the issue remains unresolved, add or update `docs/design/open-questions.md`.
+4. If a reusable UI convention has stabilized, add or update the appropriate file
+   in `docs/design/patterns/`.
+5. Periodically compress `docs/design/core.md` so it stays short and useful.
+
+## Pre-Compaction Flush
+
+Use this explicit prompt when a design session may compact or end:
+
+```text
+Before this session compacts, run design closeout:
+1. Write or update today's session scratch note under ~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/sessions/YYYY-MM-DD.md using docs/design/session-closeout-template.md.
+2. Promote approved durable decisions into the right docs/design files.
+3. Save only collaboration preferences to private memory.
+4. Tell me exactly what you saved and where.
+```
+
+## Which File To Update
+
+- Update `brand-system.md` for tokens, typography, logo rules, and durable
+  asset constraints.
+- Update `principles.md` for taste, emotional target, and anti-goals.
+- Update `decisions.md` for accepted or rejected directions with rationale.
+- Update `open-questions.md` for unresolved issues that should survive sessions.
+- Update `surfaces/*.md` for page-specific direction and constraints.
+- Update `archive.md` when a new exploration corpus becomes important enough to
+  reference later.
+
+## Private Memory Rules
+
+Private memory is for collaboration preferences and ephemeral scratch only.
+
+Keep there:
+
+- preferred number of variants per round
+- preferred review format
+- whether realistic mockups help
+- communication and pacing preferences
+- session scratch that captures the current frontier and next starting point
+
+Do not keep there:
+
+- final brand rules
+- chosen token values
+- approved or rejected visual directions that matter to the project
+
+Those belong in the repo.

--- a/docs/planning/SITEMAP.md
+++ b/docs/planning/SITEMAP.md
@@ -27,6 +27,7 @@ claude 0/                          # Workspace/inbox - drop files here for Claud
 | `AGENT_WORKTREES.md` | Parallel AI agent workflow rules: one agent per branch and worktree, `local/WIP` as integration branch, and helper scripts for create/list/retire |
 | `AGENT_WORKTREES_EXPLAINER.md` | Detailed beginner walkthrough of the multi-agent cleanup, why the workflow changed, and how to avoid shared-checkout collisions |
 | `RESEARCH_POLICY.md` | Policy for which benchmark and planning research belongs in git, what should stay local, and when research docs should be PRs |
+| `design/` | Persistent design handbook: bootstrap, brand system, surfaces, patterns, decisions, open questions, and session closeout template |
 | `BUGS.md` | Bug tracking and known issues |
 | `CODE_REVIEWS.md` | PR review findings and resolution tracking |
 | `DEPLOY.md` | Deployment guide: local dev, GitHub Pages, CI/CD workflow |
@@ -107,6 +108,25 @@ asks to preserve the research process itself.
 
 ---
 
+## Committed Design Explorations (`dicom-viewer/design/`)
+
+Historical exploration artifacts that remain in git as reference material. These
+files are not the canonical design spec; `docs/design/` now holds durable
+project truth.
+
+| Path | Description |
+|------|-------------|
+| `design/brand/brand-archive.html` | Committed overview of brand exploration history |
+| `design/brand/landing.html` | Divergent landing explorations |
+| `design/brand/logos*.html` | Parent-brand mark and integrated lockup explorations |
+| `design/colors/design-system-emerald.html` | Emerald design-system exploration |
+| `design/colors/design-system-sage.html` | Sage design-system exploration |
+| `design/colors/tokens.css` | Historical exploration token export |
+| `design/colors/app-icon-*.html` | App icon exploration rounds |
+| `design/colors/logo-variants-*.html` | Product logo exploration rounds |
+
+---
+
 ## Decisions (`dicom-viewer/docs/decisions/`)
 
 Architecture Decision Records (ADRs) for significant project decisions and rationale.
@@ -140,10 +160,12 @@ dicom-viewer/
 │   ├── sample-mri/        # Demo MRI scan
 │   ├── planning/          # Research and feature planning
 │   ├── decisions/         # ADRs and architecture rationale
+│   ├── design/            # Persistent design handbook and closeout workflow
 │   ├── BUGS.md            # Bug tracking
 │   ├── DEPLOY.md          # Deployment guide
 │   ├── DEVELOPMENT_PHILOSOPHY.md  # Why we work this way
 │   └── TESTING.md         # Test documentation
+├── design/                # Committed historical design explorations and archives
 ├── tests/                 # Playwright E2E tests, including mocked desktop integration checks
 ├── test-fixtures/         # Minimal DICOM data for CI
 └── uploads/               # Server upload destination
@@ -169,4 +191,4 @@ dicom-viewer/
 
 ---
 
-*Last updated: 2026-03-10*
+*Last updated: 2026-04-06*


### PR DESCRIPTION
## Summary
- add a repo-owned `docs/design/` handbook for persistent product and brand design context
- document the design bootstrap, brand system, surfaces, patterns, decisions, and open questions
- add a design session closeout template and point `CLAUDE.md` at the handbook entry points

## Notes
- this PR intentionally includes only repo-side files
- the local `~/.claude/agents/divergent-designer.md` and `~/.claude/agent-memory/...` companion files remain outside git
- the handbook is designed to be the canonical home for durable design knowledge going forward