### PR TITLE
Add email signup worker and landing form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,15 @@ data/
 # Environment variables
 .env
 .env.local
+.dev.vars
+.dev.vars.*
 
 # Build outputs
 dist/
 build/
 desktop/src-tauri/target/
 desktop/src-tauri/gen/
+.wrangler/
 
 # Testing
 .coverage

--- a/design/brand/landing.html
+++ b/design/brand/landing.html
@@ -24,7 +24,7 @@
     <script>
         window.MYRADONE_SIGNUP_CONFIG = {
             apiEndpoint: 'https://api.myradone.com/subscribe',
-            turnstileSiteKey: '1x00000000000000000000AA'
+            turnstileSiteKey: '0x4AAAAAAC2XG7qabjWJnaYQ'
         };
 
         window.onSignupTurnstileLoad = function () {

--- a/design/brand/landing.html
+++ b/design/brand/landing.html
@@ -19,7 +19,23 @@
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://challenges.cloudflare.com">
     <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@200;300;400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        window.MYRADONE_SIGNUP_CONFIG = {
+            apiEndpoint: 'https://api.myradone.com/subscribe',
+            turnstileSiteKey: '1x00000000000000000000AA'
+        };
+
+        window.onSignupTurnstileLoad = function () {
+            window.dispatchEvent(new Event('signup-turnstile-ready'));
+        };
+    </script>
+    <script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onSignupTurnstileLoad"
+        async
+        defer
+    ></script>
 
     <!-- Copyright (c) 2026 Divergent Health Technologies -->
     <style>
@@ -236,6 +252,126 @@
             transform: translateX(3px);
         }
 
+        .signup-section {
+            margin: 2.8rem auto 0;
+            padding-top: 2.25rem;
+            max-width: 560px;
+            border-top: 1px solid rgba(61, 58, 54, 0.08);
+            opacity: 0;
+            animation: fadeIn 1s ease 1.95s forwards;
+        }
+
+        .signup-eyebrow {
+            margin-bottom: 0.7rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+            color: var(--accent);
+        }
+
+        .signup-copy {
+            margin: 0 auto 1.35rem;
+            max-width: 480px;
+            color: var(--text-dim);
+            font-size: 0.95rem;
+        }
+
+        .signup-form {
+            display: grid;
+            gap: 0.95rem;
+        }
+
+        .signup-row {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .signup-row input {
+            width: 100%;
+            min-height: 3rem;
+            padding: 0.82rem 1rem;
+            border: 1px solid rgba(61, 58, 54, 0.14);
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.82);
+            color: var(--text);
+            font: inherit;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .signup-row input:focus {
+            outline: none;
+            border-color: rgba(240, 140, 0, 0.45);
+            box-shadow: 0 0 0 4px rgba(240, 140, 0, 0.12);
+        }
+
+        .signup-row button {
+            min-height: 3rem;
+            padding: 0.82rem 1.25rem;
+            border: 0;
+            border-radius: 12px;
+            background: var(--accent);
+            color: #fff8f3;
+            font: inherit;
+            font-weight: 500;
+            letter-spacing: 0.01em;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+        }
+
+        .signup-row button:hover:not(:disabled) {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(240, 140, 0, 0.22);
+        }
+
+        .signup-row button:disabled {
+            cursor: wait;
+            opacity: 0.72;
+        }
+
+        .signup-consent {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 0.75rem;
+            align-items: start;
+            text-align: left;
+            color: var(--text-dim);
+            font-size: 0.82rem;
+            line-height: 1.55;
+        }
+
+        .signup-consent input {
+            margin-top: 0.18rem;
+            accent-color: var(--accent);
+        }
+
+        .signup-consent a {
+            color: var(--text);
+            text-underline-offset: 0.16em;
+        }
+
+        .signup-turnstile {
+            display: flex;
+            justify-content: center;
+        }
+
+        .signup-status {
+            min-height: 1.5rem;
+            margin-top: 0.15rem;
+            font-size: 0.86rem;
+            color: var(--text-dim);
+        }
+
+        .signup-status.success {
+            color: #2d6a4f;
+        }
+
+        .signup-status.error {
+            color: #a15400;
+        }
+
         /* Footer */
         footer {
             padding: 2.5rem 2rem;
@@ -295,6 +431,19 @@
                 font-size: 0.95rem;
                 margin-bottom: 3rem;
             }
+
+            .signup-section {
+                margin-top: 2.35rem;
+                padding-top: 1.85rem;
+            }
+
+            .signup-row {
+                grid-template-columns: 1fr;
+            }
+
+            .signup-row button {
+                width: 100%;
+            }
         }
     </style>
 </head>
