### PR TITLE
Harden email signup worker

### DIFF
--- a/design/brand/landing.html
+++ b/design/brand/landing.html
@@ -625,13 +625,7 @@
                         throw new Error(data.error || 'Please try again.');
                     }
 
-                    if (data.reactivated) {
-                        setStatus("You're back on the list. We'll keep you posted.", 'success');
-                    } else if (data.already) {
-                        setStatus("You're already on the list.", 'success');
-                    } else {
-                        setStatus("Thanks. We'll be in touch.", 'success');
-                    }
+                    setStatus("Thanks. We'll be in touch.", 'success');
 
                     form.reset();
                     emailInput.focus();

--- a/tests/email-signup-worker.test.mjs
+++ b/tests/email-signup-worker.test.mjs
@@ -84,6 +84,16 @@ function createVerificationFetch(payload = { success: true }) {
     };
 }
 
+function createRateLimiter(success = true) {
+    return {
+        calls: [],
+        async limit({ key }) {
+            this.calls.push(key);
+            return { success };
+        }
+    };
+}
+
 test('helpers normalize and validate email input', () => {
     assert.equal(normalizeEmail('  DOCTOR@Example.COM '), 'doctor@example.com');
     assert.equal(isValidEmail('doctor@example.com'), true);
@@ -115,7 +125,7 @@ test('creates a new subscriber when the request is valid', async () => {
     const body = await response.json();
 
     assert.equal(response.status, 200);
-    assert.deepEqual(body, { ok: true, already: false, reactivated: false });
+    assert.deepEqual(body, { ok: true });
     assert.equal(env.DB.subscribers.get('doctor@example.com').status, 'active');
     assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://myradone.com');
 });
@@ -148,8 +158,7 @@ test('returns already for active subscribers', async () => {
     const body = await response.json();
 
     assert.equal(response.status, 200);
-    assert.equal(body.already, true);
-    assert.equal(body.reactivated, false);
+    assert.deepEqual(body, { ok: true });
 });
 
 test('reactivates unsubscribed subscribers', async () => {
@@ -180,13 +189,14 @@ test('reactivates unsubscribed subscribers', async () => {
     const body = await response.json();
 
     assert.equal(response.status, 200);
-    assert.equal(body.reactivated, true);
+    assert.deepEqual(body, { ok: true });
     assert.equal(env.DB.subscribers.get('doctor@example.com').source, 'demo');
     assert.equal(env.DB.subscribers.get('doctor@example.com').consentVersion, 'v2');
 });
 
-test('rejects missing Turnstile token, invalid email, and missing consent', async () => {
+test('rejects missing Turnstile token without calling siteverify', async () => {
     const env = createEnv();
+    let fetchCalled = false;
 
     const missingToken = await handleSubscribe(
         new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
@@ -198,9 +208,17 @@ test('rejects missing Turnstile token, invalid email, and missing consent', asyn
             })
         }),
         env,
-        createVerificationFetch()
+        async () => {
+            fetchCalled = true;
+            throw new Error('siteverify should not be called without a token');
+        }
     );
     assert.equal(missingToken.status, 403);
+    assert.equal(fetchCalled, false);
+});
+
+test('rejects invalid email and missing consent', async () => {
+    const env = createEnv();
 
     const invalidEmail = await handleSubscribe(
         new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
@@ -264,4 +282,78 @@ test('handles CORS and disallowed origins', async () => {
         createVerificationFetch()
     );
     assert.equal(blocked.status, 403);
+});
+
+test('allows preflight from disallowed origins without granting CORS', async () => {
+    const env = createEnv();
+
+    const preflight = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'OPTIONS',
+            headers: { Origin: 'https://evil.example' }
+        }),
+        env,
+        createVerificationFetch()
+    );
+
+    assert.equal(preflight.status, 204);
+    assert.equal(preflight.headers.get('Access-Control-Allow-Origin'), null);
+});
+
+test('rate limits excessive requests before siteverify and storage', async () => {
+    const rateLimiter = createRateLimiter(false);
+    const env = createEnv({
+        SUBSCRIBE_RATE_LIMIT: rateLimiter
+    });
+    let fetchCalled = false;
+
+    const response = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'CF-Connecting-IP': '203.0.113.7'
+            },
+            body: JSON.stringify({
+                email: 'doctor@example.com',
+                turnstileToken: 'token',
+                consentVersion: 'v1',
+                consentAccepted: true
+            })
+        }),
+        env,
+        async () => {
+            fetchCalled = true;
+            return createVerificationFetch()();
+        }
+    );
+
+    assert.equal(response.status, 429);
+    assert.equal(fetchCalled, false);
+    assert.deepEqual(rateLimiter.calls, ['/subscribe:203.0.113.7']);
+    assert.equal(env.DB.subscribers.size, 0);
+});
+
+test('consent versions are trimmed to a safe length before storage', async () => {
+    const env = createEnv();
+    const overlongConsentVersion = `v1-${'x'.repeat(90)}`;
+
+    const response = await handleSubscribe(
+        new Request(`https://api.myradone.com${SUBSCRIBE_PATH}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                email: 'doctor@example.com',
+                turnstileToken: 'token',
+                source: 'landing',
+                consentVersion: overlongConsentVersion,
+                consentAccepted: true
+            })
+        }),
+        env,
+        createVerificationFetch()
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(env.DB.subscribers.get('doctor@example.com').consentVersion.length, 64);
 });

--- a/workers/subscribe/src/index.mjs
+++ b/workers/subscribe/src/index.mjs
@@ -36,7 +36,7 @@ export function normalizeSource(value) {
 
 export function normalizeConsentVersion(value) {
     if (typeof value !== 'string') return 'v1';
-    const normalized = value.trim().toLowerCase();
+    const normalized = value.trim().toLowerCase().slice(0, 64);
     return normalized || 'v1';
 }
 
@@ -66,6 +66,18 @@ function isOriginAllowed(request, env) {
     const origin = request.headers.get('Origin');
     if (!origin) return true;
     return parseAllowedOrigins(env.ALLOWED_ORIGINS).has(origin);
+}
+
+async function isRateLimited(request, env) {
+    if (!env.SUBSCRIBE_RATE_LIMIT?.limit) {
+        return false;
+    }
+
+    const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+    const { success } = await env.SUBSCRIBE_RATE_LIMIT.limit({
+        key: `${SUBSCRIBE_PATH}:${ip}`
+    });
+    return !success;
 }
 
 export async function verifyTurnstileToken(token, request, env, fetchImpl = fetch) {
@@ -140,16 +152,20 @@ export async function handleSubscribe(request, env, fetchImpl = fetch) {
         return jsonResponse({ error: 'Not found' }, 404, headers);
     }
 
-    if (!isOriginAllowed(request, env)) {
-        return jsonResponse({ error: 'Origin not allowed' }, 403, headers);
-    }
-
     if (request.method === 'OPTIONS') {
         return new Response(null, { status: 204, headers });
     }
 
+    if (!isOriginAllowed(request, env)) {
+        return jsonResponse({ error: 'Origin not allowed' }, 403, headers);
+    }
+
     if (request.method !== 'POST') {
         return jsonResponse({ error: 'Method not allowed' }, 405, headers);
+    }
+
+    if (await isRateLimited(request, env)) {
+        return jsonResponse({ error: 'Too many requests. Please try again later.' }, 429, headers);
     }
 
     let payload;
@@ -179,15 +195,7 @@ export async function handleSubscribe(request, env, fetchImpl = fetch) {
         consentVersion: normalizeConsentVersion(payload?.consentVersion)
     });
 
-    return jsonResponse(
-        {
-            ok: true,
-            already: result === 'already',
-            reactivated: result === 'reactivated'
-        },
-        200,
-        headers
-    );
+    return jsonResponse({ ok: true }, 200, headers);
 }
 
 export default {

--- a/workers/subscribe/wrangler.toml
+++ b/workers/subscribe/wrangler.toml
@@ -11,3 +11,11 @@ ALLOWED_ORIGINS = "https://myradone.com,https://www.myradone.com,https://diverge
 binding = "DB"
 database_name = "myradone-subscribers"
 database_id = "33a16c5c-0618-47a8-b351-7af2f4f979e9"
+
+[[ratelimits]]
+name = "SUBSCRIBE_RATE_LIMIT"
+namespace_id = "2026040801"
+
+  [ratelimits.simple]
+  limit = 10
+  period = 60


### PR DESCRIPTION
## Summary
- add Worker-side rate limiting for signup submissions
- stop exposing subscriber membership state through distinct success responses
- clamp consent version input and tighten preflight/test coverage

## Verification
- node --test tests/email-signup-worker.test.mjs
- npx biome lint workers/subscribe/src/index.mjs tests/email-signup-worker.test.mjs