### PR TITLE
fix: harden sample loading failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,10 @@
 # as GitHub prereleases so they don't become the /releases/latest endpoint.
 #
 # Creates a draft GitHub Release with signed + notarized DMGs and updater
-# artifacts for both aarch64 and x86_64. Publish the draft manually after
-# verifying the artifacts.
+# artifacts for both aarch64 and x86_64. The Tauri action notarizes and staples
+# the `.app`; this workflow adds a post-pass that notarizes and staples the DMG
+# container too before publishing. Publish the draft manually after verifying
+# the artifacts.
 
 name: Release
 
@@ -135,3 +137,44 @@ jobs:
           releaseDraft: true
           prerelease: ${{ steps.meta.outputs.prerelease }}
           args: --target x86_64-apple-darwin
+
+      - name: Notarize and staple DMG artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          notarize_and_upload_dmg() {
+            local target_triple="$1"
+            local asset_suffix="$2"
+            local dmg_path="src-tauri/target/${target_triple}/release/bundle/dmg/myradone_${VERSION}_${asset_suffix}.dmg"
+            local dmg_name
+            dmg_name="$(basename "$dmg_path")"
+
+            if [[ ! -f "$dmg_path" ]]; then
+              echo "::error::Expected DMG not found: $dmg_path"
+              exit 1
+            fi
+
+            echo "Notarizing ${dmg_name}..."
+            xcrun notarytool submit "$dmg_path" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait
+
+            echo "Stapling ${dmg_name}..."
+            xcrun stapler staple "$dmg_path"
+
+            echo "Validating stapled ticket for ${dmg_name}..."
+            xcrun stapler validate "$dmg_path"
+
+            gh release delete-asset "$GITHUB_REF_NAME" "$dmg_name" --yes || true
+            gh release upload "$GITHUB_REF_NAME" "$dmg_path"
+          }
+
+          notarize_and_upload_dmg "aarch64-apple-darwin" "aarch64"
+          notarize_and_upload_dmg "x86_64-apple-darwin" "x64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Copyright 2026 Divergent Health Technologies
 
 ## [Unreleased]
 
+## [2026-04-09]
+
+### Fixed
+- Sample CT/MRI demo loads now surface real errors instead of `undefined`
+- Sample downloads are batched to reduce memory pressure on constrained devices
+
 ## [2026-02-01]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Copyright 2026 Divergent Health Technologies
 ### Fixed
 - Sample CT/MRI demo loads now surface real errors instead of `undefined`
 - Sample downloads are batched to reduce memory pressure on constrained devices
