### PR TITLE
Clean up mechanical test lint warnings

### DIFF
--- a/tests/desktop-import.spec.js
+++ b/tests/desktop-import.spec.js
@@ -1,8 +1,7 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
-const path = require('path');
+const path = require('node:path');
 const { test, expect } = require('@playwright/test');
-const { normalizePath, joinPaths } = require('./helpers/desktop-test-utils');
 
 const TEST_BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:5001';
 const HOME_URL = `${TEST_BASE_URL}/?nolib`;
@@ -153,7 +152,6 @@ function buildSyntheticDicomBytes(options = {}) {
 async function installMockDesktop(page, options = {}) {
     await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
     await page.addInitScript((opts) => {
-        const FILE_STORAGE_PREFIX = 'mock-desktop-fs:';
         const hasOwnPropertyFn = Object.prototype.hasOwnProperty;
         const hasOwn = (object, key) => hasOwnPropertyFn.call(object, key);
 
@@ -276,7 +274,7 @@ async function installMockDesktop(page, options = {}) {
                     const normalized = normalizePath(dirPath);
                     window.__importMockState.mkdirCalls.push({
                         path: normalized,
-                        recursive: !!(mkdirOptions && mkdirOptions.recursive),
+                        recursive: !!mkdirOptions?.recursive,
                     });
                 },
                 async remove() {},
@@ -1080,15 +1078,6 @@ test.describe('Desktop import pipeline', () => {
     // -----------------------------------------------------------------------
 
     test('importFromPaths: DICOM without SOP Instance UID counted as invalid', async ({ page }) => {
-        // Build a DICOM-like buffer that has study/series UIDs but no SOP UID.
-        // We need the transfer syntax so hasLikelyDicomMetadata returns true,
-        // but the SOP Instance UID check in processOneFile should reject it.
-        const noSopBytes = buildSyntheticDicomBytes({
-            studyInstanceUid: '1.2.study.nosop',
-            seriesInstanceUid: '1.2.series.nosop',
-            sopInstanceUid: '1.2.sop.nosop', // will be present in bytes
-        });
-
         // We will override readFile to return bytes that parse as DICOM but have
         // the SOP UID field empty. The simplest approach: build bytes without
         // a real SOP tag by constructing a custom buffer in the browser context.
@@ -1311,7 +1300,7 @@ async function installMockDesktopIntegration(page, options = {}) {
                     const normalized = normalizePath(dirPath);
                     window.__importMockState.mkdirCalls.push({
                         path: normalized,
-                        recursive: !!(mkdirOptions && mkdirOptions.recursive),
+                        recursive: !!mkdirOptions?.recursive,
                     });
                 },
                 async remove() {},

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -1,10 +1,10 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { test, expect } = require('@playwright/test');
 const { createSyntheticDicomFolder, removeSyntheticDicomFolder } = require('./dicom-fixture-helper');
-const { normalizePath, joinPaths } = require('./helpers/desktop-test-utils');
+const { joinPaths } = require('./helpers/desktop-test-utils');
 
 const TEST_BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:5001';
 const HOME_URL = `${TEST_BASE_URL}/?nolib`;
@@ -2183,7 +2183,7 @@ test.describe('Desktop library scanning', () => {
                     },
                 };
             };
-            app.desktopDecode.decodeFrameWithPixels = async (path, frameIndex) => {
+            app.desktopDecode.decodeFrameWithPixels = async () => {
                 nativeDecodeCalls += 1;
                 return {
                     rows: 1,
@@ -3449,7 +3449,7 @@ test.describe('Desktop library scanning', () => {
             let headerReads = 0;
             let fullReads = 0;
             window.__TAURI__.core = {
-                async invoke(command, args) {
+                async invoke(command) {
                     if (command !== 'read_scan_header') {
                         throw new Error(`Unexpected command: ${command}`);
                     }
@@ -3503,7 +3503,7 @@ test.describe('Desktop library scanning', () => {
             let headerReads = 0;
             let fullReads = 0;
             window.__TAURI__.core = {
-                async invoke(command, args) {
+                async invoke(command) {
                     if (command !== 'read_scan_header') {
                         throw new Error(`Unexpected command: ${command}`);
                     }
@@ -3557,7 +3557,7 @@ test.describe('Desktop library scanning', () => {
             let headerReads = 0;
             let fullReads = 0;
             window.__TAURI__.core = {
-                async invoke(command, args) {
+                async invoke(command) {
                     if (command !== 'read_scan_header') {
                         throw new Error(`Unexpected command: ${command}`);
                     }
@@ -3597,7 +3597,7 @@ test.describe('Desktop library scanning', () => {
             let headerReads = 0;
             let fullReads = 0;
             window.__TAURI__.core = {
-                async invoke(command, args) {
+                async invoke(command) {
                     if (command !== 'read_scan_header') {
                         throw new Error(`Unexpected command: ${command}`);
                     }

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
-const path = require('path');
+const path = require('node:path');
 const { test, expect } = require('@playwright/test');
 
 const HOME_URL = 'http://127.0.0.1:5001/?nolib';
@@ -294,7 +294,7 @@ test.describe('Desktop report persistence', () => {
         await expect(page.locator('#libraryView')).toBeVisible();
 
         const persisted = await page.evaluate(
-            async ({ studyUid, seriesUid }) => {
+            async ({ studyUid }) => {
                 const notes = await window.NotesAPI.loadNotes([studyUid]);
                 const config = await window.NotesAPI.loadDesktopLibraryConfig();
                 const sqlStore = JSON.parse(localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}');
@@ -304,7 +304,7 @@ test.describe('Desktop report persistence', () => {
                     sqlStore,
                 };
             },
-            { studyUid, seriesUid },
+            { studyUid },
         );
 
         expect(persisted.notes.studies[studyUid].description).toBe('Migrated study note');

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -1,8 +1,8 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 const { test, expect } = require('@playwright/test');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const HOME_URL = 'http://127.0.0.1:5001/';
 const MOCK_SQL_INIT_PATH = path.join(__dirname, 'mock-tauri-sql-init.js');
@@ -42,7 +42,7 @@ async function installMockTauriInternals(page) {
             unregisterCallback(id) {
                 callbacks.delete(id);
             },
-            async invoke(cmd, args, options) {
+            async invoke(cmd, args) {
                 switch (cmd) {
                     case 'plugin:dialog|open':
                         return null;

--- a/tests/dicom-fixture-helper.js
+++ b/tests/dicom-fixture-helper.js
@@ -1,8 +1,8 @@
 // @ts-check
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const { execFileSync } = require('child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const PYTHON_BIN = path.join(REPO_ROOT, 'venv', 'bin', 'python');

--- a/tests/e2e-sync.spec.js
+++ b/tests/e2e-sync.spec.js
@@ -803,10 +803,13 @@ test.describe('E2E Report File Sync', () => {
 
         // Device A creates and uploads a report
         const pdfContent = minimalPdfBuffer();
-        const {
-            reportId,
-            contentHash,
-        } = await insertReportWithFile(request, deviceA.access_token, deviceA.device_id, null, pdfContent);
+        const { reportId, contentHash } = await insertReportWithFile(
+            request,
+            deviceA.access_token,
+            deviceA.device_id,
+            null,
+            pdfContent,
+        );
 
         // Device B syncs to learn about the report
         const bSync = await syncAndExpectOk(request, BASE_URL, deviceB.access_token, deviceB.device_id, null, []);

--- a/tests/e2e-sync.spec.js
+++ b/tests/e2e-sync.spec.js
@@ -806,7 +806,6 @@ test.describe('E2E Report File Sync', () => {
         const {
             reportId,
             contentHash,
-            cursor: aCursor,
         } = await insertReportWithFile(request, deviceA.access_token, deviceA.device_id, null, pdfContent);
 
         // Device B syncs to learn about the report

--- a/tests/jpeg2000-worker.spec.js
+++ b/tests/jpeg2000-worker.spec.js
@@ -1,8 +1,8 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 const { test, expect } = require('@playwright/test');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const HOME_URL = 'http://127.0.0.1:5001/?nolib';
 const MR2_J2K_PATH = path.join(__dirname, '..', 'test-fixtures', 'MR2_J2KI.dcm');

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -1,9 +1,9 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 const { test, expect } = require('@playwright/test');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { createSyntheticDicomFolder, removeSyntheticDicomFolder } = require('./dicom-fixture-helper');
 
 /**
@@ -106,7 +106,7 @@ async function getSliceInfo(page) {
     const text = await page.locator(SLICE_INFO_SELECTOR).textContent();
     const match = text.match(/(\d+)\s*\/\s*(\d+)/);
     if (match) {
-        return { current: parseInt(match[1]), total: parseInt(match[2]) };
+        return { current: parseInt(match[1], 10), total: parseInt(match[2], 10) };
     }
     return null;
 }
@@ -142,7 +142,7 @@ async function jumpToSlice(page, zeroBasedIndex) {
 async function isButtonActive(page, selector) {
     const button = page.locator(selector);
     const classList = await button.getAttribute('class');
-    return classList && classList.includes('active');
+    return classList?.includes('active');
 }
 
 async function getCanvasCursor(page) {
@@ -430,9 +430,6 @@ test.describe('Test Suite 15: Library View - Test Mode Studies Table', () => {
 
         const expandIcon = page.locator(`${STUDIES_BODY_SELECTOR} .expand-icon`).first();
         await expect(expandIcon).toBeVisible();
-
-        // Initial state: expand icon should be pointing right (collapsed)
-        const initialIconText = await expandIcon.textContent();
 
         // Click the study row to expand it
         const studyRow = page.locator(`${STUDIES_BODY_SELECTOR} .study-row`).first();
@@ -823,9 +820,6 @@ test.describe('Test Suite 19: Metadata Panel', () => {
 
     test('Metadata panel updates slice number after navigation', async ({ page }) => {
         const initialSlice = await getSliceInfo(page);
-
-        // Extract initial slice number from metadata panel
-        const initialMetadata = await page.locator(METADATA_CONTENT_SELECTOR).textContent();
 
         // Navigate to next slice
         await page.keyboard.press('ArrowRight');

--- a/tests/maintenance.spec.js
+++ b/tests/maintenance.spec.js
@@ -1,12 +1,12 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 
-const fs = require('fs');
-const net = require('net');
-const os = require('os');
-const path = require('path');
-const { spawn } = require('child_process');
-const { once } = require('events');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { once } = require('node:events');
 const { test, expect, request: playwrightRequest } = require('@playwright/test');
 
 const REPO_ROOT = path.resolve(__dirname, '..');

--- a/tests/sync-helpers.js
+++ b/tests/sync-helpers.js
@@ -9,7 +9,7 @@
  */
 
 const { expect } = require('@playwright/test');
-const { randomUUID } = require('crypto');
+const { randomUUID } = require('node:crypto');
 
 const BASE_URL = 'http://127.0.0.1:5001';
 
@@ -256,7 +256,7 @@ function minimalPdfBuffer() {
  * @returns {string}
  */
 function sha256Hex(buffer) {
-    const crypto = require('crypto');
+    const crypto = require('node:crypto');
     return crypto.createHash('sha256').update(buffer).digest('hex');
 }
 

--- a/tests/sync-outbox.spec.js
+++ b/tests/sync-outbox.spec.js
@@ -135,7 +135,7 @@ async function clearOutbox(page) {
  * @param {Object} [data] - unused by the real API but kept for test readability
  * @returns {Promise<void>}
  */
-async function enqueueChange(page, table, key, operation, data = {}) {
+async function enqueueChange(page, table, key, operation, _data = {}) {
     await page.evaluate(
         ({ table, key, operation }) => {
             if (typeof window._SyncOutbox !== 'undefined') {

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -930,7 +930,7 @@ test.describe('Sync Multiple Changes Per Request', () => {
             description: 'Original',
             baseSyncVersion: 0,
         });
-        await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [insert]);
+        const initialSync = await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [insert]);
 
         // Send two changes: one with correct version (new comment), one with stale version
         const freshChange = commentInsertChange({ text: 'Fresh comment' });
@@ -939,7 +939,7 @@ test.describe('Sync Multiple Changes Per Request', () => {
             baseSyncVersion: 0,
         });
 
-        const result = await syncAndExpectOk(request, BASE_URL, access_token, device_id, r1.delta_cursor, [
+        const result = await syncAndExpectOk(request, BASE_URL, access_token, device_id, initialSync.delta_cursor, [
             freshChange,
             staleChange,
         ]);

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -20,8 +20,6 @@ const {
     uniqueStudyUid,
     uniqueRecordUuid,
     uniqueOperationUuid,
-    createTestUser,
-    loginUser,
     registerDevice,
     syncRequest,
     syncAndExpectOk,
@@ -932,14 +930,13 @@ test.describe('Sync Multiple Changes Per Request', () => {
             description: 'Original',
             baseSyncVersion: 0,
         });
-        const r1 = await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [insert]);
-        const currentVersion = r1.accepted[0].sync_version;
+        await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [insert]);
 
         // Send two changes: one with correct version (new comment), one with stale version
         const freshChange = commentInsertChange({ text: 'Fresh comment' });
         const staleChange = studyNoteUpdateChange(studyUid, {
             description: 'Stale update',
-            baseSyncVersion: 0, // stale -- should be currentVersion
+            baseSyncVersion: 0,
         });
 
         const result = await syncAndExpectOk(request, BASE_URL, access_token, device_id, r1.delta_cursor, [

--- a/tests/viewing-tools.spec.js
+++ b/tests/viewing-tools.spec.js
@@ -70,7 +70,7 @@ async function getWLValues(page) {
     const text = await page.locator(WL_DISPLAY_SELECTOR).textContent();
     const match = text.match(/C:\s*(-?\d+)\s*W:\s*(\d+)/);
     if (match) {
-        return { center: parseInt(match[1]), width: parseInt(match[2]) };
+        return { center: parseInt(match[1], 10), width: parseInt(match[2], 10) };
     }
     return null;
 }
@@ -79,7 +79,7 @@ async function getWLValues(page) {
 async function isButtonActive(page, selector) {
     const button = page.locator(selector);
     const classList = await button.getAttribute('class');
-    return classList && classList.includes('active');
+    return classList?.includes('active');
 }
 
 // Helper function to perform a drag operation
@@ -123,7 +123,7 @@ async function getSliceInfo(page) {
     const text = await page.locator('#sliceInfo').textContent();
     const match = text.match(/(\d+)\s*\/\s*(\d+)/);
     if (match) {
-        return { current: parseInt(match[1]), total: parseInt(match[2]) };
+        return { current: parseInt(match[1], 10), total: parseInt(match[2], 10) };
     }
     return null;
 }
@@ -153,15 +153,6 @@ async function getCanvasCursor(page) {
     return await page.locator(CANVAS_SELECTOR).evaluate((el) => {
         return window.getComputedStyle(el).cursor;
     });
-}
-
-// Seeded random number generator for reproducible tests
-function seededRandom(seed) {
-    let state = seed;
-    return () => {
-        state = (state * 1103515245 + 12345) & 0x7fffffff;
-        return state / 0x7fffffff;
-    };
 }
 
 /**
@@ -468,21 +459,11 @@ test.describe('Test Suite 3: Pan Tool', () => {
         const centerX = bounds.x + bounds.width / 2;
         const centerY = bounds.y + bounds.height / 2;
 
-        // Get initial canvas transform (if any)
-        const initialTransform = await page.locator(CANVAS_SELECTOR).evaluate((el) => {
-            return window.getComputedStyle(el).transform;
-        });
-
         // Perform pan drag
         await performDrag(page, centerX, centerY, centerX + 50, centerY + 50);
 
         // Wait for update
         await page.waitForTimeout(100);
-
-        // Get new transform
-        const newTransform = await page.locator(CANVAS_SELECTOR).evaluate((el) => {
-            return window.getComputedStyle(el).transform;
-        });
 
         // Transform should change (image moved)
         // Note: If the app uses internal state rather than CSS transform,


### PR DESCRIPTION
## Summary
- clean up remaining mechanical lint findings in test files only
- switch test helpers to explicit node: builtins and remove dead locals/unused params
- add small parseInt/optional-chain fixes without touching runtime or CSS code

## Verification
- tests-only Biome lint: 0 warnings, 0 infos
- npm run lint
- NODE_PATH=/Users/gabriel/ai-worktrees/dicom-viewer/codex-linting-infra/node_modules npx playwright test tests/desktop-runtime-compat.spec.js tests/viewing-tools.spec.js tests/sync-protocol.spec.js -g "desktop storage ready promise resolves before the full desktop shell is available|window/level|pan|stale"
- NODE_PATH=/Users/gabriel/ai-worktrees/dicom-viewer/codex-linting-infra/node_modules npx playwright test tests/desktop-import.spec.js tests/desktop-library.spec.js tests/library-and-navigation.spec.js tests/e2e-sync.spec.js -g "DICOM without SOP Instance UID counted as invalid|desktop path scan|Study row shows expand icon and clicking expands series|Metadata panel updates slice number after navigation|upload a report on Device A, sync, Device B can download the file"