@@ -330,11 +479,171 @@
                     Try the viewer <span>&rarr;</span>
                 </a>
             </div>
+
+            <div class="signup-section" aria-labelledby="signupTitle">
+                <p class="signup-eyebrow">myRadOne Updates</p>
+                <p class="signup-copy" id="signupTitle">
+                    Get launch notes, product updates, and early access news without waiting for the full release.
+                </p>
+
+                <form class="signup-form" id="signupForm">
+                    <div class="signup-row">
+                        <input
+                            type="email"
+                            id="signupEmail"
+                            name="email"
+                            placeholder="Your email"
+                            autocomplete="email"
+                            required
+                        >
+                        <button type="submit" id="signupButton">Stay updated</button>
+                    </div>
+
+                    <label class="signup-consent" for="signupConsent">
+                        <input type="checkbox" id="signupConsent" required>
+                        <span>
+                            I'd like to receive periodic emails about myRadOne updates and developments. Unsubscribe anytime.
+                            See the <a href="./privacy.html">Privacy Policy</a>.
+                        </span>
+                    </label>
+
+                    <div class="signup-turnstile" id="signupTurnstile"></div>
+                </form>
+
+                <p class="signup-status" id="signupStatus" aria-live="polite"></p>
+            </div>
         </div>
     </main>
 
     <footer>
         <p>&copy; 2026 Divergent Health Technologies</p>
     </footer>
+    <script>
+        (function () {
+            const config = window.MYRADONE_SIGNUP_CONFIG || {};
+            const form = document.getElementById('signupForm');
+            const emailInput = document.getElementById('signupEmail');
+            const consentInput = document.getElementById('signupConsent');
+            const submitButton = document.getElementById('signupButton');
+            const status = document.getElementById('signupStatus');
+            const turnstileContainer = document.getElementById('signupTurnstile');
+            const defaultTestSiteKey = '1x00000000000000000000AA';
+            let widgetId = null;
+            let turnstileToken = '';
+
+            function setStatus(message, type) {
+                status.textContent = message;
+                status.className = type ? `signup-status ${type}` : 'signup-status';
+            }
+
+            function resetTurnstile() {
+                turnstileToken = '';
+                if (widgetId !== null && window.turnstile) {
+                    window.turnstile.reset(widgetId);
+                }
+            }
+
+            function renderTurnstile() {
+                if (!window.turnstile || widgetId !== null) return;
+
+                if (!config.turnstileSiteKey) {
+                    turnstileContainer.hidden = true;
+                    submitButton.disabled = true;
+                    setStatus('Signup is not configured yet. Add a Turnstile site key to enable submissions.', 'error');
+                    return;
+                }
+
+                widgetId = window.turnstile.render('#signupTurnstile', {
+                    sitekey: config.turnstileSiteKey,
+                    theme: 'light',
+                    size: 'compact',
+                    callback: function (token) {
+                        turnstileToken = token;
+                        if (status.classList.contains('error')) {
+                            setStatus('', '');
+                        }
+                    },
+                    'expired-callback': function () {
+                        turnstileToken = '';
+                    },
+                    'error-callback': function () {
+                        turnstileToken = '';
+                        setStatus('Security check failed to load. Refresh and try again.', 'error');
+                    }
+                });
+
+                if (
+                    config.turnstileSiteKey === defaultTestSiteKey &&
+                    !['localhost', '127.0.0.1'].includes(window.location.hostname)
+                ) {
+                    console.warn('Cloudflare Turnstile is still using the test site key.');
+                }
+            }
+
+            window.addEventListener('signup-turnstile-ready', renderTurnstile);
+            if (window.turnstile) {
+                renderTurnstile();
+            }
+
+            form.addEventListener('submit', async function (event) {
+                event.preventDefault();
+                setStatus('', '');
+
+                if (!consentInput.checked) {
+                    setStatus('Please confirm that you want product updates.', 'error');
+                    consentInput.focus();
+                    return;
+                }
+
+                if (!turnstileToken && widgetId !== null && window.turnstile) {
+                    turnstileToken = window.turnstile.getResponse(widgetId);
+                }
+
+                if (!turnstileToken) {
+                    setStatus('Please complete the security check.', 'error');
+                    return;
+                }
+
+                submitButton.disabled = true;
+
+                try {
+                    const response = await fetch(config.apiEndpoint, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            email: emailInput.value,
+                            turnstileToken,
+                            source: 'landing',
+                            consentVersion: 'v1',
+                            consentAccepted: consentInput.checked
+                        })
+                    });
+
+                    const data = await response.json();
+
+                    if (!response.ok || !data.ok) {
+                        throw new Error(data.error || 'Please try again.');
+                    }
+
+                    if (data.reactivated) {
+                        setStatus("You're back on the list. We'll keep you posted.", 'success');
+                    } else if (data.already) {
+                        setStatus("You're already on the list.", 'success');
+                    } else {
+                        setStatus("Thanks. We'll be in touch.", 'success');
+                    }
+
+                    form.reset();
+                    emailInput.focus();
+                    resetTurnstile();
+                } catch (error) {
+                    setStatus(error.message || 'Something went wrong. Try again.', 'error');
+                    resetTurnstile();
+                } finally {
+                    submitButton.disabled = false;
+                }
+            });
+        }());
+    </script>
 </body>
 </html>