+- macOS release DMGs are now notarized and stapled in CI, not just the app bundle
 
 ## [2026-02-01]
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dicom-viewer-desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dicom-viewer-desktop",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dicom-viewer-desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dicom-viewer-desktop",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dicom-viewer-desktop",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "myradone -- your medical imaging library",
   "scripts": {
     "build:plain-dmg": "./scripts/build-plain-dmg.sh",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dicom-viewer-desktop",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "myradone -- your medical imaging library",
   "scripts": {
     "build:plain-dmg": "./scripts/build-plain-dmg.sh",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "dicom-viewer-desktop"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "dicom-core",
  "dicom-dictionary-std",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dicom-viewer-desktop"
-version = "0.3.0"
+version = "0.3.1"
 description = "myradone -- your medical imaging library"
 authors = ["Gabriel Casalduc <gabriel@divergent.health>"]
 license = "MIT"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dicom-viewer-desktop"
-version = "0.3.1"
+version = "0.3.2"
 description = "myradone -- your medical imaging library"
 authors = ["Gabriel Casalduc <gabriel@divergent.health>"]
 license = "MIT"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "myradone",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "health.divergent.dicomviewer",
   "build": {
     "beforeDevCommand": "npm run dev:web",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "myradone",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "health.divergent.dicomviewer",
   "build": {
     "beforeDevCommand": "npm run dev:web",

--- a/docs/js/app/import-pipeline.js
+++ b/docs/js/app/import-pipeline.js
@@ -68,14 +68,7 @@
     }
 
     const normalizeBinaryResponse = app.utils.normalizeBinaryResponse;
-
-    function getImportParseErrorMessage(error) {
-        if (!error) return '';
-        if (typeof error === 'string') return error;
-        if (typeof error.message === 'string' && error.message) return error.message;
-        if (typeof error.exception === 'string' && error.exception) return error.exception;
-        return String(error);
-    }
+    const getErrorMessage = app.utils.getErrorMessage;
 
     function hasDicomPreamble(bytes) {
         return !!(
@@ -99,7 +92,7 @@
             return true;
         }
 
-        const message = getImportParseErrorMessage(parseResult?.error).toLowerCase();
+        const message = getErrorMessage(parseResult?.error, '').toLowerCase();
         return IMPORT_TRUNCATION_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
     }
 
@@ -210,7 +203,7 @@
         // Build path with a simple join -- appDataDir already ends with separator
         // on some platforms, so normalize by stripping trailing separator first.
         const base = appDataDir.replace(/[\\/]+$/, '');
-        return base + '/' + LIBRARY_SUBFOLDER;
+        return `${base}/${LIBRARY_SUBFOLDER}`;
     }
 
     /**
@@ -244,7 +237,7 @@
         const sopSegment = sanitizeUidSegment(sopUid);
 
         const root = String(libraryRoot).replace(/[\\/]+$/, '');
-        return root + '/' + studySegment + '/' + seriesSegment + '/' + sopSegment + '.dcm';
+        return `${root}/${studySegment}/${seriesSegment}/${sopSegment}.dcm`;
     }
 
     /**

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -22,6 +22,7 @@
     } = app.dom;
     const { closeReportViewer } = app.reportsUi;
     const { openHelpViewer, closeHelpViewer } = app.helpViewer;
+    const { getErrorMessage } = app.utils;
     const {
         applyDesktopLibraryScan,
         applyDesktopLibrarySnapshot,
@@ -128,7 +129,9 @@
             }
             await displayStudies();
         } catch (err) {
-            alert(`Error: ${err.message}`);
+            if (err?.name === 'AbortError') return;
+            console.error('Dropped folder load failed:', err);
+            alert(`Error: ${getErrorMessage(err)}`);
         }
     }
 
@@ -157,7 +160,8 @@
                 await displayStudies();
             } catch (err) {
                 if (err.name !== 'AbortError') {
-                    alert(`Error: ${err.message}`);
+                    console.error('Managed library drop failed:', err);
+                    alert(`Error: ${getErrorMessage(err)}`);
                 }
             } finally {
                 state.libraryAbort = null;
@@ -175,7 +179,9 @@
             }
             await displayStudies();
         } catch (err) {
-            alert(`Error: ${err.message}`);
+            if (err?.name === 'AbortError') return;
+            console.error('Tauri drop fallback failed:', err);
+            alert(`Error: ${getErrorMessage(err)}`);
         }
     }
 
@@ -186,7 +192,9 @@
             state.studies = await loadSampleStudies(samplePath, button, buttonLabel);
             await displayStudies();
         } catch (err) {
-            alert(`Error loading sample: ${err.message}`);
+            if (err?.name === 'AbortError') return;
+            console.error('Sample load failed:', err);
+            alert(`Error loading sample: ${getErrorMessage(err)}`);
         }
     }
 

--- a/docs/js/app/sources.js
+++ b/docs/js/app/sources.js
@@ -15,6 +15,8 @@
     const DESKTOP_MAX_CONCURRENT_LARGE_READS = 2;
     const DESKTOP_SCAN_HEADER_BYTES = 256 * 1024;
     const DESKTOP_SCAN_HEADER_READ_SIZES = Object.freeze([64 * 1024, DESKTOP_SCAN_HEADER_BYTES]);
+    // See docs/planning/REMEDIATION-PLAN.md (DBG-MEDIUM-9).
+    const SAMPLE_FETCH_BATCH_SIZE = 20;
     const DESKTOP_SCAN_SKIP_EXTENSIONS = new Set([
         '.bmp',
         '.chm',
@@ -55,13 +57,14 @@
     const DESKTOP_SCAN_SKIP_DIRECTORY_NAMES = new Set(['__macosx', 'catapult', 'ddv', 'libraries', 'reviewer']);
     const SCAN_PROGRESS_UPDATE_INTERVAL = 200;
     const SCAN_YIELD_INTERVAL_MS = 16;
+    const { getErrorMessage = (_error, fallback = 'Unknown error') => fallback } = app.utils || {};
 
     function updateScanProgress(processed, total, valid) {
         if (processed % SCAN_PROGRESS_UPDATE_INTERVAL !== 0 && processed !== total) return;
 
         const pct = Math.round((processed / total) * 100);
         progressFill.style.animation = 'none';
-        progressFill.style.width = pct + '%';
+        progressFill.style.width = `${pct}%`;
         progressText.textContent = `Scanning... ${pct}%`;
         progressDetail.textContent = `${processed}/${total} files (${valid} viewable DICOM)`;
     }
@@ -78,6 +81,40 @@
         uploadProgress.style.display = 'none';
         progressFill.style.width = '0%';
         progressFill.style.animation = 'none';
+    }
+
+    function formatHttpStatus(response) {
+        const status = Number(response?.status);
+        const statusText = String(response?.statusText || '').trim();
+        if (!Number.isFinite(status)) {
+            return statusText || 'request failed';
+        }
+        return statusText ? `${status} ${statusText}` : `HTTP ${status}`;
+    }
+
+    async function fetchSampleManifest(samplePath) {
+        const manifestPath = `${samplePath}/manifest.json`;
+        const manifestRes = await fetch(manifestPath);
+        if (!manifestRes.ok) {
+            throw new Error(`Unable to load sample manifest from ${manifestPath} (${formatHttpStatus(manifestRes)}).`);
+        }
+
+        const fileNames = await manifestRes.json();
+        if (!Array.isArray(fileNames) || !fileNames.every((name) => typeof name === 'string' && name)) {
+            throw new Error('Sample manifest is invalid.');
+        }
+
+        return fileNames;
+    }
+
+    async function fetchSampleBlob(samplePath, name) {
+        const filePath = `${samplePath}/${name}`;
+        const res = await fetch(filePath);
+        if (!res.ok) {
+            throw new Error(`Unable to download ${filePath} (${formatHttpStatus(res)}).`);
+        }
+
+        return res.blob();
     }
 
     // Resolve the map key for a series within a study. Uses bare UID unless a
@@ -312,14 +349,6 @@
         stats[key] += delta;
     }
 
-    function getDesktopScanParseErrorMessage(error) {
-        if (!error) return '';
-        if (typeof error === 'string') return error;
-        if (typeof error.message === 'string' && error.message) return error.message;
-        if (typeof error.exception === 'string' && error.exception) return error.exception;
-        return String(error);
-    }
-
     function hasDicomPreamble(bytes) {
         return !!(
             bytes &&
@@ -358,7 +387,7 @@
             return true;
         }
 
-        const message = getDesktopScanParseErrorMessage(parseResult?.error).toLowerCase();
+        const message = getErrorMessage(parseResult?.error, '').toLowerCase();
         return DESKTOP_SCAN_TRUNCATION_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
     }
 
@@ -1426,43 +1455,42 @@
         progressFill.style.width = '0%';
 
         try {
-            const manifestRes = await fetch(`${samplePath}/manifest.json`);
-            const fileNames = await manifestRes.json();
-
-            progressText.textContent = 'Downloading DICOM files...';
-            progressDetail.textContent = `0/${fileNames.length} files`;
-
-            const filePromises = fileNames.map(async (name, i) => {
-                const res = await fetch(`${samplePath}/${name}`);
-                const blob = await res.blob();
-                if ((i + 1) % 5 === 0 || i === fileNames.length - 1) {
-                    const pct = Math.round(((i + 1) / fileNames.length) * 50);
-                    progressFill.style.width = `${pct}%`;
-                    progressDetail.textContent = `${i + 1}/${fileNames.length} files`;
-                }
-                return { name, blob };
-            });
-
-            const files = await Promise.all(filePromises);
-            progressText.textContent = 'Processing DICOM files...';
-            progressFill.style.width = '50%';
-
+            const fileNames = await fetchSampleManifest(samplePath);
+            const totalFiles = fileNames.length;
+            const totalProgressSteps = Math.max(totalFiles * 2, 1);
             const studies = {};
+            let downloaded = 0;
             let processed = 0;
 
-            for (const { blob } of files) {
-                const meta = await parseDicomMetadata(blob);
-                processed++;
+            progressText.textContent = 'Downloading DICOM files...';
+            progressDetail.textContent = `0/${totalFiles} files`;
 
-                const pct = 50 + Math.round((processed / files.length) * 50);
-                progressFill.style.width = `${pct}%`;
-                progressDetail.textContent = `Processing ${processed}/${files.length}`;
+            for (let batchStart = 0; batchStart < totalFiles; batchStart += SAMPLE_FETCH_BATCH_SIZE) {
+                const batchNames = fileNames.slice(batchStart, batchStart + SAMPLE_FETCH_BATCH_SIZE);
+                const files = await Promise.all(
+                    batchNames.map(async (name) => {
+                        const blob = await fetchSampleBlob(samplePath, name);
+                        downloaded++;
+                        progressText.textContent = 'Downloading DICOM files...';
+                        progressDetail.textContent = `${downloaded}/${totalFiles} files`;
+                        progressFill.style.width = `${Math.round(((downloaded + processed) / totalProgressSteps) * 100)}%`;
+                        return { blob };
+                    }),
+                );
 
-                if (!isRenderableImageMetadata(meta)) continue;
+                for (const { blob } of files) {
+                    const meta = await parseDicomMetadata(blob);
+                    processed++;
 
-                addSliceToStudies(studies, meta, { kind: 'blob', blob });
+                    progressText.textContent = 'Processing DICOM files...';
+                    progressDetail.textContent = `Processing ${processed}/${totalFiles}`;
+                    progressFill.style.width = `${Math.round(((downloaded + processed) / totalProgressSteps) * 100)}%`;
+
+                    if (!isRenderableImageMetadata(meta)) continue;
+
+                    addSliceToStudies(studies, meta, { kind: 'blob', blob });
+                }
             }
-
             return finalizeStudies(studies);
         } finally {
             hideProgressOverlay();

--- a/docs/js/app/utils.js
+++ b/docs/js/app/utils.js
@@ -36,6 +36,34 @@
                 return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
             });
         },
+        getErrorMessage(error, fallback = 'Unknown error') {
+            if (!error) {
+                return fallback;
+            }
+
+            if (typeof error === 'string') {
+                return error || fallback;
+            }
+
+            if (typeof error.message === 'string' && error.message.trim()) {
+                return error.message;
+            }
+
+            if (typeof error.exception === 'string' && error.exception.trim()) {
+                return error.exception;
+            }
+
+            const stringified = String(error);
+            if (
+                stringified === '[object Object]' &&
+                typeof error.constructor?.name === 'string' &&
+                error.constructor.name
+            ) {
+                return error.constructor.name;
+            }
+
+            return stringified || fallback;
+        },
         createStagedError(stage, message, extra = {}) {
             const error = new Error(message);
             error.stage = stage;

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -30,6 +30,11 @@ const { createSyntheticDicomFolder, removeSyntheticDicomFolder } = require('./di
 const TEST_URL = 'http://127.0.0.1:5001/?test';
 const APP_URL = 'http://127.0.0.1:5001/';
 const HOME_URL = 'http://127.0.0.1:5001/?nolib';
+const SAMPLE_FETCH_BATCH_SIZE = 20;
+const SAMPLE_CT_MANIFEST = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'docs', 'sample', 'manifest.json'), 'utf8'),
+);
+const SAMPLE_CT_BATCH_TEST_FILES = SAMPLE_CT_MANIFEST.slice(0, SAMPLE_FETCH_BATCH_SIZE + 5);
 
 // Selectors - kept consistent with viewing-tools.spec.js
 const CANVAS_SELECTOR = '#imageCanvas';
@@ -1109,6 +1114,66 @@ test.describe('Test Suite 22: Sample MRI Button', () => {
 
         // Toolbar should be visible
         await expect(page.locator(TOOLBAR_SELECTOR)).toBeVisible();
+    });
+});
+
+// ============================================================================
+// Test Suite 22A: Sample CT Loader Resilience
+// ============================================================================
+
+test.describe('Test Suite 22A: Sample CT Loader Resilience', () => {
+    test('Sample CT loader limits concurrent sample downloads', async ({ page }) => {
+        let inFlight = 0;
+        let maxInFlight = 0;
+
+        await page.route('**/sample/manifest.json', async (route) => {
+            await route.fulfill({ json: SAMPLE_CT_BATCH_TEST_FILES });
+        });
+        await page.route('**/sample/*.dcm', async (route) => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            try {
+                await new Promise((resolve) => setTimeout(resolve, 50));
+                await route.continue();
+            } finally {
+                inFlight--;
+            }
+        });
+
+        await page.goto(HOME_URL);
+        await page.locator('#loadSampleCtBtn').click();
+
+        await page.waitForSelector('#studiesTable', { state: 'visible', timeout: 60000 });
+        await expect(page.locator('#studiesBody tr').first()).toBeVisible({ timeout: 10000 });
+        expect(maxInFlight).toBeLessThanOrEqual(SAMPLE_FETCH_BATCH_SIZE);
+    });
+
+    test('Sample CT loader reports which sample file failed to download', async ({ page }) => {
+        await page.route('**/sample/manifest.json', async (route) => {
+            await route.fulfill({ json: ['02510.dcm', '02511.dcm'] });
+        });
+        await page.route('**/sample/02511.dcm', async (route) => {
+            await route.fulfill({
+                status: 500,
+                contentType: 'text/plain',
+                body: 'sample download failed',
+            });
+        });
+
+        await page.goto(HOME_URL);
+
+        const dialogPromise = page.waitForEvent('dialog');
+        await page.locator('#loadSampleCtBtn').click();
+        const dialog = await dialogPromise;
+
+        expect(dialog.message()).toMatch(
+            /Error loading sample: Unable to download sample\/02511\.dcm \((?:500 Internal Server Error|HTTP 500)\)\./,
+        );
+        expect(dialog.message()).not.toContain('undefined');
+        await dialog.accept();
+
+        await expect(page.locator('#loadSampleCtBtn')).toHaveText('CT Scan');
+        await expect(page.locator('#loadSampleCtBtn')).toBeEnabled();
     });
 });
 

