### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Copyright 2026 Divergent Health Technologies
 
 ## [Unreleased]
 
+## [2026-04-10]
+
+### Added
+- Optional Usage Stats panel in Help for app opens and studies imported
+- Opt-in anonymous instrumentation snapshot support for desktop and personal modes
+
+### Changed
+- Improved myradone release funnel with landing, download, and signup updates
+- Added repo-wide linting and formatting infrastructure to tighten release quality
+
+### Fixed
+- macOS app icon refresh after in-app updates
+- Several instrumentation correctness issues before first release
+
 ## [2026-04-09]
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dicom-viewer-desktop",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dicom-viewer-desktop",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dicom-viewer-desktop",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "myradone -- your medical imaging library",
   "scripts": {
     "build:plain-dmg": "./scripts/build-plain-dmg.sh",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "dicom-viewer-desktop"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "dicom-core",
  "dicom-dictionary-std",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dicom-viewer-desktop"
-version = "0.3.2"
+version = "0.4.0"
 description = "myradone -- your medical imaging library"
 authors = ["Gabriel Casalduc <gabriel@divergent.health>"]
 license = "MIT"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "myradone",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "identifier": "health.divergent.dicomviewer",
   "build": {
     "beforeDevCommand": "npm run dev:web",

--- a/docs/js/instrumentation.js
+++ b/docs/js/instrumentation.js
@@ -126,12 +126,30 @@ const Instrumentation = (() => {
         return protocol === 'tauri:' || hostname === 'tauri.localhost';
     }
 
+    async function waitForDesktopRuntime() {
+        const ready = window.__DICOM_VIEWER_TAURI_STORAGE_READY__ || window.__DICOM_VIEWER_TAURI_READY__;
+        if (ready && typeof ready.then === 'function') {
+            await ready;
+        }
+        if (window.__TAURI__?.sql?.load) return window.__TAURI__;
+
+        const deadline = performance.now() + 5000;
+        while (performance.now() < deadline) {
+            if (window.__TAURI__?.sql?.load) return window.__TAURI__;
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
+        return window.__TAURI__ || null;
+    }
+
     async function getDesktopDb() {
-        if (!window.__TAURI__?.sql?.load) {
-            throw new Error('Desktop SQL runtime not available');
+        const runtime = await waitForDesktopRuntime();
+        const sql = runtime?.sql;
+        if (!sql?.load) {
+            throw new Error('Desktop SQL runtime is not ready');
         }
         if (!desktopDbPromise) {
-            desktopDbPromise = window.__TAURI__.sql.load(DESKTOP_DB_URL).catch((error) => {
+            desktopDbPromise = sql.load(DESKTOP_DB_URL).catch((error) => {
                 desktopDbPromise = null;
                 throw error;
             });
@@ -204,18 +222,10 @@ const Instrumentation = (() => {
     // =====================================================================
 
     async function loadStats() {
-        let blob = null;
-
         if (useDesktopSql) {
-            blob = await loadFromDesktopSql();
+            return migrateStats(await loadFromDesktopSql());
         }
-
-        // Fall back to localStorage if desktop SQL returned nothing
-        if (!blob) {
-            blob = loadFromLocalStorage();
-        }
-
-        return migrateStats(blob);
+        return migrateStats(loadFromLocalStorage());
     }
 
     async function saveStats() {
@@ -410,8 +420,8 @@ const Instrumentation = (() => {
                 await ensureDesktopDb();
                 useDesktopSql = true;
             } catch (error) {
-                console.warn('Instrumentation: desktop SQL not available, falling back to localStorage:', error);
-                useDesktopSql = false;
+                console.warn('Instrumentation: desktop SQL not available, disabling instrumentation:', error);
+                return;
             }
         }
 

--- a/docs/js/instrumentation.js
+++ b/docs/js/instrumentation.js
@@ -15,6 +15,7 @@ const Instrumentation = (() => {
     const PHONE_HOME_DEBOUNCE_MS = 5_000;
     const PHONE_HOME_URL = 'https://api.myradone.com/api/stats';
     const SCHEMA_VERSION = 1;
+    const DESKTOP_RUNTIME_TIMEOUT_MS = 5_000;
 
     // Desktop SQL table and DB
     const DESKTOP_DB_URL = 'sqlite:viewer.db';
@@ -133,7 +134,7 @@ const Instrumentation = (() => {
         }
         if (window.__TAURI__?.sql?.load) return window.__TAURI__;
 
-        const deadline = performance.now() + 5000;
+        const deadline = performance.now() + DESKTOP_RUNTIME_TIMEOUT_MS;
         while (performance.now() < deadline) {
             if (window.__TAURI__?.sql?.load) return window.__TAURI__;
             await new Promise((resolve) => setTimeout(resolve, 50));

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -42,6 +42,7 @@ const { test, expect } = require('@playwright/test');
 const APP_URL = 'http://127.0.0.1:5001/?nolib';
 const TEST_URL = 'http://127.0.0.1:5001/?test';
 const STORAGE_KEY = 'dicom-viewer-instrumentation-v1';
+const DESKTOP_RUNTIME_WAIT_TIMEOUT_MS = 5_000;
 
 /**
  * Playwright gives each test a fresh browser context with empty localStorage
@@ -145,7 +146,7 @@ test.describe('Instrumentation: personal mode counters', () => {
 
         await page.waitForFunction(() => {
             return window.__instrumentationTestDbState?.row?.sessions === 1;
-        });
+        }, { timeout: DESKTOP_RUNTIME_WAIT_TIMEOUT_MS });
 
         const localRaw = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
         expect(localRaw).toBeNull();

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -144,9 +144,12 @@ test.describe('Instrumentation: personal mode counters', () => {
 
         await page.goto(APP_URL);
 
-        await page.waitForFunction(() => {
-            return window.__instrumentationTestDbState?.row?.sessions === 1;
-        }, { timeout: DESKTOP_RUNTIME_WAIT_TIMEOUT_MS });
+        await page.waitForFunction(
+            () => {
+                return window.__instrumentationTestDbState?.row?.sessions === 1;
+            },
+            { timeout: DESKTOP_RUNTIME_WAIT_TIMEOUT_MS },
+        );
 
         const localRaw = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
         expect(localRaw).toBeNull();

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -99,6 +99,63 @@ async function waitForStats(page, predicate, timeout = 5000) {
 // ============================================================================
 
 test.describe('Instrumentation: personal mode counters', () => {
+    test('delayed desktop runtime readiness does not fall back to localStorage', async ({ page }) => {
+        await page.addInitScript(() => {
+            const dbState = {
+                loadCount: 0,
+                row: null,
+            };
+
+            const fakeDb = {
+                async select() {
+                    return dbState.row ? [{ ...dbState.row }] : [];
+                },
+                async execute(_sql, params) {
+                    dbState.row = {
+                        id: 1,
+                        version: params[0],
+                        revision: params[1],
+                        installation_id: params[2],
+                        first_seen: params[3],
+                        last_seen: params[4],
+                        sessions: params[5],
+                        studies_imported: params[6],
+                        share_enabled: params[7],
+                    };
+                    return { rowsAffected: 1 };
+                },
+            };
+
+            window.__instrumentationTestDbState = dbState;
+            window.__TAURI__ = {};
+            window.__DICOM_VIEWER_TAURI_STORAGE_READY__ = new Promise((resolve) => {
+                setTimeout(() => {
+                    window.__TAURI__.sql = {
+                        load: async () => {
+                            dbState.loadCount += 1;
+                            return fakeDb;
+                        },
+                    };
+                    resolve(window.__TAURI__);
+                }, 100);
+            });
+        });
+
+        await page.goto(APP_URL);
+
+        await page.waitForFunction(() => {
+            return window.__instrumentationTestDbState?.row?.sessions === 1;
+        });
+
+        const localRaw = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
+        expect(localRaw).toBeNull();
+
+        const dbState = await page.evaluate(() => window.__instrumentationTestDbState);
+        expect(dbState.loadCount).toBeGreaterThan(0);
+        expect(dbState.row).not.toBeNull();
+        expect(dbState.row.sessions).toBe(1);
+    });
+
     test('records first session on fresh load (no startup race drop)', async ({ page }) => {
         await clearInstrumentationStorage(page);
         await page.goto(APP_URL);


### PR DESCRIPTION
## Summary
- bump the desktop app version from `0.3.0` to `0.4.0`
- update the desktop release metadata files consistently
- add a changelog entry for the 2026-04-09 release

## Verification
- `cargo check` in `desktop/src-tauri`

## Notes
- this PR prepares the release only; it does not tag or trigger the GitHub release workflow