--- a/design/brand/privacy.html
+++ b/design/brand/privacy.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Divergent Health Technologies Privacy</title>
+    <meta name="description" content="Privacy details for Divergent Health Technologies and myRadOne launch updates.">
+    <meta name="theme-color" content="#FFF8F3">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #fff8f3;
+            --surface: rgba(255, 255, 255, 0.72);
+            --text: #3d3a36;
+            --text-dim: #6b6660;
+            --accent: #f08c00;
+            --accent-soft: rgba(240, 140, 0, 0.12);
+            --border: rgba(61, 58, 54, 0.1);
+            --serif: 'Lora', Georgia, serif;
+            --sans: 'Inter', system-ui, sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: var(--sans);
+            background:
+                radial-gradient(circle at top, rgba(240, 140, 0, 0.08), transparent 38%),
+                var(--bg);
+            color: var(--text);
+            line-height: 1.7;
+        }
+
+        main {
+            width: min(760px, calc(100vw - 2.5rem));
+            margin: 0 auto;
+            padding: 4rem 0 5rem;
+        }
+
+        .eyebrow {
+            margin: 0 0 1.2rem;
+            color: var(--accent);
+            font-size: 0.76rem;
+            font-weight: 600;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        h1 {
+            margin: 0 0 1rem;
+            font-family: var(--serif);
+            font-style: italic;
+            font-size: clamp(2rem, 4vw, 3rem);
+            font-weight: 500;
+            line-height: 1.12;
+        }
+
+        .intro,
+        .back-link {
+            color: var(--text-dim);
+        }
+
+        .back-link {
+            display: inline-flex;
+            margin-bottom: 2rem;
+            text-decoration: none;
+        }
+
+        .back-link:hover {
+            color: var(--text);
+        }
+
+        .policy-grid {
+            display: grid;
+            gap: 1rem;
+            margin-top: 2rem;
+        }
+
+        .policy-card {
+            padding: 1.35rem 1.4rem;
+            border: 1px solid var(--border);
+            background: var(--surface);
+            backdrop-filter: blur(10px);
+            border-radius: 18px;
+        }
+
+        .policy-card h2 {
+            margin: 0 0 0.55rem;
+            font-size: 1rem;
+            font-weight: 600;
+        }
+
+        .policy-card p,
+        .policy-card ul {
+            margin: 0;
+            color: var(--text-dim);
+            font-size: 0.98rem;
+        }
+
+        .policy-card ul {
+            padding-left: 1.2rem;
+        }
+
+        .policy-card strong {
+            color: var(--text);
+        }
+
+        .contact-note {
+            margin-top: 2rem;
+            padding: 1rem 1.2rem;
+            background: var(--accent-soft);
+            border-radius: 16px;
+            color: var(--text);
+        }
+
+        a {
+            color: inherit;
+        }
+
+        @media (max-width: 640px) {
+            main {
+                width: min(100vw - 1.5rem, 760px);
+                padding: 2.75rem 0 3.5rem;
+            }
+
+            .policy-card {
+                border-radius: 14px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <a class="back-link" href="./landing.html">&larr; Back to landing page</a>
+        <p class="eyebrow">Privacy</p>
+        <h1>Privacy for myRadOne launch updates</h1>
+        <p class="intro">
+            Divergent Health Technologies uses this signup form to collect launch-interest emails for myRadOne. This page covers that marketing signup flow, not the future handling of clinical imaging data.
+        </p>
+
+        <div class="policy-grid">
+            <section class="policy-card">
+                <h2>What we collect</h2>
+                <p>
+                    If you subscribe, we store your <strong>email address</strong>, the <strong>date you subscribed</strong>, the <strong>page source</strong>, and the <strong>consent text version</strong> you agreed to.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>What we do not collect here</h2>
+                <p>
+                    This signup flow is for newsletter-style updates only. We do <strong>not</strong> ask for medical images, health records, passwords, or other patient data in this form.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>How we use it</h2>
+                <p>
+                    We use your email to send occasional updates about myRadOne, product availability, and launch news. We do not sell this list to data brokers or ad networks.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>Storage and protection</h2>
+                <p>
+                    Signup records are stored in infrastructure we control on Cloudflare. The form is protected by Cloudflare Turnstile to reduce spam and automated abuse.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>Unsubscribing</h2>
+                <p>
+                    Every update email should include a way to unsubscribe. You can also request removal by emailing us directly.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>Questions</h2>
+                <ul>
+                    <li>Email: <a href="mailto:info@divergent.health">info@divergent.health</a></li>
+                    <li>Company: Divergent Health Technologies</li>
+                </ul>
+            </section>
+        </div>
+
+        <p class="contact-note">
+            If the signup copy changes later, we version that consent text in our subscriber records so we can trace which wording each subscriber agreed to.
+        </p>
+    </main>
+</body>
+</html>

--- a/docs/decisions/012-email-signup-and-contact.md
+++ b/docs/decisions/012-email-signup-and-contact.md
@@ -1,0 +1,69 @@
+# ADR 012: Email Signup and Contact Intake
+
+## Status
+
+Implemented
+
+## Context
+
+myRadOne needs a simple way to capture launch-interest emails from the public landing page without introducing a hosted form vendor or a heavier CRM stack before launch. The form collects marketing contact data, not medical images or clinical records, so the right design goal is lean ownership and clear consent rather than HIPAA-grade application complexity.
+
+The existing landing experience is a static page in this repository. That means the intake path should work with the same lightweight deployment model, fit the current brand surface, and preserve flexibility while we are still pre-launch.
+
+## Decision
+
+We will collect signup emails through a small Cloudflare Worker backed by a D1 database, with the landing page posting to `https://api.myradone.com/subscribe`.
+
+The landing page includes:
+
+- An email field
+- A required affirmative opt-in checkbox
+- A privacy-policy link
+- A Cloudflare Turnstile challenge to reduce automated abuse
+
+The Worker stores only the minimum durable data needed to manage a list responsibly:
+
+- `email`
+- `status`
+- `subscribed_at`
+- `unsubscribed_at`
+- `source`
+- `consent_version`
+
+## Alternatives Considered
+
+### Hosted form services
+
+Rejected for now. Tally, JotForm, and similar tools would get the job done quickly, but they add an extra vendor and push a core acquisition surface outside infrastructure we already control.
+
+### Direct-to-newsletter SaaS signup
+
+Rejected for now. Services like Buttondown, Beehiiv, or Kit may still be useful later for sending campaigns, but using them as the system of record now would make future data portability and consent auditing harder than necessary.
+
+### No anti-abuse layer
+
+Rejected. CORS alone does not stop direct POST spam. Turnstile provides a lightweight first line of defense without changing the owned-data model.
+
+## Design Details
+
+- The Worker lives in `workers/subscribe/` with its own `wrangler.toml`.
+- The D1 schema is managed through committed migrations rather than one-off shell commands.
+- Allowed origins are configurable, but the default list includes both `myradone.com` and `divergent.health` because the current landing artifact still uses the Divergent brand surface.
+- The Worker treats a signup for an unsubscribed address as a reactivation instead of returning a duplicate success.
+- The landing page ships with Cloudflare's visible Turnstile test site key by default so local testing works before production credentials are added.
+- A static privacy page lives next to the landing page so the consent copy points to a real document immediately.
+
+## Consequences
+
+Positive:
+
+- Full ownership of subscriber data
+- No dependency on a third-party form embed
+- Clear consent trail via `consent_version`
+- Lower spam risk than an unprotected POST endpoint
+
+Tradeoffs:
+
+- Cloudflare setup is now part of the launch checklist
+- We still need a separate outbound email system later
+- Production launch requires replacing the test Turnstile site key and configuring the Worker custom domain

--- a/tests/email-signup-worker.test.mjs
+++ b/tests/email-signup-worker.test.mjs
@@ -1,0 +1,267 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    SUBSCRIBE_PATH,
+    handleSubscribe,
+    isValidEmail,
+    normalizeEmail,
+    parseAllowedOrigins
+} from '../workers/subscribe/src/index.mjs';
+
+function createDb(initialSubscribers = []) {
+    const subscribers = new Map(
+        initialSubscribers.map((subscriber) => [subscriber.email, { ...subscriber }])
+    );
+
+    return {
+        subscribers,
+        prepare(query) {
+            return {
+                args: [],
+                bind(...args) {
+                    this.args = args;
+                    return this;
+                },
+                async first() {
+                    if (query.startsWith('SELECT status FROM subscribers')) {
+                        const email = this.args[0];
+                        const subscriber = subscribers.get(email);
+                        return subscriber ? { status: subscriber.status } : null;
+                    }
+
+                    throw new Error(`Unhandled first() query: ${query}`);
+                },
+                async run() {
+                    if (query.startsWith('INSERT INTO subscribers')) {
+                        const [email, source, consentVersion] = this.args;
+                        subscribers.set(email, {
+                            email,
+                            status: 'active',
+                            source,
+                            consentVersion,
+                            unsubscribedAt: null
+                        });
+                        return { success: true };
+                    }
+
+                    if (query.startsWith("UPDATE subscribers SET status = 'active'")) {
+                        const [source, consentVersion, email] = this.args;
+                        const subscriber = subscribers.get(email);
+                        subscribers.set(email, {
+                            ...subscriber,
+                            status: 'active',
+                            source,
+                            consentVersion,
+                            unsubscribedAt: null
+                        });
+                        return { success: true };
+                    }
+
+                    throw new Error(`Unhandled run() query: ${query}`);
+                }
+            };
+        }
+    };
+}
+
+function createEnv(overrides = {}) {
+    return {
+        ALLOWED_ORIGINS: 'https://myradone.com,https://divergent.health',
+        TURNSTILE_SECRET_KEY: 'test-secret',
+        DB: createDb(),
+        ...overrides
+    };
+}
+
+function createVerificationFetch(payload = { success: true }) {
+    return async function fetchMock(url) {
+        assert.equal(url, 'https://challenges.cloudflare.com/turnstile/v0/siteverify');
+        return new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    };
+}
+
+test('helpers normalize and validate email input', () => {
+    assert.equal(normalizeEmail('  DOCTOR@Example.COM '), 'doctor@example.com');
+    assert.equal(isValidEmail('doctor@example.com'), true);
+    assert.equal(isValidEmail('not-an-email'), false);
+    assert.deepEqual(
+        [...parseAllowedOrigins('https://myradone.com, https://divergent.health')],
+        ['https://myradone.com', 'https://divergent.health']
+    );
+});
+
+test('creates a new subscriber when the request is valid', async () => {
+    const env = createEnv();
+    const request = new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://myradone.com'
+        },
+        body: JSON.stringify({
+            email: 'doctor@example.com',
+            turnstileToken: 'token',
+            source: 'landing',
+            consentVersion: 'v1',
+            consentAccepted: true
+        })
+    });
+
+    const response = await handleSubscribe(request, env, createVerificationFetch());
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(body, { ok: true, already: false, reactivated: false });
+    assert.equal(env.DB.subscribers.get('doctor@example.com').status, 'active');
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://myradone.com');
+});
+
+test('returns already for active subscribers', async () => {
+    const env = createEnv({
+        DB: createDb([
+            {
+                email: 'doctor@example.com',
+                status: 'active',
+                source: 'landing',
+                consentVersion: 'v1'
+            }
+        ])
+    });
+
+    const request = new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            email: 'doctor@example.com',
+            turnstileToken: 'token',
+            source: 'landing',
+            consentVersion: 'v1',
+            consentAccepted: true
+        })
+    });
+
+    const response = await handleSubscribe(request, env, createVerificationFetch());
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.already, true);
+    assert.equal(body.reactivated, false);
+});
+
+test('reactivates unsubscribed subscribers', async () => {
+    const env = createEnv({
+        DB: createDb([
+            {
+                email: 'doctor@example.com',
+                status: 'unsubscribed',
+                source: 'landing',
+                consentVersion: 'v1'
+            }
+        ])
+    });
+
+    const request = new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            email: 'doctor@example.com',
+            turnstileToken: 'token',
+            source: 'demo',
+            consentVersion: 'v2',
+            consentAccepted: true
+        })
+    });
+
+    const response = await handleSubscribe(request, env, createVerificationFetch());
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.reactivated, true);
+    assert.equal(env.DB.subscribers.get('doctor@example.com').source, 'demo');
+    assert.equal(env.DB.subscribers.get('doctor@example.com').consentVersion, 'v2');
+});
+
+test('rejects missing Turnstile token, invalid email, and missing consent', async () => {
+    const env = createEnv();
+
+    const missingToken = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                email: 'doctor@example.com',
+                consentAccepted: true
+            })
+        }),
+        env,
+        createVerificationFetch()
+    );
+    assert.equal(missingToken.status, 403);
+
+    const invalidEmail = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                email: 'bad-email',
+                turnstileToken: 'token',
+                consentAccepted: true
+            })
+        }),
+        env,
+        createVerificationFetch()
+    );
+    assert.equal(invalidEmail.status, 400);
+
+    const missingConsent = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                email: 'doctor@example.com',
+                turnstileToken: 'token',
+                consentAccepted: false
+            })
+        }),
+        env,
+        createVerificationFetch()
+    );
+    assert.equal(missingConsent.status, 400);
+});
+
+test('handles CORS and disallowed origins', async () => {
+    const env = createEnv();
+
+    const preflight = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'OPTIONS',
+            headers: { Origin: 'https://divergent.health' }
+        }),
+        env,
+        createVerificationFetch()
+    );
+    assert.equal(preflight.status, 204);
+    assert.equal(preflight.headers.get('Access-Control-Allow-Origin'), 'https://divergent.health');
+
+    const blocked = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Origin: 'https://evil.example'
+            },
+            body: JSON.stringify({
+                email: 'doctor@example.com',
+                turnstileToken: 'token',
+                consentAccepted: true
+            })
+        }),
+        env,
+        createVerificationFetch()
+    );
+    assert.equal(blocked.status, 403);
+});

