### PR TITLE
Fix myradone Pages signup source

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -15,22 +15,6 @@ The DICOM Viewer is a **static single-page application** that runs entirely in t
 - GitHub Pages works out of the box
 - Medical images never leave the user's machine
 
-### myRadOne Landing Page (Cloudflare Pages)
-
-The public `myradone.com` marketing site is a separate static bundle in `site/`.
-
-- `site/index.html` is the landing page
-- `site/privacy.html` is the signup privacy page
-- `site/fonts/`, `site/library-screenshot.png`, and `site/viewer-screenshot.png` are part of the deployable asset set
-
-Deploy it to the Cloudflare Pages project named `myradone` with:
-
-```bash
-npx wrangler pages deploy site --project-name myradone --branch main
-```
-
-This project is currently deployed manually, so merging a PR does not update `myradone.com` by itself.
-
 The application consists of static files in the `docs/` folder:
 
 ```
@@ -41,6 +25,24 @@ docs/
 ├── sample/             # Demo CT scan (optional)
 └── sample-mri/         # Demo MRI scan (optional)
 ```
+
+---
+
+## myRadOne Landing Page (Cloudflare Pages)
+
+The public `myradone.com` marketing site is a separate static bundle in `site/`.
+
+- `site/index.html` is the landing page
+- `site/privacy.html` is the signup privacy page
+- `site/fonts/`, `site/library-screenshot.png`, and `site/viewer-screenshot.png` are part of the deployable asset set
+
+Deploy it to the Cloudflare Pages project named `myradone` with:
+
+```bash
+npx wrangler pages deploy site --project-name myradone
+```
+
+This project is currently deployed manually, so merging a PR does not update `myradone.com` by itself.
 
 ---
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -15,6 +15,22 @@ The DICOM Viewer is a **static single-page application** that runs entirely in t
 - GitHub Pages works out of the box
 - Medical images never leave the user's machine
 
