### PR TITLE
BUG-009: best-effort macOS icon refresh after updater installs

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -276,8 +276,7 @@ fn write_macos_icon_refresh_attempt_state(
     path: &std::path::Path,
     state: &MacosIconRefreshAttemptState,
 ) -> std::io::Result<()> {
-    let json = serde_json::to_vec(state)
-        .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?;
+    let json = serde_json::to_vec(state).map_err(std::io::Error::other)?;
     std::fs::write(path, json)
 }
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6,7 +6,7 @@ mod persistence;
 mod scan;
 mod secure_store;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{
     menu::{AboutMetadata, Menu, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder},
     AppHandle, Emitter, Manager, Runtime, State,
@@ -250,6 +250,38 @@ fn desktop_db_migrations() -> Vec<Migration> {
 }
 
 #[cfg(target_os = "macos")]
+const MACOS_ICON_REFRESH_MAX_ATTEMPTS: u32 = 3;
+#[cfg(target_os = "macos")]
+const MACOS_ICON_REFRESH_VERSION_FILE: &str = ".last_lsregister_version";
+#[cfg(target_os = "macos")]
+const MACOS_ICON_REFRESH_ATTEMPT_FILE: &str = ".lsregister_attempt_state.json";
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct MacosIconRefreshAttemptState {
+    version: String,
+    attempts: u32,
+}
+
+#[cfg(target_os = "macos")]
+fn read_macos_icon_refresh_attempt_state(path: &std::path::Path) -> MacosIconRefreshAttemptState {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|json| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(target_os = "macos")]
+fn write_macos_icon_refresh_attempt_state(
+    path: &std::path::Path,
+    state: &MacosIconRefreshAttemptState,
+) -> std::io::Result<()> {
+    let json = serde_json::to_vec(state)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?;
+    std::fs::write(path, json)
+}
+
+#[cfg(target_os = "macos")]
 fn maybe_refresh_macos_icon_registration<R: Runtime, M: Manager<R>>(manager: &M) {
     let current_version = manager.package_info().version.to_string();
     let app_data = match manager.path().app_data_dir() {
@@ -261,11 +293,28 @@ fn maybe_refresh_macos_icon_registration<R: Runtime, M: Manager<R>>(manager: &M)
             return;
         }
     };
-    let version_file = app_data.join(".last_lsregister_version");
+    let version_file = app_data.join(MACOS_ICON_REFRESH_VERSION_FILE);
     let last_version = std::fs::read_to_string(&version_file).unwrap_or_default();
     if last_version.trim() == current_version {
         return;
     }
+    let attempt_file = app_data.join(MACOS_ICON_REFRESH_ATTEMPT_FILE);
+    let attempt_state = read_macos_icon_refresh_attempt_state(&attempt_file);
+    if attempt_state.version == current_version
+        && attempt_state.attempts >= MACOS_ICON_REFRESH_MAX_ATTEMPTS
+    {
+        eprintln!(
+            "[desktop-updater] BUG-009: skipping lsregister after {} failed attempts for version {}",
+            attempt_state.attempts,
+            current_version
+        );
+        return;
+    }
+    let next_attempt = if attempt_state.version == current_version {
+        attempt_state.attempts.saturating_add(1)
+    } else {
+        1
+    };
 
     let exe = match std::env::current_exe() {
         Ok(path) => path,
@@ -295,7 +344,24 @@ fn maybe_refresh_macos_icon_registration<R: Runtime, M: Manager<R>>(manager: &M)
     // BUG-009: Best-effort workaround for stale macOS app icons after updater installs.
     // `lsregister -f` re-registers the bundle with LaunchServices, which may prompt
     // Icon Services to re-read the .icns after a version change. This is not a
-    // guaranteed cache flush, so we only run once per version and log failures.
+    // guaranteed cache flush, so we run it in the background with a per-version
+    // retry cap and persist success only after the command completes.
+    if let Err(error) = std::fs::create_dir_all(&app_data) {
+        eprintln!(
+            "[desktop-updater] BUG-009: unable to create app data dir for retry state: {error}"
+        );
+    } else {
+        let next_state = MacosIconRefreshAttemptState {
+            version: current_version.clone(),
+            attempts: next_attempt,
+        };
+        if let Err(error) = write_macos_icon_refresh_attempt_state(&attempt_file, &next_state) {
+            eprintln!(
+                "[desktop-updater] BUG-009: unable to persist lsregister retry state: {error}"
+            );
+        }
+    }
+
     let candidates = [
         "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister",
         "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
@@ -304,39 +370,72 @@ fn maybe_refresh_macos_icon_registration<R: Runtime, M: Manager<R>>(manager: &M)
         .into_iter()
         .find(|path| std::path::Path::new(path).exists())
     else {
-        eprintln!("[desktop-updater] BUG-009: lsregister binary not found");
+        eprintln!(
+            "[desktop-updater] BUG-009: lsregister binary not found on attempt {} of {}",
+            next_attempt, MACOS_ICON_REFRESH_MAX_ATTEMPTS
+        );
         return;
     };
 
-    match std::process::Command::new(lsregister)
-        .arg("-f")
-        .arg(bundle)
-        .output()
-    {
-        Ok(output) if output.status.success() => {
-            eprintln!(
-                "[desktop-updater] BUG-009: lsregister -f succeeded for {}",
-                bundle.display()
-            );
-            let _ = std::fs::create_dir_all(&app_data);
-            if let Err(error) = std::fs::write(&version_file, &current_version) {
-                eprintln!(
-                    "[desktop-updater] BUG-009: lsregister succeeded but failed to persist version gate: {error}"
-                );
+    let app_data = app_data.clone();
+    let attempt_file = attempt_file.clone();
+    let bundle = bundle.to_path_buf();
+    let current_version = current_version.clone();
+    let lsregister = String::from(lsregister);
+    let version_file = version_file.clone();
+
+    if let Err(error) = std::thread::Builder::new()
+        .name(String::from("macos-icon-refresh"))
+        .spawn(move || {
+            match std::process::Command::new(&lsregister)
+                .arg("-f")
+                .arg(&bundle)
+                .output()
+            {
+                Ok(output) if output.status.success() => {
+                    eprintln!(
+                        "[desktop-updater] BUG-009: lsregister -f succeeded for {}",
+                        bundle.display()
+                    );
+                    if let Err(error) = std::fs::create_dir_all(&app_data) {
+                        eprintln!(
+                            "[desktop-updater] BUG-009: unable to create app data dir after lsregister success: {error}"
+                        );
+                        return;
+                    }
+                    if let Err(error) = std::fs::write(&version_file, &current_version) {
+                        eprintln!(
+                            "[desktop-updater] BUG-009: lsregister succeeded but failed to persist version gate: {error}"
+                        );
+                        return;
+                    }
+                    let _ = std::fs::remove_file(&attempt_file);
+                }
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    eprintln!(
+                        "[desktop-updater] BUG-009: lsregister -f attempt {} of {} exited {} for {}: {}",
+                        next_attempt,
+                        MACOS_ICON_REFRESH_MAX_ATTEMPTS,
+                        output.status,
+                        bundle.display(),
+                        stderr.trim()
+                    );
+                }
+                Err(error) => {
+                    eprintln!(
+                        "[desktop-updater] BUG-009: failed to run lsregister -f attempt {} of {}: {}",
+                        next_attempt,
+                        MACOS_ICON_REFRESH_MAX_ATTEMPTS,
+                        error
+                    );
+                }
             }
-        }
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!(
-                "[desktop-updater] BUG-009: lsregister -f exited {} for {}: {}",
-                output.status,
-                bundle.display(),
-                stderr.trim()
-            );
-        }
-        Err(error) => {
-            eprintln!("[desktop-updater] BUG-009: failed to run lsregister -f: {error}");
-        }
+        })
+    {
+        eprintln!(
+            "[desktop-updater] BUG-009: unable to spawn background lsregister thread: {error}"
+        );
     }
 }
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -249,6 +249,97 @@ fn desktop_db_migrations() -> Vec<Migration> {
     ]
 }
 
+#[cfg(target_os = "macos")]
+fn maybe_refresh_macos_icon_registration<R: Runtime, M: Manager<R>>(manager: &M) {
+    let current_version = manager.package_info().version.to_string();
+    let app_data = match manager.path().app_data_dir() {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!(
+                "[desktop-updater] BUG-009: unable to resolve app data dir for icon refresh: {error}"
+            );
+            return;
+        }
+    };
+    let version_file = app_data.join(".last_lsregister_version");
+    let last_version = std::fs::read_to_string(&version_file).unwrap_or_default();
+    if last_version.trim() == current_version {
+        return;
+    }
+
+    let exe = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!(
+                "[desktop-updater] BUG-009: unable to resolve current executable for icon refresh: {error}"
+            );
+            return;
+        }
+    };
+    let Some(bundle) = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+    else {
+        eprintln!(
+            "[desktop-updater] BUG-009: unable to resolve .app bundle from executable path {}",
+            exe.display()
+        );
+        return;
+    };
+
+    if bundle.extension().and_then(|ext| ext.to_str()) != Some("app") || !bundle.is_dir() {
+        return;
+    }
+
+    // BUG-009: Best-effort workaround for stale macOS app icons after updater installs.
+    // `lsregister -f` re-registers the bundle with LaunchServices, which may prompt
+    // Icon Services to re-read the .icns after a version change. This is not a
+    // guaranteed cache flush, so we only run once per version and log failures.
+    let candidates = [
+        "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister",
+        "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
+    ];
+    let Some(lsregister) = candidates
+        .into_iter()
+        .find(|path| std::path::Path::new(path).exists())
+    else {
+        eprintln!("[desktop-updater] BUG-009: lsregister binary not found");
+        return;
+    };
+
+    match std::process::Command::new(lsregister)
+        .arg("-f")
+        .arg(bundle)
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            eprintln!(
+                "[desktop-updater] BUG-009: lsregister -f succeeded for {}",
+                bundle.display()
+            );
+            let _ = std::fs::create_dir_all(&app_data);
+            if let Err(error) = std::fs::write(&version_file, &current_version) {
+                eprintln!(
+                    "[desktop-updater] BUG-009: lsregister succeeded but failed to persist version gate: {error}"
+                );
+            }
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!(
+                "[desktop-updater] BUG-009: lsregister -f exited {} for {}: {}",
+                output.status,
+                bundle.display(),
+                stderr.trim()
+            );
+        }
+        Err(error) => {
+            eprintln!("[desktop-updater] BUG-009: failed to run lsregister -f: {error}");
+        }
+    }
+}
+
 fn main() {
     let debug_settings = parse_debug_settings();
     if debug_settings.decode_mode != "auto"
@@ -288,6 +379,9 @@ fn main() {
                     }
                 }
             }