--- a/workers/subscribe/README.md
+++ b/workers/subscribe/README.md
@@ -1,0 +1,61 @@
+# myRadOne Signup Worker
+
+Cloudflare Worker + D1 for newsletter signup collection.
+
+## Files
+
+- `src/index.mjs` - Worker implementation
+- `migrations/0001_create_subscribers.sql` - D1 schema
+- `wrangler.toml` - Worker config
+
+## Production setup
+
+1. Create the D1 database:
+
+   ```bash
+   npx wrangler d1 create myradone-subscribers
+   ```
+
+2. Copy the returned `database_id` into `workers/subscribe/wrangler.toml`.
+
+3. Apply the migration remotely:
+
+   ```bash
+   npx wrangler d1 migrations apply myradone-subscribers --remote --config workers/subscribe/wrangler.toml
+   ```
+
+4. Set the Turnstile secret:
+
+   ```bash
+   npx wrangler secret put TURNSTILE_SECRET_KEY --config workers/subscribe/wrangler.toml
+   ```
+
+5. Deploy the Worker:
+
+   ```bash
+   npx wrangler deploy --config workers/subscribe/wrangler.toml
+   ```
+
+6. Add a custom domain in Cloudflare:
+
+   - Worker: `myradone-subscribe`
+   - Domain: `api.myradone.com`
+   - Path: `/subscribe`
+
+7. Replace the test Turnstile site key in `design/brand/landing.html` with the production site key before launch.
+
+## Local testing
+
+Create `workers/subscribe/.dev.vars` with the Turnstile test secret:
+
+```dotenv
+TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+```
+
+Then run:
+
+```bash
+npx wrangler dev --config workers/subscribe/wrangler.toml
+```
+
+The landing page currently uses Cloudflare's visible test site key by default so the signup flow can be exercised locally without production credentials.

