### PR TITLE
Clean up runtime lint warnings

### DIFF
--- a/docs/js/app/account-ui.js
+++ b/docs/js/app/account-ui.js
@@ -258,7 +258,7 @@
             const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
             const json = atob(base64);
             return JSON.parse(json);
-        } catch (e) {
+        } catch {
             return null;
         }
     }
@@ -561,11 +561,6 @@
             statusEl.classList.remove('signed-in');
             statusEl.title = 'Click to sign in';
         }
-    }
-
-    function hideAccountStatus() {
-        if (!statusEl) return;
-        statusEl.style.display = 'none';
     }
 
     // ---- Auth Flows ----

--- a/docs/js/app/comments-ui.js
+++ b/docs/js/app/comments-ui.js
@@ -180,8 +180,9 @@
         if (idx === -1) return;
 
         const newText = prompt('Edit comment:', comments[idx].text);
-        if (newText !== null && newText.trim()) {
-            comments[idx].text = newText.trim();
+        const trimmedText = newText?.trim();
+        if (trimmedText) {
+            comments[idx].text = trimmedText;
             comments[idx].time = Date.now();
             updateCommentListUI(studyUid, seriesUid);
             if (!String(commentId).startsWith('local-')) {

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -479,12 +479,10 @@
      *
      * @param {Object} dataSet - dicomParser dataset
      * @param {Object} pixelDataElement - Pixel data element (x7fe00010)
-     * @param {number} rows - Image height
-     * @param {number} cols - Image width
      * @param {number} bitsAllocated - Bits per pixel (8 or 16)
      * @returns {TypedArray} Decoded pixel data
      */
-    function decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated, frameIndex = 0) {
+    function decodeJpegLossless(dataSet, pixelDataElement, bitsAllocated, frameIndex = 0) {
         try {
             let frameData;
 
@@ -773,22 +771,13 @@
      * Decode JPEG 2000 compressed pixel data using OpenJPEG WASM
      *
      * @param {Object} dataSet - dicomParser dataset
-     * @param {Object} pixelDataElement - Pixel data element (unused, uses dataSet.elements)
      * @param {number} rows - Image height
      * @param {number} cols - Image width
      * @param {number} bitsAllocated - Bits per pixel
      * @param {number} pixelRepresentation - 0=unsigned, 1=signed
      * @returns {Promise<TypedArray>} Decoded pixel data
      */
-    async function decodeJpeg2000(
-        dataSet,
-        pixelDataElement,
-        rows,
-        cols,
-        bitsAllocated,
-        pixelRepresentation,
-        frameIndex = 0,
-    ) {
+    async function decodeJpeg2000(dataSet, rows, cols, bitsAllocated, pixelRepresentation, frameIndex = 0) {
         try {
             console.log('Attempting JPEG 2000 decode for', rows, 'x', cols, 'image');
 

--- a/docs/js/app/help-viewer.js
+++ b/docs/js/app/help-viewer.js
@@ -34,25 +34,30 @@
     function renderHelpContent() {
         const tocEl = $('helpToc');
         const contentEl = $('helpContent');
-        if (!tocEl || !contentEl || !Array.isArray(HELP_SECTIONS)) return;
+        const helpSections = window.HELP_SECTIONS;
+        if (!tocEl || !contentEl || !Array.isArray(helpSections)) return;
 
-        tocEl.innerHTML = HELP_SECTIONS.map(
-            (section) => `
+        tocEl.innerHTML = helpSections
+            .map(
+                (section) => `
             <a href="#help-${escapeHtml(section.id)}" class="help-toc-item" data-section-id="${escapeHtml(section.id)}">
                 ${escapeHtml(section.title)}
             </a>
         `,
-        ).join('');
+            )
+            .join('');
 
-        // HELP_SECTIONS content is authored static HTML from help-content.js, not user input.
-        contentEl.innerHTML = HELP_SECTIONS.map(
-            (section) => `
+        // window.HELP_SECTIONS content is authored static HTML from help-content.js, not user input.
+        contentEl.innerHTML = helpSections
+            .map(
+                (section) => `
             <section id="help-${escapeHtml(section.id)}" class="help-section" data-section-id="${escapeHtml(section.id)}">
                 <h2>${escapeHtml(section.title)}</h2>
                 ${section.content}
             </section>
         `,
-        ).join('');
+            )
+            .join('');
 
         tocEl.querySelectorAll('.help-toc-item').forEach((item) => {
             item.addEventListener('click', (e) => {

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -741,7 +741,6 @@
                 try {
                     pixelData = await decodeJpeg2000(
                         dataSet,
-                        pixelDataElement,
                         rows,
                         cols,
                         bitsAllocated,
@@ -758,7 +757,7 @@
                 }
             } else if (isJpegLossless(transferSyntax)) {
                 try {
-                    pixelData = decodeJpegLossless(dataSet, pixelDataElement, rows, cols, bitsAllocated, frameIndex);
+                    pixelData = decodeJpegLossless(dataSet, pixelDataElement, bitsAllocated, frameIndex);
                 } catch (error) {
                     return buildDecodeError('JPEG Lossless decode failed', getDecodeFailureMessage(error), {
                         stage: getDecodeFailureStage(error),

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -282,7 +282,7 @@
 
             try {
                 return await parseDicomHeaderDataSet(headerBytes);
-            } catch (error) {
+            } catch {
                 if (headerBytes.byteLength < requestedBytes) {
                     return null;
                 }
@@ -772,14 +772,7 @@
         }
     }
 
-    async function processDesktopPathDicomDirFile(
-        fileEntry,
-        studies,
-        indexedFilePaths,
-        stats,
-        onProgress,
-        availablePaths = null,
-    ) {
+    async function processDesktopPathDicomDirFile(fileEntry, stats, onProgress, availablePaths = null) {
         const sourcePath = fileEntry?.source?.path || '';
         const shouldTimeReads = typeof stats.readFileMs === 'number';
         let indexedCount = 0;
@@ -1193,14 +1186,7 @@
                             queuedFilePaths.add(currentPath);
                         }
                         stats.discovered++;
-                        await processDesktopPathDicomDirFile(
-                            fileEntry,
-                            studies,
-                            indexedFilePaths,
-                            stats,
-                            onProgress,
-                            manifestPathSet,
-                        );
+                        await processDesktopPathDicomDirFile(fileEntry, stats, onProgress, manifestPathSet);
                         continue;
                     }
 
@@ -1316,8 +1302,6 @@
                                 source: { kind: 'path', path: entryPath },
                                 rootPath: current.rootPath,
                             },
-                            studies,
-                            indexedFilePaths,
                             stats,
                             onProgress,
                         );

--- a/docs/js/app/sync-engine.js
+++ b/docs/js/app/sync-engine.js
@@ -305,7 +305,7 @@ const _SyncEngine = (() => {
                 const retryAfter = res.headers.get('Retry-After');
                 if (retryAfter) {
                     const seconds = parseInt(retryAfter, 10);
-                    if (!isNaN(seconds)) {
+                    if (!Number.isNaN(seconds)) {
                         this._retryAfterMs = seconds * 1000;
                     }
                 }

--- a/docs/js/app/tools.js
+++ b/docs/js/app/tools.js
@@ -23,7 +23,7 @@
 
         const row = parseFloat(parts[0]);
         const col = parseFloat(parts[1]);
-        if (isNaN(row) || isNaN(col) || row <= 0 || col <= 0) return null;
+        if (Number.isNaN(row) || Number.isNaN(col) || row <= 0 || col <= 0) return null;
 
         return { row, col };
     }
@@ -374,7 +374,7 @@
         applyViewTransform();
     }
 
-    function handleZoomDrag(dx, dy) {
+    function handleZoomDrag(dy) {
         const sensitivity = 0.005;
         const delta = -dy * sensitivity;
         state.viewTransform.zoom = Math.max(0.1, Math.min(10, state.viewTransform.zoom + delta));
@@ -434,7 +434,7 @@
                 handlePanDrag(dx, dy);
                 break;
             case 'zoom':
-                handleZoomDrag(dx, dy);
+                handleZoomDrag(dy);
                 break;
         }
 

--- a/docs/js/app/update-ui.js
+++ b/docs/js/app/update-ui.js
@@ -41,7 +41,7 @@ const _UpdateUI = (() => {
         if (initialized) return;
 
         const config = window.CONFIG;
-        if (!config || !config.features || !config.features.autoUpdate) {
+        if (!config?.features?.autoUpdate) {
             return;
         }
 

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -31,7 +31,6 @@
     const { resetViewForNewSeries, updateWLDisplay } = app.tools;
 
     const VIEWER_PRELOAD_RADIUS = config?.deploymentMode === 'desktop' ? 1 : 3;
-    const MAX_SHARED_PATH_DATASETS = 1;
     let loadGeneration = 0;
     let activeLoadRequestId = 0;
     const inFlightLoads = new Map();
@@ -142,7 +141,7 @@
 
     function rememberSharedPathDataSet(path, entry) {
         if (!path) return entry;
-        // MAX_SHARED_PATH_DATASETS is 1, so just keep the latest
+        // Only retain the latest shared-path dataset entry.
         sharedPathDataSets.clear();
         sharedPathDataSets.set(path, entry);
         return entry;
@@ -412,7 +411,7 @@
     }
 
     function updateSliceMetadata(info, slice, index, totalSlices) {
-        if (info && info.isBlank) {
+        if (info?.isBlank) {
             metadataContent.innerHTML = `
                 <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${totalSlices}</div></div>
                 <div class="metadata-item"><div class="label">Modality</div><div class="value">${escapeHtml(info.modality || '-')}</div></div>
@@ -459,7 +458,7 @@
             return;
         }
 
-        if (info && info.error) {
+        if (info?.error) {
             metadataContent.innerHTML = `
                 <div class="metadata-item"><div class="label">Slice</div><div class="value">${index + 1} / ${totalSlices}</div></div>
                 <div class="metadata-item"><div class="label">Status</div><div class="value" style="color: #f0ad4e;">Decode Error</div></div>

--- a/docs/js/help-content.js
+++ b/docs/js/help-content.js
@@ -1,6 +1,6 @@
 // If you edit this file, also update USER_GUIDE.md to keep the in-app help in sync.
 
-const HELP_SECTIONS = [
+window.HELP_SECTIONS = [
     {
         id: 'introduction',
         title: 'Introduction',

--- a/docs/js/persistence/desktop.js
+++ b/docs/js/persistence/desktop.js
@@ -13,9 +13,7 @@
 const _NotesDesktop = (() => {
     const {
         createEmptyStore,
-        clone,
         normalizeCommentId,
-        loadStore,
         ensureStudy,
         ensureSeries,
         normalizeReportId,
@@ -179,14 +177,10 @@ const _NotesDesktop = (() => {
                 throw error;
             });
         }
-        try {
-            const db = await desktopDbPromise;
-            desktopDbFailure = null;
-            desktopDbRetryAt = 0;
-            return db;
-        } catch (error) {
-            throw error;
-        }
+        const db = await desktopDbPromise;
+        desktopDbFailure = null;
+        desktopDbRetryAt = 0;
+        return db;
     }
 
     async function getDesktopAppConfigValue(key) {

--- a/docs/js/persistence/server.js
+++ b/docs/js/persistence/server.js
@@ -156,7 +156,7 @@ const _NotesServer = (() => {
                 body: JSON.stringify(payload),
             });
             // Promote record_uuid to id for canonical identifier usage
-            if (result && result.record_uuid) {
+            if (result?.record_uuid) {
                 result.id = result.record_uuid;
             }
             return result;

--- a/tests/jpeg2000-worker.spec.js
+++ b/tests/jpeg2000-worker.spec.js
@@ -240,7 +240,6 @@ test('decodeJpeg2000 decodes a real JPEG 2000 DICOM to the same pixels as its un
 
             const decodedPixels = await window.DicomViewerApp.dicom.decodeJpeg2000(
                 jpeg2000DataSet,
-                jpeg2000DataSet.elements.x7fe00010,
                 rows,
                 cols,
                 bitsAllocated,


### PR DESCRIPTION
## Summary
- remove dead runtime locals and unused internal parameters in app JS modules
- tighten a few runtime checks with optional chaining and Number.isNaN
- make the help-content contract explicit through window.HELP_SECTIONS and simplify desktop DB error flow

## Verification
- npm run lint