+
+            #[cfg(target_os = "macos")]
+            maybe_refresh_macos_icon_registration(app);
 
             Ok(())
         })

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -20,15 +20,51 @@ Known issues, bugs, and their resolution status.
 | **Priority** | Medium |
 | **Found** | 2026-04-07 |
 | **Resolved** | 2026-04-08 |
-| **Root Cause** | macOS Icon Services caches rendered bitmaps separately from LaunchServices metadata. Tauri updater currently replaces the bundle and runs `touch`, which does not reliably refresh the rendered icon cache. |
-| **Fix** | Best-effort interim fix: run `lsregister -f` once per app version at startup, gated to packaged `.app` bundles, and retry on the next launch if the command fails. |
-| **Follow-up** | Replace the `lsregister` shell-out with `LSRegisterURL` FFI so the app uses the public CoreServices API directly. |
-| **Verification** | Validated with a real packaged in-app update from a disposable `0.3.0` QA app (amber `A` icon) to `0.3.1` (blue `B` icon) over an HTTPS updater feed. Finder showed the new icon after the updated app launched, `.last_lsregister_version` advanced to `0.3.1`, and the marker timestamp stayed unchanged on the following launch. |
-| **Workaround** | `lsregister -f /Applications/myradone.app && killall Finder && killall Dock` |
+| **PR** | #73 |
 
