### PR TITLE
Fix mobile top button overlapping logo

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -668,6 +668,20 @@
 
         /* ---- Responsive ---- */
 
+        /* Mid-range: shrink the top button before it collides with the logo.
+           Below 860px the logo + gap + button width + button width would
+           overflow, so progressively shrink the button. */
+        @media (max-width: 860px) {
+            .talk-btn {
+                font-size: 0.75rem;
+                padding: 0.55rem 1.15rem;
+            }
+            .talk-wrap {
+                top: 1rem;
+                right: 1rem;
+            }
+        }
+
         @media (max-width: 640px) {
             .hero { padding: 4.5rem 1.5rem 1.5rem; }
             .logo { font-size: 2.5rem; margin-bottom: 1rem; }

--- a/site/index.html
+++ b/site/index.html
@@ -669,8 +669,16 @@
         /* ---- Responsive ---- */
 
         @media (max-width: 640px) {
-            .hero { padding: 3rem 1.5rem; }
-            .logo { margin-bottom: 1rem; }
+            .hero { padding: 4.5rem 1.5rem 1.5rem; }
+            .logo { font-size: 2.5rem; margin-bottom: 1rem; }
+            .talk-wrap {
+                top: 0.75rem;
+                right: 0.75rem;
+            }
+            .talk-btn {
+                font-size: 0.72rem;
+                padding: 0.5rem 1rem;
+            }
             .app-preview {
                 flex-direction: column;
                 max-width: 400px;

--- a/site/index.html
+++ b/site/index.html
@@ -689,9 +689,18 @@
                 flex-direction: column;
                 gap: 0.8rem;
             }
+            .cta-primary-wrap {
+                width: 100%;
+            }
             .cta-primary, .cta-secondary {
                 width: 100%;
                 text-align: center;
+            }
+            .cta-note {
+                position: static;
+                transform: none;
+                margin-top: 0.5rem;
+                display: block;
             }
             .feature { gap: 1rem; }
         }


### PR DESCRIPTION
## Summary
- Mobile viewport fix: "Get in touch" button was overlapping the myRadOne wordmark on narrow screens
- Tighten the button to the top-right corner at `<=640px`
- Shrink font and padding slightly on mobile
- Add top padding to the hero so the logo clears the fixed button
- Shrink logo to 2.5rem on mobile (was hitting the button area)

## Test plan
- [ ] Verify at 640px and below: button doesn't overlap wordmark
- [ ] Verify at 641px+: desktop layout unchanged
- [ ] Verify dropdown still opens on hover/click on desktop
- [ ] Verify Escape key still closes dropdown

Generated with [Claude Code](https://claude.com/claude-code)