### PR TITLE
Harden auth and fix sync remediation findings

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 mod decode;
 mod path_util;
+mod persistence;
 mod scan;
 mod secure_store;
 
@@ -307,6 +308,8 @@ fn main() {
             decode::decode_frame_with_pixels,
             decode::take_decoded_frame,
             decode::read_scan_header,
+            persistence::apply_desktop_migration,
+            persistence::load_legacy_desktop_browser_stores,
             scan::read_scan_manifest,
             secure_store::load_secure_auth_state,
             secure_store::store_secure_auth_state,

--- a/desktop/src-tauri/src/persistence.rs
+++ b/desktop/src-tauri/src/persistence.rs
@@ -12,10 +12,7 @@ use tauri_plugin_sql::{DbInstances, DbPool};
 const CURRENT_STORE_KEY: &str = "dicom-viewer-notes-v3";
 const LIBRARY_CONFIG_KEY: &str = "dicom-viewer-library-config";
 const LEGACY_WEBKIT_SCAN_MAX_DEPTH: usize = 12;
-const LEGACY_WEBKIT_PROFILES: &[&str] = &[
-    "health.divergent.dicomviewer",
-    "dicom-viewer-desktop",
-];
+const LEGACY_WEBKIT_PROFILES: &[&str] = &["health.divergent.dicomviewer", "dicom-viewer-desktop"];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -439,7 +436,12 @@ mod tests {
         collect_localstorage_dbs, decode_webkit_localstorage_blob, modified_ms,
         sort_localstorage_db_paths, LEGACY_WEBKIT_SCAN_MAX_DEPTH,
     };
-    use std::{collections::BTreeSet, fs, path::PathBuf, time::{Duration, SystemTime, UNIX_EPOCH}};
+    use std::{
+        collections::BTreeSet,
+        fs,
+        path::PathBuf,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
 
     fn temp_dir(label: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(

--- a/docs/js/app/sync-engine.js
+++ b/docs/js/app/sync-engine.js
@@ -546,9 +546,7 @@ const _SyncEngine = (() => {
                     // Update existing comment
                     existing.text = data.text || '';
                     existing.updated_at = data.updated_at || Date.now();
-                    // Keep time in sync with the remote timestamp so the UI
-                    // shows the correct display time for this comment
-                    existing.time = data.updated_at || existing.time || Date.now();
+                    existing.time = data.created_at || existing.time || Date.now();
                     existing.sync_version = syncVersion;
                 } else {
                     // Insert new comment from remote
@@ -570,6 +568,7 @@ const _SyncEngine = (() => {
             if (tableName === 'reports') {
                 const studyUid = data.study_uid;
                 if (!studyUid) return;
+                if (!store.studies[studyUid]) return;
                 const deletedAt = data.deletedAt || data.deleted_at || null;
                 const { normalizeReportId } = window._NotesInternals;
                 const targetId = normalizeReportId(recordKey);

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -88,7 +88,7 @@ module.exports = defineConfig({
    * - CI environment: Always start fresh to ensure clean, reproducible state
    */
   webServer: {
-    command: './venv/bin/flask run --host=127.0.0.1 --port=5001',
+    command: 'FLASK_ENV=test ./venv/bin/flask run --host=127.0.0.1 --port=5001',
     url: 'http://127.0.0.1:5001/api/test-data/info',
     reuseExistingServer: !process.env.CI,
     timeout: 60000,

--- a/server/routes/auth.py
+++ b/server/routes/auth.py
@@ -102,9 +102,7 @@ def _clear_auth_failures(action, email):
 def _log_auth_event(action, email, event, retry_after=None):
     normalized = _normalize_email(email)
     hashed_email = (
-        hashlib.sha256(normalized.encode('utf-8')).hexdigest()[:12]
-        if normalized
-        else '-'
+        hashlib.sha256(normalized.encode('utf-8')).hexdigest()[:12] if normalized else '-'
     )
     current_app.logger.warning(
         'auth_%s action=%s ip=%s email_hash=%s retry_after=%s',

--- a/server/routes/auth.py
+++ b/server/routes/auth.py
@@ -7,11 +7,15 @@ desktop modes continue using the existing session-token auth.
 Copyright (c) 2026 Divergent Health Technologies
 """
 
+import hashlib
 import re
 import sqlite3
+import threading
+import time
+from collections import defaultdict, deque
 
 import jwt as pyjwt
-from flask import Blueprint, g, jsonify, request
+from flask import Blueprint, current_app, g, jsonify, request
 
 from server.auth.jwt_utils import (
     ACCESS_TOKEN_LIFETIME,
@@ -38,6 +42,86 @@ MIN_PASSWORD_LENGTH = 8
 # Simple email validation -- just checks structure, not deliverability
 _EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
 
+# Sliding-window auth throttling keyed by (route, ip, email). This slows
+# repeated guessing for a target account without locking out unrelated signups
+# or broad test runs that create many unique users from the same machine.
+_AUTH_WINDOW_SECONDS = 15 * 60
+_AUTH_MAX_ATTEMPTS = 5
+_AUTH_FAILURES = defaultdict(deque)
+_AUTH_FAILURES_LOCK = threading.Lock()
+
+
+def _normalize_email(email):
+    return (email or '').strip().lower()
+
+
+def _client_ip():
+    forwarded = request.headers.get('X-Forwarded-For', '')
+    if forwarded:
+        return forwarded.split(',')[0].strip() or 'unknown'
+    return request.remote_addr or 'unknown'
+
+
+def _auth_failure_key(action, email):
+    normalized = _normalize_email(email) or '*'
+    return f'{action}:{_client_ip()}:{normalized}'
+
+
+def _prune_attempts(attempts, now_s):
+    cutoff = now_s - _AUTH_WINDOW_SECONDS
+    while attempts and attempts[0] <= cutoff:
+        attempts.popleft()
+
+
+def _rate_limit_retry_after(action, email):
+    now_s = int(time.time())
+    key = _auth_failure_key(action, email)
+    with _AUTH_FAILURES_LOCK:
+        attempts = _AUTH_FAILURES[key]
+        _prune_attempts(attempts, now_s)
+        if len(attempts) < _AUTH_MAX_ATTEMPTS:
+            return None
+        return max(1, _AUTH_WINDOW_SECONDS - (now_s - attempts[0]))
+
+
+def _record_auth_failure(action, email):
+    now_s = int(time.time())
+    key = _auth_failure_key(action, email)
+    with _AUTH_FAILURES_LOCK:
+        attempts = _AUTH_FAILURES[key]
+        _prune_attempts(attempts, now_s)
+        attempts.append(now_s)
+
+
+def _clear_auth_failures(action, email):
+    key = _auth_failure_key(action, email)
+    with _AUTH_FAILURES_LOCK:
+        _AUTH_FAILURES.pop(key, None)
+
+
+def _log_auth_event(action, email, event, retry_after=None):
+    normalized = _normalize_email(email)
+    hashed_email = (
+        hashlib.sha256(normalized.encode('utf-8')).hexdigest()[:12]
+        if normalized
+        else '-'
+    )
+    current_app.logger.warning(
+        'auth_%s action=%s ip=%s email_hash=%s retry_after=%s',
+        event,
+        action,
+        _client_ip(),
+        hashed_email,
+        retry_after if retry_after is not None else '-',
+    )
+
+
+def _rate_limited_response(retry_after):
+    response = jsonify({'error': 'Too many attempts. Please try again later.'})
+    response.status_code = 429
+    response.headers['Retry-After'] = str(retry_after)
+    return response
+
 
 # ---------------------------------------------------------------------------
 # Auth endpoints
@@ -49,13 +133,18 @@ def signup():
     """Create a new user account.
 
     Request body: { email, password, name }
-    Returns: { access_token, refresh_token, expires_in }
+    Returns: { accepted: true } without revealing whether the email was new.
     """
     data = request.get_json(silent=True) or {}
 
-    email = (data.get('email') or '').strip()
+    email = _normalize_email(data.get('email'))
     password = data.get('password') or ''
     name = (data.get('name') or '').strip()
+
+    retry_after = _rate_limit_retry_after('signup', email)
+    if retry_after is not None:
+        _log_auth_event('signup', email, 'rate_limited', retry_after)
+        return _rate_limited_response(retry_after)
 
     # Validate inputs
     if not email or not _EMAIL_RE.match(email):
@@ -68,20 +157,14 @@ def signup():
         return jsonify({'error': 'Name is required'}), 400
 
     try:
-        user_id = create_user(email, password, name)
+        create_user(email, password, name)
     except sqlite3.IntegrityError:
-        return jsonify({'error': 'Email already registered'}), 409
+        _record_auth_failure('signup', email)
+        _log_auth_event('signup', email, 'duplicate')
+        return jsonify({'accepted': True}), 202
 
-    access_token = create_access_token(user_id)
-    refresh_token = create_refresh_token(user_id)
-
-    return jsonify(
-        {
-            'access_token': access_token,
-            'refresh_token': refresh_token,
-            'expires_in': ACCESS_TOKEN_LIFETIME,
-        }
-    ), 201
+    _clear_auth_failures('signup', email)
+    return jsonify({'accepted': True}), 202
 
 
 @auth_bp.route('/api/auth/login', methods=['POST'])
@@ -93,8 +176,13 @@ def login():
     """
     data = request.get_json(silent=True) or {}
 
-    email = (data.get('email') or '').strip()
+    email = _normalize_email(data.get('email'))
     password = data.get('password') or ''
+
+    retry_after = _rate_limit_retry_after('login', email)
+    if retry_after is not None:
+        _log_auth_event('login', email, 'rate_limited', retry_after)
+        return _rate_limited_response(retry_after)
 
     if not email or not password:
         return jsonify({'error': 'Email and password are required'}), 400
@@ -102,8 +190,11 @@ def login():
     user = get_user_by_email(email)
     if user is None or not verify_password(user, password):
         # Deliberately vague to avoid user enumeration
+        _record_auth_failure('login', email)
+        _log_auth_event('login', email, 'failed')
         return jsonify({'error': 'Invalid email or password'}), 401
 
+    _clear_auth_failures('login', email)
     access_token = create_access_token(user['id'])
     refresh_token = create_refresh_token(user['id'])
 

--- a/server/security.py
+++ b/server/security.py
@@ -4,6 +4,7 @@ Security middleware: CSRF origin check, session token auth, security headers.
 Copyright (c) 2026 Divergent Health Technologies
 """
 
+import os
 import secrets
 from urllib.parse import urlparse
 
@@ -30,6 +31,8 @@ def _is_test_mode_request():
     on the page load signals test mode. For direct API requests (Playwright's
     request fixture), we check for the X-Test-Mode header instead.
     """
+    if os.environ.get('FLASK_ENV') != 'test':
+        return False
     if request.args.get('test') is not None:
         return True
     return request.headers.get('X-Test-Mode') == '1'

--- a/server/sync/delta.py
+++ b/server/sync/delta.py
@@ -202,7 +202,7 @@ def get_max_sync_version(db, user_id=None):
 def _next_sync_version(db, table, key, device_id, user_id):
     """Allocate the next sync_version for a user-scoped record."""
     now = int(time.time())
-    new_version = get_max_sync_version(db) + 1
+    new_version = get_max_sync_version(db, user_id) + 1
     db.execute(
         """
         INSERT INTO sync_server_versions (

--- a/tests/auth-security.spec.js
+++ b/tests/auth-security.spec.js
@@ -52,6 +52,10 @@ function uniqueStudyUid() {
     return `test-auth-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+function uniqueEmail() {
+    return `auth-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
 function sameOriginHeaders(extra = {}) {
     return {
         Origin: BASE_URL,
@@ -232,6 +236,13 @@ test.describe('Test Suite 38: Test-Mode Bypass', () => {
         const response = await request.get(`${BASE_URL}/api/test-data/studies`);
         // 200 if test data exists, but should not be 401 regardless
         expect(response.status()).not.toBe(401);
+    });
+
+    test('X-Test-Mode bypasses PHI auth only in the explicit test environment', async ({ request }) => {
+        const response = await request.get(`${BASE_URL}/api/notes/`, {
+            headers: { 'X-Test-Mode': '1' },
+        });
+        expect(response.status()).toBe(200);
     });
 });
 
@@ -490,5 +501,57 @@ test.describe('Test Suite 42: Static File Serving - No Auth Required', () => {
 
         const contentType = response.headers()['content-type'] || '';
         expect(contentType).toContain('text/html');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test Suite 43: Auth Endpoint Hardening
+// ---------------------------------------------------------------------------
+
+test.describe('Test Suite 43: Auth Endpoint Hardening', () => {
+    test('login is rate limited after repeated failures for the same email', async ({ request }) => {
+        const email = uniqueEmail();
+        const headers = sameOriginHeaders();
+
+        for (let attempt = 1; attempt <= 5; attempt += 1) {
+            const response = await request.post(`${BASE_URL}/api/auth/login`, {
+                headers,
+                data: { email, password: 'wrong-password' },
+            });
+            expect(response.status()).toBe(401);
+        }
+
+        const limited = await request.post(`${BASE_URL}/api/auth/login`, {
+            headers,
+            data: { email, password: 'wrong-password' },
+        });
+        expect(limited.status()).toBe(429);
+        expect(Number(limited.headers()['retry-after'] || '0')).toBeGreaterThan(0);
+    });
+
+    test('signup returns the same accepted response for new and duplicate emails', async ({ request }) => {
+        const email = uniqueEmail();
+        const payload = {
+            email,
+            password: 'TestPassword123!',
+            name: 'Auth Security Test',
+        };
+        const headers = sameOriginHeaders();
+
+        const first = await request.post(`${BASE_URL}/api/auth/signup`, {
+            headers,
+            data: payload,
+        });
+        const second = await request.post(`${BASE_URL}/api/auth/signup`, {
+            headers,
+            data: payload,
+        });
+        const firstBody = await first.json();
+        const secondBody = await second.json();
+
+        expect(first.status()).toBe(202);
+        expect(second.status()).toBe(202);
+        expect(firstBody).toEqual({ accepted: true });
+        expect(secondBody).toEqual({ accepted: true });
     });
 });

--- a/tests/e2e-sync.spec.js
+++ b/tests/e2e-sync.spec.js
@@ -127,7 +127,7 @@ async function insertReportWithFile(request, token, deviceId, cursor, fileConten
 // ---------------------------------------------------------------------------
 
 test.describe('E2E Authentication Flow', () => {
-    test('signup creates account and returns tokens', async ({ request }) => {
+    test('signup creates account and allows a subsequent login', async ({ request }) => {
         const email = uniqueEmail();
         const password = 'SecurePass123!';
         const name = 'E2E Test User';
@@ -136,7 +136,7 @@ test.describe('E2E Authentication Flow', () => {
         const signupResponse = await request.post(`${BASE_URL}/api/auth/signup`, {
             data: { email, password, name },
         });
-        expect(signupResponse.status()).toBe(201);
+        expect(signupResponse.status()).toBe(202);
 
         // Verify we can now log in with those credentials
         const loginResponse = await request.post(`${BASE_URL}/api/auth/login`, {

--- a/tests/sync-engine.spec.js
+++ b/tests/sync-engine.spec.js
@@ -351,9 +351,7 @@ test.describe('Sync Engine', () => {
         });
     });
 
-    test('remote comment updates preserve created time instead of overwriting it with updated_at', async ({
-        page,
-    }) => {
+    test('remote comment updates preserve created time instead of overwriting it with updated_at', async ({ page }) => {
         await setupSyncEnginePage(page);
 
         const comment = await page.evaluate(() => {

--- a/tests/sync-engine.spec.js
+++ b/tests/sync-engine.spec.js
@@ -5,6 +5,42 @@ const { test, expect } = require('@playwright/test');
 
 const BASE_URL = 'http://127.0.0.1:5001/?nolib';
 
+async function setupSyncEnginePage(page) {
+    await page.goto(BASE_URL);
+    await page.waitForFunction(() => typeof window._SyncEngine?.SyncEngine === 'function', null, {
+        timeout: 10000,
+    });
+
+    await page.evaluate(() => {
+        window.__SYNC_TEST_STORE = { studies: {} };
+
+        function ensureStudy(store, studyUid) {
+            if (!store.studies[studyUid]) {
+                store.studies[studyUid] = {
+                    description: '',
+                    comments: [],
+                    reports: [],
+                    series: {},
+                };
+            }
+            return store.studies[studyUid];
+        }
+
+        window._NotesInternals = {
+            loadStore() {
+                return structuredClone(window.__SYNC_TEST_STORE);
+            },
+            saveStore(store) {
+                window.__SYNC_TEST_STORE = structuredClone(store);
+            },
+            ensureStudy,
+            normalizeReportId(id) {
+                return String(id || '').trim();
+            },
+        };
+    });
+}
+
 test.describe('Sync Engine', () => {
     test('successful sync updates comment sync_version and emits lifecycle events', async ({ page }) => {
         await page.goto(BASE_URL);
@@ -244,5 +280,125 @@ test.describe('Sync Engine', () => {
             type: 'png',
             size: 84,
         });
+    });
+
+    test('remote report inserts do not create phantom studies', async ({ page }) => {
+        await setupSyncEnginePage(page);
+
+        const store = await page.evaluate(() => {
+            const engine = new window._SyncEngine.SyncEngine({
+                getAccessToken: async () => 'valid-access-token',
+                onAuthRequired: () => {},
+            });
+            engine._applyRemoteData(
+                'reports',
+                'remote-report-1',
+                {
+                    study_uid: 'missing-study',
+                    name: 'Remote report',
+                    type: 'pdf',
+                    size: 1024,
+                },
+                7,
+            );
+            return window.__SYNC_TEST_STORE;
+        });
+
+        expect(store).toEqual({ studies: {} });
+    });
+
+    test('remote report inserts still apply when the study already exists', async ({ page }) => {
+        await setupSyncEnginePage(page);
+
+        const reports = await page.evaluate(() => {
+            window.__SYNC_TEST_STORE = {
+                studies: {
+                    'known-study': {
+                        description: '',
+                        comments: [],
+                        reports: [],
+                        series: {},
+                    },
+                },
+            };
+
+            const engine = new window._SyncEngine.SyncEngine({
+                getAccessToken: async () => 'valid-access-token',
+                onAuthRequired: () => {},
+            });
+            engine._applyRemoteData(
+                'reports',
+                'remote-report-2',
+                {
+                    study_uid: 'known-study',
+                    name: 'Known study report',
+                    type: 'pdf',
+                    size: 2048,
+                },
+                9,
+            );
+
+            return window.__SYNC_TEST_STORE.studies['known-study'].reports;
+        });
+
+        expect(reports).toHaveLength(1);
+        expect(reports[0]).toMatchObject({
+            id: 'remote-report-2',
+            name: 'Known study report',
+            type: 'pdf',
+            size: 2048,
+            sync_version: 9,
+        });
+    });
+
+    test('remote comment updates preserve created time instead of overwriting it with updated_at', async ({
+        page,
+    }) => {
+        await setupSyncEnginePage(page);
+
+        const comment = await page.evaluate(() => {
+            window.__SYNC_TEST_STORE = {
+                studies: {
+                    'study-1': {
+                        description: '',
+                        comments: [
+                            {
+                                id: 'comment-1',
+                                record_uuid: 'comment-1',
+                                text: 'Original',
+                                time: 111,
+                                created_at: 111,
+                                updated_at: 111,
+                                sync_version: 1,
+                            },
+                        ],
+                        reports: [],
+                        series: {},
+                    },
+                },
+            };
+
+            const engine = new window._SyncEngine.SyncEngine({
+                getAccessToken: async () => 'valid-access-token',
+                onAuthRequired: () => {},
+            });
+            engine._applyRemoteData(
+                'comments',
+                'comment-1',
+                {
+                    study_uid: 'study-1',
+                    text: 'Edited remotely',
+                    created_at: 111,
+                    updated_at: 222,
+                },
+                5,
+            );
+
+            return window.__SYNC_TEST_STORE.studies['study-1'].comments[0];
+        });
+
+        expect(comment.time).toBe(111);
+        expect(comment.updated_at).toBe(222);
+        expect(comment.sync_version).toBe(5);
     });
 });

--- a/tests/sync-helpers.js
+++ b/tests/sync-helpers.js
@@ -65,7 +65,7 @@ async function createTestUser(request, baseUrl = BASE_URL) {
     const response = await request.post(`${baseUrl}/api/auth/signup`, {
         data: { email, password, name },
     });
-    expect(response.status()).toBe(201);
+    expect(response.status()).toBe(202);
 
     return { email, password, name };
 }

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -820,6 +820,26 @@ test.describe('Sync Cross-User Isolation', () => {
         expect(userAStudyNote?.data?.description).toBe('User A private note');
         expect(userBStudyNote?.data?.description).toBe('User B private note');
     });
+
+    test('sync versions are allocated independently per user', async ({ request }) => {
+        const userA = await setupSyncUser(request);
+        const userB = await setupSyncUser(request);
+
+        const changeA = commentInsertChange({ text: 'User A first change' });
+        const changeB = commentInsertChange({ text: 'User B first change' });
+
+        const resultA = await syncAndExpectOk(
+            request, BASE_URL, userA.access_token, userA.device_id, null, [changeA]
+        );
+        const resultB = await syncAndExpectOk(
+            request, BASE_URL, userB.access_token, userB.device_id, null, [changeB]
+        );
+
+        expect(resultA.accepted).toHaveLength(1);
+        expect(resultB.accepted).toHaveLength(1);
+        expect(resultA.accepted[0].sync_version).toBe(1);
+        expect(resultB.accepted[0].sync_version).toBe(1);
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -828,12 +828,8 @@ test.describe('Sync Cross-User Isolation', () => {
         const changeA = commentInsertChange({ text: 'User A first change' });
         const changeB = commentInsertChange({ text: 'User B first change' });
 
-        const resultA = await syncAndExpectOk(
-            request, BASE_URL, userA.access_token, userA.device_id, null, [changeA]
-        );
-        const resultB = await syncAndExpectOk(
-            request, BASE_URL, userB.access_token, userB.device_id, null, [changeB]
-        );
+        const resultA = await syncAndExpectOk(request, BASE_URL, userA.access_token, userA.device_id, null, [changeA]);
+        const resultB = await syncAndExpectOk(request, BASE_URL, userB.access_token, userB.device_id, null, [changeB]);
 
         expect(resultA.accepted).toHaveLength(1);
         expect(resultB.accepted).toHaveLength(1);


### PR DESCRIPTION
## Summary
- gate the legacy test-mode auth bypass behind `FLASK_ENV=test`, add signup/login throttling, and normalize signup responses to avoid account enumeration
- scope sync version allocation per user and fix remote sync application regressions for report inserts and comment timestamps
- restore desktop persistence command registration in the Tauri app and add regression coverage for the auth and sync fixes

## Testing
- cargo check --manifest-path desktop/src-tauri/Cargo.toml
- NODE_PATH="/Users/gabriel/claude 0/dicom-viewer/node_modules" "/Users/gabriel/claude 0/dicom-viewer/node_modules/.bin/playwright" test tests/auth-security.spec.js tests/sync-protocol.spec.js tests/sync-engine.spec.js