-**Notes:**
-- The startup workaround skips dev-mode binaries automatically because it only runs for resolved `.app` bundle paths.
-- `lsregister -f` is the strongest available best-effort signal today, but it still cannot guarantee an immediate Icon Services bitmap refresh on every macOS version.
+**How Encountered:**
+After a packaged macOS updater install changed the app icon, Finder and the Dock could
+continue showing the stale rendered bitmap even though the updated `.icns` was already
+present inside the new app bundle.
+
+**Root Cause:**
+macOS Icon Services caches rendered bitmaps separately from LaunchServices metadata.
+Tauri's updater currently replaces the bundle and runs `touch`, which updates the
+bundle timestamp but does not reliably invalidate Icon Services' cached icon bitmap.
+
+**Solution:**
+- Added a macOS-only startup helper in `desktop/src-tauri/src/main.rs` that resolves
+  packaged `.app` bundles, then schedules `lsregister -f` on a background thread so
+  the app window is not blocked during launch.
+- Kept the existing per-version success gate in `$APPDATA/.last_lsregister_version`.
+- Added a per-version retry cap in `$APPDATA/.lsregister_attempt_state.json` so a
+  future permanent failure will stop retrying after three attempts.
+
+**Why This Solution:**
+Alternatives considered:
+- *Run `lsregister` inline during startup* - Rejected; it fixes the cache issue but can
+  stall first launch after an update.
+- *Retry on every launch until success* - Rejected; a future macOS restriction could
+  turn that into unbounded startup work forever.
+
+Chose a background best-effort refresh with capped retries because it preserves the
+validated icon fix while keeping launch responsive and failure mode bounded.
+
+**Verification:**
+- Validated with a real packaged in-app update from a disposable `0.3.0` QA app
+  (amber `A` icon) to `0.3.1` (blue `B` icon) over an HTTPS updater feed.
+- Finder showed the new icon after the updated app launched.
+- `.last_lsregister_version` advanced to `0.3.1`.
+- The version-gate marker timestamp stayed unchanged on the following launch, proving
+  the helper did not re-run after a successful refresh.
+
+**Follow-up:**
+- Replace the `lsregister` shell-out with `LSRegisterURL` FFI so the app uses the
+  public CoreServices API directly.
+
+**Files Changed:**
+- `desktop/src-tauri/src/main.rs`
+- `docs/BUGS.md`
 
 ### BUG-008: Desktop native decode bridge crashed on unaligned typed-array payloads
 

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -6,26 +6,29 @@ Known issues, bugs, and their resolution status.
 
 ## Open Bugs
 