+### myRadOne Landing Page (Cloudflare Pages)
+
+The public `myradone.com` marketing site is a separate static bundle in `site/`.
+
+- `site/index.html` is the landing page
+- `site/privacy.html` is the signup privacy page
+- `site/fonts/`, `site/library-screenshot.png`, and `site/viewer-screenshot.png` are part of the deployable asset set
+
+Deploy it to the Cloudflare Pages project named `myradone` with:
+
+```bash
+npx wrangler pages deploy site --project-name myradone --branch main
+```
+
+This project is currently deployed manually, so merging a PR does not update `myradone.com` by itself.
+
 The application consists of static files in the `docs/` folder:
 
 ```

--- a/site/index.html
+++ b/site/index.html
@@ -794,6 +794,7 @@
     </footer>
 
     <script>
+        document.addEventListener('DOMContentLoaded', () => {
         // -- Preview hover (JS-controlled to prevent flicker) --
         const preview = document.querySelector('.app-preview');
         const frames = preview.querySelectorAll('.preview-frame');
@@ -859,16 +860,24 @@
         let turnstileWidgetId = null;
         let turnstileToken = null;
 
+        function renderTurnstileIfReady() {
+            if (!signupOverlay.classList.contains('visible')) return;
+            if (turnstileWidgetId !== null) return;
+            if (typeof turnstile === 'undefined') return;
+
+            turnstileWidgetId = turnstile.render('#turnstile-container', {
+                sitekey: TURNSTILE_SITE_KEY,
+                callback: (token) => { turnstileToken = token; },
+            });
+        }
+
+        window.onMyRadOneTurnstileLoad = renderTurnstileIfReady;
+
         signupTrigger.addEventListener('click', (e) => {
             e.preventDefault();
             talkWrap.classList.remove('open');
             signupOverlay.classList.add('visible');
-            if (typeof turnstile !== 'undefined' && turnstileWidgetId === null) {
-                turnstileWidgetId = turnstile.render('#turnstile-container', {
-                    sitekey: TURNSTILE_SITE_KEY,
-                    callback: (token) => { turnstileToken = token; },
-                });
-            }
+            renderTurnstileIfReady();
         });
 
         signupOverlay.addEventListener('click', (e) => {
@@ -934,6 +943,7 @@
                 signupSubmit.textContent = 'Sign up';
             }
         });
+        });
     </script>
 
     <!-- Signup overlay -->
@@ -953,6 +963,6 @@
             </form>
         </div>
     </div>
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onMyRadOneTurnstileLoad" async defer></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -609,6 +609,15 @@
 
         .signup-consent input { margin-top: 0.15rem; }
 
+        .signup-consent a {
+            color: var(--accent);
+            text-decoration: none;
+        }
+
+        .signup-consent a:hover {
+            text-decoration: underline;
+        }
+
         .signup-submit {
             width: 100%;
             padding: 0.7rem;
@@ -830,7 +839,10 @@
         });
 
         document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') talkWrap.classList.remove('open');
+            if (e.key === 'Escape') {
+                talkWrap.classList.remove('open');
+                signupOverlay.classList.remove('visible');
+            }
         });
 
         // -- Signup overlay --
@@ -898,7 +910,7 @@
                 });
 
                 if (resp.ok) {
-                    signupStatus.textContent = 'Thanks! We will be in touch.';
+                    signupStatus.textContent = "Thanks. We'll be in touch.";
                     signupStatus.classList.add('success');
                     signupSubmit.style.display = 'none';
                     signupEmail.style.display = 'none';
@@ -933,7 +945,7 @@
                 <input type="email" id="signup-email" required placeholder="your@email.com" class="signup-input">
                 <label class="signup-consent">
                     <input type="checkbox" id="signup-consent-check" required>
-                    <span>I agree to receive occasional product updates</span>
+                    <span>I'd like to receive occasional myRadOne updates. Unsubscribe anytime. See the <a href="./privacy.html" target="_blank" rel="noopener">Privacy Policy</a>.</span>
                 </label>
                 <div id="turnstile-container"></div>
                 <button type="submit" class="signup-submit">Sign up</button>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Copyright (c) 2026 Divergent Health Technologies -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Divergent Health Technologies Privacy</title>
+    <title>myRadOne Privacy Policy</title>
     <meta name="description" content="Privacy details for Divergent Health Technologies and myRadOne launch updates.">
     <meta name="theme-color" content="#FFF8F3">
     <style>
@@ -187,7 +188,7 @@
             <section class="policy-card">
                 <h2>Unsubscribing</h2>
                 <p>
-                    Every update email should include a way to unsubscribe. You can also request removal by emailing us directly.
+                    Every commercial update email will include a functional unsubscribe option. You can also request removal by emailing us directly.
                 </p>
             </section>
 

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Divergent Health Technologies Privacy</title>
+    <meta name="description" content="Privacy details for Divergent Health Technologies and myRadOne launch updates.">
+    <meta name="theme-color" content="#FFF8F3">
+    <style>
+        @font-face {
+            font-family: 'Inter';
+            src: url('fonts/Inter-variable.woff2') format('woff2');
+            font-weight: 100 900;
+            font-display: swap;
+        }
+        @font-face {
+            font-family: 'Lora';
+            src: url('fonts/Lora-variable.woff2') format('woff2');
+            font-weight: 400 700;
+            font-style: normal;
+            font-display: swap;
+        }
+
+        :root {
+            --bg: #fff8f3;
+            --surface: rgba(255, 255, 255, 0.72);
+            --text: #3d3a36;
+            --text-dim: #6b6660;
+            --accent: #f08c00;
+            --accent-soft: rgba(240, 140, 0, 0.12);
+            --border: rgba(61, 58, 54, 0.1);
+            --serif: 'Lora', Georgia, serif;
+            --sans: 'Inter', system-ui, sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: var(--sans);
+            background:
+                radial-gradient(circle at top, rgba(240, 140, 0, 0.08), transparent 38%),
+                var(--bg);
+            color: var(--text);
+            line-height: 1.7;
+        }
+
+        main {
+            width: min(760px, calc(100vw - 2.5rem));
+            margin: 0 auto;
+            padding: 4rem 0 5rem;
+        }
+
+        .eyebrow {
+            margin: 0 0 1.2rem;
+            color: var(--accent);
+            font-size: 0.76rem;
+            font-weight: 600;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        h1 {
+            margin: 0 0 1rem;
+            font-family: var(--serif);
+            font-style: italic;
+            font-size: clamp(2rem, 4vw, 3rem);
+            font-weight: 500;
+            line-height: 1.12;
+        }
+
+        .intro,
+        .back-link {
+            color: var(--text-dim);
+        }
+
+        .back-link {
+            display: inline-flex;
+            margin-bottom: 2rem;
+            text-decoration: none;
+        }
+
+        .back-link:hover {
+            color: var(--text);
+        }
+
+        .policy-grid {
+            display: grid;
+            gap: 1rem;
+            margin-top: 2rem;
+        }
+
+        .policy-card {
+            padding: 1.35rem 1.4rem;
+            border: 1px solid var(--border);
+            background: var(--surface);
+            backdrop-filter: blur(10px);
+            border-radius: 18px;
+        }
+
+        .policy-card h2 {
+            margin: 0 0 0.55rem;
+            font-size: 1rem;
+            font-weight: 600;
+        }
+
+        .policy-card p,
+        .policy-card ul {
+            margin: 0;
+            color: var(--text-dim);
+            font-size: 0.98rem;
+        }
+
+        .policy-card ul {
+            padding-left: 1.2rem;
+        }
+
+        .policy-card strong {
+            color: var(--text);
+        }
+
+        .contact-note {
+            margin-top: 2rem;
+            padding: 1rem 1.2rem;
+            background: var(--accent-soft);
+            border-radius: 16px;
+            color: var(--text);
+        }
+
+        a {
+            color: inherit;
+        }
+
+        @media (max-width: 640px) {
+            main {
+                width: min(100vw - 1.5rem, 760px);
+                padding: 2.75rem 0 3.5rem;
+            }
+
+            .policy-card {
+                border-radius: 14px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <a class="back-link" href="./">&larr; Back to landing page</a>
+        <p class="eyebrow">Privacy</p>
+        <h1>Privacy for myRadOne launch updates</h1>
+        <p class="intro">
+            Divergent Health Technologies uses this signup form to collect launch-interest emails for myRadOne. This page covers that marketing signup flow, not the future handling of clinical imaging data.
+        </p>
+
+        <div class="policy-grid">
+            <section class="policy-card">
+                <h2>What we collect</h2>
+                <p>
+                    If you subscribe, we store your <strong>email address</strong>, the <strong>date you subscribed</strong>, the <strong>page source</strong>, and the <strong>consent text version</strong> you agreed to.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>What we do not collect here</h2>
+                <p>
+                    This signup flow is for newsletter-style updates only. We do <strong>not</strong> ask for medical images, health records, passwords, or other patient data in this form.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>How we use it</h2>
+                <p>
+                    We use your email to send occasional updates about myRadOne, product availability, and launch news. We do not sell this list to data brokers or ad networks.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>Storage and protection</h2>
+                <p>
+                    Signup records are stored in infrastructure we control on Cloudflare. The form is protected by Cloudflare Turnstile to reduce spam and automated abuse.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>Unsubscribing</h2>
+                <p>
+                    Every update email should include a way to unsubscribe. You can also request removal by emailing us directly.
+                </p>
+            </section>
+
+            <section class="policy-card">
+                <h2>Questions</h2>
+                <ul>
+                    <li>Email: <a href="mailto:info@divergent.health">info@divergent.health</a></li>
+                    <li>Company: Divergent Health Technologies</li>
+                </ul>
+            </section>
+        </div>
+
+        <p class="contact-note">
+            If the signup copy changes later, we version that consent text in our subscriber records so we can trace which wording each subscriber agreed to.
+        </p>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track the live myradone Pages landing bundle in `site/`
- add the signup privacy page and link it from the consent copy
- document that `myradone.com` is manually deployed from Cloudflare Pages `site/`
- fix the production signup initialization bug tracked in #78

## Verification
- deployed `site/` to the Cloudflare Pages project `myradone`
- verified `https://myradone.com` now serves the Worker-backed signup form
- verified `https://myradone.com/privacy` serves the privacy page
- verified the production HTML includes `https://api.myradone.com/subscribe` and Turnstile wiring

## Notes
- the live site was previously serving an older manual Pages deployment that still used an inline placeholder `onsubmit` handler instead of the Worker
- the signup button was later found to be nonfunctional because the signup script initialized before the overlay DOM existed; that regression is tracked in #78
- I could not complete an automated end-to-end signup from this worktree because Playwright is not installed here