--- a/workers/subscribe/migrations/0001_create_subscribers.sql
+++ b/workers/subscribe/migrations/0001_create_subscribers.sql
@@ -1,0 +1,9 @@
+CREATE TABLE subscribers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'unsubscribed')),
+    subscribed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    unsubscribed_at TEXT,
+    source TEXT NOT NULL DEFAULT 'landing' CHECK (source IN ('landing', 'demo', 'app')),
+    consent_version TEXT NOT NULL DEFAULT 'v1'
+);

--- a/workers/subscribe/src/index.mjs
+++ b/workers/subscribe/src/index.mjs
@@ -1,0 +1,203 @@
+export const SUBSCRIBE_PATH = '/subscribe';
+
+const DEFAULT_ALLOWED_ORIGINS = [
+    'https://myradone.com',
+    'https://www.myradone.com',
+    'https://divergent.health',
+    'https://www.divergent.health'
+];
+
+const VALID_SOURCES = new Set(['landing', 'demo', 'app']);
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function parseAllowedOrigins(originsValue) {
+    const configuredOrigins = (originsValue || '')
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean);
+
+    return new Set(configuredOrigins.length ? configuredOrigins : DEFAULT_ALLOWED_ORIGINS);
+}
+
+export function normalizeEmail(value) {
+    if (typeof value !== 'string') return '';
+    return value.trim().toLowerCase();
+}
+
+export function isValidEmail(email) {
+    return email.length > 3 && email.length <= 254 && EMAIL_PATTERN.test(email);
+}
+
+export function normalizeSource(value) {
+    if (typeof value !== 'string') return 'landing';
+    const normalized = value.trim().toLowerCase();
+    return VALID_SOURCES.has(normalized) ? normalized : 'landing';
+}
+
+export function normalizeConsentVersion(value) {
+    if (typeof value !== 'string') return 'v1';
+    const normalized = value.trim().toLowerCase();
+    return normalized || 'v1';
+}
+
+function jsonResponse(payload, status, headers) {
+    return new Response(JSON.stringify(payload), { status, headers });
+}
+
+function createResponseHeaders(request, env) {
+    const headers = new Headers({
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Max-Age': '86400',
+        'Cache-Control': 'no-store',
+        'Content-Type': 'application/json; charset=UTF-8',
+        Vary: 'Origin'
+    });
+
+    const origin = request.headers.get('Origin');
+    if (origin && parseAllowedOrigins(env.ALLOWED_ORIGINS).has(origin)) {
+        headers.set('Access-Control-Allow-Origin', origin);
+    }
+
+    return headers;
+}
+
+function isOriginAllowed(request, env) {
+    const origin = request.headers.get('Origin');
+    if (!origin) return true;
+    return parseAllowedOrigins(env.ALLOWED_ORIGINS).has(origin);
+}
+
+export async function verifyTurnstileToken(token, request, env, fetchImpl = fetch) {
+    if (typeof token !== 'string' || !token.trim()) {
+        return { ok: false, code: 'missing-token' };
+    }
+
+    if (!env.TURNSTILE_SECRET_KEY) {
+        throw new Error('TURNSTILE_SECRET_KEY is not configured');
+    }
+
+    const formData = new FormData();
+    formData.set('secret', env.TURNSTILE_SECRET_KEY);
+    formData.set('response', token.trim());
+
+    const connectingIp = request.headers.get('CF-Connecting-IP');
+    if (connectingIp) {
+        formData.set('remoteip', connectingIp);
+    }
+
+    const response = await fetchImpl('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+        method: 'POST',
+        body: formData
+    });
+
+    if (!response.ok) {
+        return { ok: false, code: 'verification-unavailable' };
+    }
+
+    const payload = await response.json();
+    return {
+        ok: Boolean(payload.success),
+        code: payload.success ? 'ok' : 'verification-failed',
+        errors: Array.isArray(payload['error-codes']) ? payload['error-codes'] : []
+    };
+}
+
+export async function saveSubscriber(db, { email, source, consentVersion }) {
+    const existing = await db
+        .prepare('SELECT status FROM subscribers WHERE email = ? LIMIT 1')
+        .bind(email)
+        .first();
+
+    if (!existing) {
+        await db
+            .prepare('INSERT INTO subscribers (email, source, consent_version) VALUES (?, ?, ?)')
+            .bind(email, source, consentVersion)
+            .run();
+
+        return 'created';
+    }
+
+    if (existing.status === 'active') {
+        return 'already';
+    }
+
+    await db
+        .prepare(
+            "UPDATE subscribers SET status = 'active', unsubscribed_at = NULL, subscribed_at = datetime('now'), source = ?, consent_version = ? WHERE email = ?"
+        )
+        .bind(source, consentVersion, email)
+        .run();
+
+    return 'reactivated';
+}
+
+export async function handleSubscribe(request, env, fetchImpl = fetch) {
+    const headers = createResponseHeaders(request, env);
+    const { pathname } = new URL(request.url);
+
+    if (pathname !== SUBSCRIBE_PATH) {
+        return jsonResponse({ error: 'Not found' }, 404, headers);
+    }
+
+    if (!isOriginAllowed(request, env)) {
+        return jsonResponse({ error: 'Origin not allowed' }, 403, headers);
+    }
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers });
+    }
+
+    if (request.method !== 'POST') {
+        return jsonResponse({ error: 'Method not allowed' }, 405, headers);
+    }
+
+    let payload;
+    try {
+        payload = await request.json();
+    } catch {
+        return jsonResponse({ error: 'Invalid JSON body' }, 400, headers);
+    }
+
+    const email = normalizeEmail(payload?.email);
+    if (!isValidEmail(email)) {
+        return jsonResponse({ error: 'Please enter a valid email address.' }, 400, headers);
+    }
+
+    if (payload?.consentAccepted !== true) {
+        return jsonResponse({ error: 'Consent is required.' }, 400, headers);
+    }
+
+    const verification = await verifyTurnstileToken(payload?.turnstileToken, request, env, fetchImpl);
+    if (!verification.ok) {
+        return jsonResponse({ error: 'Security check failed. Please try again.' }, 403, headers);
+    }
+
+    const result = await saveSubscriber(env.DB, {
+        email,
+        source: normalizeSource(payload?.source),
+        consentVersion: normalizeConsentVersion(payload?.consentVersion)
+    });
+
+    return jsonResponse(
+        {
+            ok: true,
+            already: result === 'already',
+            reactivated: result === 'reactivated'
+        },
+        200,
+        headers
+    );
+}
+
+export default {
+    async fetch(request, env) {
+        try {
+            return await handleSubscribe(request, env);
+        } catch (error) {
+            console.error('subscribe worker failed', error);
+            const headers = createResponseHeaders(request, env);
+            return jsonResponse({ error: 'Server error' }, 500, headers);
+        }
+    }
+};