+*No open bugs currently tracked.*
+
+---
+
+## Resolved Bugs
+
 ### BUG-009: macOS dock icon not updated after app update
 
 | Field | Value |
 |-------|-------|
-| **Status** | Fix implemented, awaiting updater QA |
+| **Status** | Resolved |
 | **Priority** | Medium |
 | **Found** | 2026-04-07 |
+| **Resolved** | 2026-04-08 |
 | **Root Cause** | macOS Icon Services caches rendered bitmaps separately from LaunchServices metadata. Tauri updater currently replaces the bundle and runs `touch`, which does not reliably refresh the rendered icon cache. |
 | **Fix** | Best-effort interim fix: run `lsregister -f` once per app version at startup, gated to packaged `.app` bundles, and retry on the next launch if the command fails. |
 | **Follow-up** | Replace the `lsregister` shell-out with `LSRegisterURL` FFI so the app uses the public CoreServices API directly. |
-| **Verification needed** | Test with the real in-app updater flow, then confirm the icon refreshes after restart and that the version gate prevents repeated runs on later launches. |
+| **Verification** | Validated with a real packaged in-app update from a disposable `0.3.0` QA app (amber `A` icon) to `0.3.1` (blue `B` icon) over an HTTPS updater feed. Finder showed the new icon after the updated app launched, `.last_lsregister_version` advanced to `0.3.1`, and the marker timestamp stayed unchanged on the following launch. |
 | **Workaround** | `lsregister -f /Applications/myradone.app && killall Finder && killall Dock` |
 
 **Notes:**
 - The startup workaround skips dev-mode binaries automatically because it only runs for resolved `.app` bundle paths.
 - `lsregister -f` is the strongest available best-effort signal today, but it still cannot guarantee an immediate Icon Services bitmap refresh on every macOS version.
-
----
-
-## Resolved Bugs
 
 ### BUG-008: Desktop native decode bridge crashed on unaligned typed-array payloads
 

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -6,7 +6,22 @@ Known issues, bugs, and their resolution status.
 
 ## Open Bugs
 
-*No open bugs currently tracked.*
+### BUG-009: macOS dock icon not updated after app update
+
+| Field | Value |
+|-------|-------|
+| **Status** | Fix implemented, awaiting updater QA |
+| **Priority** | Medium |
+| **Found** | 2026-04-07 |
+| **Root Cause** | macOS Icon Services caches rendered bitmaps separately from LaunchServices metadata. Tauri updater currently replaces the bundle and runs `touch`, which does not reliably refresh the rendered icon cache. |
+| **Fix** | Best-effort interim fix: run `lsregister -f` once per app version at startup, gated to packaged `.app` bundles, and retry on the next launch if the command fails. |
+| **Follow-up** | Replace the `lsregister` shell-out with `LSRegisterURL` FFI so the app uses the public CoreServices API directly. |
+| **Verification needed** | Test with the real in-app updater flow, then confirm the icon refreshes after restart and that the version gate prevents repeated runs on later launches. |
+| **Workaround** | `lsregister -f /Applications/myradone.app && killall Finder && killall Dock` |
+
+**Notes:**
+- The startup workaround skips dev-mode binaries automatically because it only runs for resolved `.app` bundle paths.
+- `lsregister -f` is the strongest available best-effort signal today, but it still cannot guarantee an immediate Icon Services bitmap refresh on every macOS version.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a macOS-only startup helper that runs `lsregister -f` once per app version for packaged `.app` bundles
- persist a version gate so the workaround retries only after failed runs or future updates
- document BUG-009 as an open bug with the interim workaround and remaining updater QA

## Verification
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`

## Remaining QA
- verify with the real in-app updater flow on macOS
- confirm the icon refreshes after restart and the version gate prevents repeated runs on later launches