--- a/tests/library-and-navigation.spec.js
+++ b/tests/library-and-navigation.spec.js
@@ -1148,6 +1148,44 @@ test.describe('Test Suite 22A: Sample CT Loader Resilience', () => {
         expect(maxInFlight).toBeLessThanOrEqual(SAMPLE_FETCH_BATCH_SIZE);
     });
 
+    test('Sample CT loader surfaces non-Error failures instead of "undefined"', async ({ page }) => {
+        await page.addInitScript(() => {
+            const app = window.DicomViewerApp || {};
+            let sourcesValue = app.sources;
+            Object.defineProperty(app, 'sources', {
+                configurable: true,
+                enumerable: true,
+                get() {
+                    return sourcesValue;
+                },
+                set(value) {
+                    sourcesValue = {
+                        ...value,
+                        loadSampleStudies: async () => {
+                            throw 'synthetic non-error';
+                        },
+                    };
+                },
+            });
+            window.DicomViewerApp = app;
+        });
+
+        await page.goto(HOME_URL);
+
+        const dialogPromise = page.waitForEvent('dialog');
+        await page.locator('#loadSampleCtBtn').evaluate((button) => {
+            setTimeout(() => button.click(), 0);
+        });
+        const dialog = await dialogPromise;
+
+        expect(dialog.message()).toContain('Error loading sample: synthetic non-error');
+        expect(dialog.message()).not.toContain('undefined');
+        await dialog.accept();
+
+        await expect(page.locator('#loadSampleCtBtn')).toHaveText('CT Scan');
+        await expect(page.locator('#loadSampleCtBtn')).toBeEnabled();
+    });
+
     test('Sample CT loader reports which sample file failed to download', async ({ page }) => {
         await page.route('**/sample/manifest.json', async (route) => {
             await route.fulfill({ json: ['02510.dcm', '02511.dcm'] });

--- a/workers/download/worker.js
+++ b/workers/download/worker.js
@@ -4,6 +4,31 @@
 const REPO = 'elgabrielc/dicom-viewer';
 const CACHE_TTL = 300; // 5 minutes
 const CACHE_KEY = 'https://myradone.com/_internal/download-url';
+const GITHUB_LATEST_RELEASE_URL = `https://github.com/${REPO}/releases/latest`;
+
+function extractTagName(location) {
+  if (!location) return '';
+
+  const match = location.match(/\/releases\/tag\/([^/?#]+)/);
+  return match?.[1] || '';
+}
+
+async function resolveLatestDmgUrl() {
+  const latestReleaseResp = await fetch(GITHUB_LATEST_RELEASE_URL, {
+    headers: {
+      'User-Agent': 'myradone-download-worker',
+    },
+    redirect: 'manual',
+  });
+
+  const tagName = extractTagName(latestReleaseResp.headers.get('location'));
+  if (!tagName) {
+    throw new Error('Could not resolve latest release tag');
+  }
+
+  const version = tagName.startsWith('v') ? tagName.slice(1) : tagName;
+  return `https://github.com/${REPO}/releases/download/${tagName}/myradone_${version}_aarch64.dmg`;
+}
 
 export default {
   async fetch(request) {
@@ -22,31 +47,19 @@ export default {
       return Response.redirect(dmgUrl, 302);
     }
 
-    const apiUrl = `https://api.github.com/repos/${REPO}/releases/latest`;
-    const resp = await fetch(apiUrl, {
-      headers: {
-        'Accept': 'application/vnd.github+json',
-        'User-Agent': 'myradone-download-worker',
-      },
-    });
-
-    if (!resp.ok) {
+    let dmgUrl = '';
+    try {
+      dmgUrl = await resolveLatestDmgUrl();
+    } catch (_error) {
       return new Response('Could not fetch release info', { status: 502 });
     }
 
-    const release = await resp.json();
-    const dmg = release.assets.find(a => a.name.endsWith('_aarch64.dmg'));
-
-    if (!dmg) {
-      return new Response('DMG not found in latest release', { status: 404 });
-    }
-
     // Store the URL string so the Cache API can actually cache it
-    const cacheResp = new Response(dmg.browser_download_url, {
+    const cacheResp = new Response(dmgUrl, {
       headers: { 'Cache-Control': `public, max-age=${CACHE_TTL}` },
     });
     await cache.put(CACHE_KEY, cacheResp);
 
-    return Response.redirect(dmg.browser_download_url, 302);
+    return Response.redirect(dmgUrl, 302);
   },
 };

--- a/workers/download/worker.js
+++ b/workers/download/worker.js
@@ -6,11 +6,25 @@ const CACHE_TTL = 300; // 5 minutes
 const CACHE_KEY = 'https://myradone.com/_internal/download-url';
 const GITHUB_LATEST_RELEASE_URL = `https://github.com/${REPO}/releases/latest`;
 
+function formatHttpStatus(response) {
+  const status = Number(response?.status);
+  const statusText = String(response?.statusText || '').trim();
+  if (!Number.isFinite(status)) return statusText || 'request failed';
+  return statusText ? `${status} ${statusText}` : `HTTP ${status}`;
+}
+
 function extractTagName(location) {
   if (!location) return '';
 
   const match = location.match(/\/releases\/tag\/([^/?#]+)/);
   return match?.[1] || '';
+}
+
+// Keep this naming in sync with the release workflow, which publishes the
+// public arm64 installer under myradone_${version}_aarch64.dmg.
+function buildPublishedDmgUrl(tagName) {
+  const version = tagName.startsWith('v') ? tagName.slice(1) : tagName;
+  return `https://github.com/${REPO}/releases/download/${tagName}/myradone_${version}_aarch64.dmg`;
 }
 
 async function resolveLatestDmgUrl() {
@@ -21,13 +35,18 @@ async function resolveLatestDmgUrl() {
     redirect: 'manual',
   });
 
+  if (latestReleaseResp.status !== 302) {
+    throw new Error(
+      `Unexpected response from ${GITHUB_LATEST_RELEASE_URL} (${formatHttpStatus(latestReleaseResp)}).`,
+    );
+  }
+
   const tagName = extractTagName(latestReleaseResp.headers.get('location'));
   if (!tagName) {
     throw new Error('Could not resolve latest release tag');
   }
 
-  const version = tagName.startsWith('v') ? tagName.slice(1) : tagName;
-  return `https://github.com/${REPO}/releases/download/${tagName}/myradone_${version}_aarch64.dmg`;
+  return buildPublishedDmgUrl(tagName);
 }
 
 export default {
@@ -50,7 +69,8 @@ export default {
     let dmgUrl = '';
     try {
       dmgUrl = await resolveLatestDmgUrl();
-    } catch (_error) {
+    } catch (error) {
+      console.error('Failed to resolve latest release DMG URL', error);
       return new Response('Could not fetch release info', { status: 502 });
     }
 


### PR DESCRIPTION
## Summary
- fix sample load alerts so failures no longer surface as `undefined`
- batch sample downloads in groups of 20 with fetch-and-parse per batch to reduce peak memory pressure
- add explicit manifest/file HTTP error handling and regression coverage for bounded concurrency and failed sample downloads

## Verification
- `npx biome check docs/js/app/utils.js docs/js/app/main.js docs/js/app/sources.js docs/js/app/import-pipeline.js tests/library-and-navigation.spec.js`
- `npx playwright test tests/library-and-navigation.spec.js -g "Sample CT loader" --workers=1`

## Release Note
- a local plain DMG was built successfully for device testing
- updater artifact signing still relies on the existing CI/release workflow secrets (`TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`)