--- a/workers/subscribe/wrangler.toml
+++ b/workers/subscribe/wrangler.toml
@@ -1,6 +1,8 @@
 name = "myradone-subscribe"
 main = "src/index.mjs"
 compatibility_date = "2026-04-07"
+workers_dev = false
+preview_urls = false
 
 [vars]
 ALLOWED_ORIGINS = "https://myradone.com,https://www.myradone.com,https://divergent.health,https://www.divergent.health"

--- a/workers/subscribe/wrangler.toml
+++ b/workers/subscribe/wrangler.toml
@@ -1,0 +1,11 @@
+name = "myradone-subscribe"
+main = "src/index.mjs"
+compatibility_date = "2026-04-07"
+
+[vars]
+ALLOWED_ORIGINS = "https://myradone.com,https://www.myradone.com,https://divergent.health,https://www.divergent.health"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "myradone-subscribers"
+database_id = "33a16c5c-0618-47a8-b351-7af2f4f979e9"


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker + D1 signup backend under workers/subscribe
- add Turnstile-protected signup UI and privacy page for the brand landing surface
- document the architecture in ADR 012 and cover the Worker logic with tests

## Verification
- node --test tests/email-signup-worker.test.mjs
- npx wrangler d1 migrations apply myradone-subscribers --remote --config workers/subscribe/wrangler.toml
- npx wrangler d1 execute myradone-subscribers --remote --command "SELECT name FROM sqlite_master WHERE type='table' AND name='subscribers';"
- npx wrangler deploy --config workers/subscribe/wrangler.toml
- curl -i https://api.myradone.com/subscribe