### PR TITLE
[codex] Add subscriber admin dashboard worker

### DIFF
--- a/docs/decisions/012-email-signup-and-contact.md
+++ b/docs/decisions/012-email-signup-and-contact.md
@@ -52,6 +52,7 @@ Rejected. CORS alone does not stop direct POST spam. Turnstile provides a lightw
 - The Worker treats a signup for an unsubscribed address as a reactivation instead of returning a duplicate success.
 - The landing page ships with Cloudflare's visible Turnstile test site key by default so local testing works before production credentials are added.
 - A static privacy page lives next to the landing page so the consent copy points to a real document immediately.
+- The subscriber write path now has a matching internal read path at `workers/dashboard/`, a separate protected Worker that exposes subscriber analytics and a paginated list view without requiring ad hoc `wrangler d1 execute` access.
 
 ## Consequences
 

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -1,0 +1,290 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    DASHBOARD_PATH,
+    SUMMARY_PATH,
+    SUBSCRIBERS_PATH,
+    authenticate,
+    createErrorResponse,
+    dispatchRequest,
+    handleDashboard,
+    handleSubscribers,
+    handleSummary
+} from '../workers/dashboard/src/lib.mjs';
+
+const DASHBOARD_HTML = '<!doctype html><html><body data-dashboard-shell="true">dashboard</body></html>';
+
+function createEnv({ subscribers = [], token = 'secret-token', rateLimitSuccess = true } = {}) {
+    return {
+        DASHBOARD_TOKEN: token,
+        DASHBOARD_RATE_LIMIT: {
+            async limit() {
+                return { success: rateLimitSuccess };
+            }
+        },
+        SUBSCRIBERS_DB: createDb(subscribers)
+    };
+}
+
+function createDb(initialSubscribers) {
+    const subscribers = initialSubscribers.map((subscriber, index) => ({
+        id: index + 1,
+        email: subscriber.email,
+        status: subscriber.status ?? 'active',
+        subscribed_at: subscriber.subscribed_at ?? '2026-04-12 12:00:00',
+        source: subscriber.source ?? 'landing',
+        consent_version: subscriber.consent_version ?? 'v1'
+    }));
+
+    return {
+        prepare(query) {
+            return {
+                args: [],
+                bind(...args) {
+                    this.args = args;
+                    return this;
+                },
+                async first() {
+                    if (query.includes('COUNT(*) AS total') && query.includes("status = 'active'")) {
+                        const total = subscribers.length;
+                        const active = subscribers.filter((row) => row.status === 'active').length;
+                        const unsubscribed = subscribers.filter((row) => row.status === 'unsubscribed').length;
+                        return { total, active, unsubscribed };
+                    }
+
+                    if (query.startsWith('SELECT COUNT(*) AS total FROM subscribers')) {
+                        return { total: filterSubscribers(query, this.args, subscribers).length };
+                    }
+
+                    throw new Error(`Unhandled first() query: ${query}`);
+                },
+                async all() {
+                    if (query.startsWith('SELECT source, status, COUNT(*) AS count')) {
+                        const grouped = new Map();
+                        for (const subscriber of subscribers) {
+                            const key = `${subscriber.source}:${subscriber.status}`;
+                            grouped.set(key, (grouped.get(key) || 0) + 1);
+                        }
+
+                        return {
+                            results: [...grouped.entries()]
+                                .map(([key, count]) => {
+                                    const [source, status] = key.split(':');
+                                    return { source, status, count };
+                                })
+                                .sort((left, right) => left.source.localeCompare(right.source) || left.status.localeCompare(right.status))
+                        };
+                    }
+
+                    if (query.startsWith('WITH RECURSIVE days(day) AS')) {
+                        return {
+                            results: buildDailyRows(subscribers)
+                        };
+                    }
+
+                    if (query.includes('SELECT id, email, status, subscribed_at, source, consent_version')) {
+                        const filtered = filterSubscribers(query, this.args, subscribers);
+                        const [limit, offset] = extractPagination(query, this.args);
+                        const { column, direction } = extractSort(query);
+                        const sorted = [...filtered].sort((left, right) => compareRows(left, right, column, direction));
+                        return {
+                            results: sorted.slice(offset, offset + limit)
+                        };
+                    }
+
+                    throw new Error(`Unhandled all() query: ${query}`);
+                }
+            };
+        }
+    };
+}
+
+function filterSubscribers(query, args, subscribers) {
+    let bindIndex = 0;
+    let rows = [...subscribers];
+
+    if (query.includes('status = ?')) {
+        const status = args[bindIndex];
+        bindIndex += 1;
+        rows = rows.filter((row) => row.status === status);
+    }
+
+    if (query.includes('source = ?')) {
+        const source = args[bindIndex];
+        rows = rows.filter((row) => row.source === source);
+    }
+
+    return rows;
+}
+
+function extractPagination(query, args) {
+    const needsStatus = query.includes('status = ?');
+    const needsSource = query.includes('source = ?');
+    const offsetIndex = (needsStatus ? 1 : 0) + (needsSource ? 1 : 0);
+    return [args[offsetIndex], args[offsetIndex + 1]];
+}
+
+function extractSort(query) {
+    const match = query.match(/ORDER BY ([a-z_]+) (ASC|DESC), id (ASC|DESC)/i);
+    return {
+        column: match ? match[1] : 'subscribed_at',
+        direction: match ? match[2].toLowerCase() : 'desc'
+    };
+}
+
+function compareRows(left, right, column, direction) {
+    const factor = direction === 'asc' ? 1 : -1;
+    const leftValue = left[column];
+    const rightValue = right[column];
+
+    if (leftValue < rightValue) return -1 * factor;
+    if (leftValue > rightValue) return 1 * factor;
+
+    return (left.id - right.id) * factor;
+}
+
+function buildDailyRows(subscribers) {
+    const counts = new Map();
+    for (const subscriber of subscribers) {
+        const day = subscriber.subscribed_at.slice(0, 10);
+        counts.set(day, (counts.get(day) || 0) + 1);
+    }
+
+    const today = new Date('2026-04-12T00:00:00Z');
+    const rows = [];
+    for (let index = 29; index >= 0; index -= 1) {
+        const date = new Date(today);
+        date.setUTCDate(today.getUTCDate() - index);
+        const day = date.toISOString().slice(0, 10);
+        rows.push({
+            day,
+            count: counts.get(day) || 0
+        });
+    }
+
+    return rows;
+}
+
+function createRequest(path, { token = null, method = 'GET' } = {}) {
+    const headers = new Headers();
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+    return new Request(`https://dashboard.myradone.com${path}`, {
+        method,
+        headers
+    });
+}
+
+test('authenticate rejects missing and wrong tokens, accepts matching token', () => {
+    const env = createEnv();
+
+    assert.equal(authenticate(createRequest(DASHBOARD_PATH), env), false);
+    assert.equal(authenticate(createRequest(DASHBOARD_PATH, { token: 'wrong' }), env), false);
+    assert.equal(authenticate(createRequest(DASHBOARD_PATH, { token: 'secret-token' }), env), true);
+});
+
+test('handleDashboard returns login page without auth and shell with auth', async () => {
+    const env = createEnv();
+
+    const loginResponse = await handleDashboard(createRequest(DASHBOARD_PATH), env, DASHBOARD_HTML);
+    assert.equal(loginResponse.status, 200);
+    assert.match(await loginResponse.text(), /Open dashboard/);
+
+    const shellResponse = await handleDashboard(
+        createRequest(DASHBOARD_PATH, { token: 'secret-token' }),
+        env,
+        DASHBOARD_HTML
+    );
+    assert.equal(shellResponse.status, 200);
+    assert.match(await shellResponse.text(), /data-dashboard-shell="true"/);
+});
+
+test('handleSummary returns empty shapes on an empty database', async () => {
+    const env = createEnv({ subscribers: [] });
+    const payload = await handleSummary(env);
+
+    assert.deepEqual(payload.counts, {
+        total: 0,
+        active: 0,
+        unsubscribed: 0
+    });
+    assert.equal(payload.sources.length, 3);
+    assert.equal(payload.daily.length, 30);
+});
+
+test('handleSubscribers rejects invalid filters and sort params', async () => {
+    const env = createEnv();
+
+    await assert.rejects(
+        () => handleSubscribers(createRequest(`${SUBSCRIBERS_PATH}?status=bad`), env),
+        /Invalid status filter/
+    );
+    await assert.rejects(
+        () => handleSubscribers(createRequest(`${SUBSCRIBERS_PATH}?source=other`), env),
+        /Invalid source filter/
+    );
+    await assert.rejects(
+        () => handleSubscribers(createRequest(`${SUBSCRIBERS_PATH}?sort=created_at`), env),
+        /Invalid sort column/
+    );
+    await assert.rejects(
+        () => handleSubscribers(createRequest(`${SUBSCRIBERS_PATH}?order=sideways`), env),
+        /Invalid sort order/
+    );
+});
+
+test('handleSubscribers enforces per_page <= 100', async () => {
+    const env = createEnv();
+
+    await assert.rejects(
+        () => handleSubscribers(createRequest(`${SUBSCRIBERS_PATH}?per_page=101`), env),
+        /Integer parameter out of range/
+    );
+});
+
+test('handleSubscribers paginates and sorts seeded subscribers', async () => {
+    const env = createEnv({
+        subscribers: [
+            { email: 'zeta@example.com', source: 'demo', subscribed_at: '2026-04-10 08:00:00' },
+            { email: 'alpha@example.com', source: 'landing', subscribed_at: '2026-04-12 09:00:00' },
+            { email: 'beta@example.com', source: 'app', status: 'unsubscribed', subscribed_at: '2026-04-11 07:00:00' }
+        ]
+    });
+
+    const payload = await handleSubscribers(
+        createRequest(`${SUBSCRIBERS_PATH}?sort=email&order=asc&per_page=2&page=1`),
+        env
+    );
+
+    assert.equal(payload.subscribers.length, 2);
+    assert.equal(payload.subscribers[0].email, 'alpha@example.com');
+    assert.equal(payload.pagination.total, 3);
+    assert.equal(payload.pagination.total_pages, 2);
+});
+
+test('dispatchRequest returns 401 for unauthenticated API requests and 429 when rate-limited', async () => {
+    const env = createEnv();
+
+    const unauthorized = await dispatchRequest(createRequest(SUMMARY_PATH), env, DASHBOARD_HTML);
+    assert.equal(unauthorized.status, 401);
+    assert.deepEqual(await unauthorized.json(), { error: 'Unauthorized' });
+
+    const rateLimitedEnv = createEnv({ rateLimitSuccess: false });
+    const rateLimited = await dispatchRequest(createRequest(SUMMARY_PATH), rateLimitedEnv, DASHBOARD_HTML);
+    assert.equal(rateLimited.status, 429);
+});
+
+test('createErrorResponse turns unexpected failures into JSON 500 payloads', async () => {
+    const request = createRequest(SUBSCRIBERS_PATH);
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    const response = createErrorResponse(request, new Error('boom'));
+
+    console.error = originalConsoleError;
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(await response.json(), { error: 'Server error' });
+});

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
 
 import {
     DASHBOARD_PATH,
@@ -15,6 +17,24 @@ import {
 } from '../workers/dashboard/src/lib.mjs';
 
 const DASHBOARD_HTML = '<!doctype html><html><body data-dashboard-shell="true">dashboard</body></html>';
+const REAL_DASHBOARD_HTML = fs.readFileSync(
+    new URL('../workers/dashboard/src/dashboard.html', import.meta.url),
+    'utf8'
+);
+
+function extractInlineScript(html) {
+    const match = html.match(/<script>([\s\S]*?)<\/script>/);
+    assert.ok(match, 'expected inline script');
+    return match[1];
+}
+
+function sha256Base64(value) {
+    return crypto.createHash('sha256').update(value).digest('base64');
+}
+
+function sha256Hex(value) {
+    return crypto.createHash('sha256').update(value).digest('hex');
+}
 
 function createEnv({ subscribers = [], token = 'secret-token', rateLimitSuccess = true } = {}) {
     return {
@@ -181,13 +201,23 @@ function createRequest(path, { token = null, cookieToken = null, method = 'GET' 
     });
 }
 
-test('authenticate rejects missing and wrong tokens, accepts matching token', () => {
+test('authenticate rejects missing and wrong tokens, accepts matching token', async () => {
     const env = createEnv();
 
-    assert.equal(authenticate(createRequest(DASHBOARD_PATH), env), false);
-    assert.equal(authenticate(createRequest(DASHBOARD_PATH, { token: 'wrong' }), env), false);
-    assert.equal(authenticate(createRequest(DASHBOARD_PATH, { token: 'secret-token' }), env), true);
-    assert.equal(authenticate(createRequest(DASHBOARD_PATH, { cookieToken: 'secret-token' }), env), true);
+    assert.equal(await authenticate(createRequest(DASHBOARD_PATH), env), false);
+    assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { token: 'wrong' }), env), false);
+    assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { token: 'secret-token' }), env), true);
+
+    const sessionLogin = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'POST', token: 'secret-token' }),
+        env,
+        DASHBOARD_HTML
+    );
+    const cookieValue = decodeURIComponent(
+        sessionLogin.headers.get('Set-Cookie').match(/myradone_dashboard_token=([^;]+)/)[1]
+    );
+    assert.equal(cookieValue, sha256Hex('secret-token'));
+    assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { cookieToken: cookieValue }), env), true);
 });
 
 test('handleDashboard returns login page without auth and shell with auth', async () => {
@@ -195,18 +225,30 @@ test('handleDashboard returns login page without auth and shell with auth', asyn
 
     const loginResponse = await handleDashboard(createRequest(DASHBOARD_PATH), env, DASHBOARD_HTML);
     assert.equal(loginResponse.status, 200);
-    assert.match(await loginResponse.text(), /Open dashboard/);
+    const loginHtml = await loginResponse.text();
+    assert.match(loginHtml, /Open dashboard/);
     assert.match(loginResponse.headers.get('Set-Cookie'), /Max-Age=0/);
 
-    const shellResponse = await handleDashboard(
-        createRequest(DASHBOARD_PATH, { cookieToken: 'secret-token' }),
+    const sessionLogin = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'POST', token: 'secret-token' }),
         env,
-        DASHBOARD_HTML
+        REAL_DASHBOARD_HTML
     );
+    const cookieValue = decodeURIComponent(
+        sessionLogin.headers.get('Set-Cookie').match(/myradone_dashboard_token=([^;]+)/)[1]
+    );
+    const shellResponse = await handleDashboard(createRequest(DASHBOARD_PATH, { cookieToken: cookieValue }), env, REAL_DASHBOARD_HTML);
     assert.equal(shellResponse.status, 200);
-    assert.match(await shellResponse.text(), /data-dashboard-shell="true"/);
+    const shellHtml = await shellResponse.text();
+    assert.match(shellHtml, /data-dashboard-shell="true"/);
     assert.match(shellResponse.headers.get('Content-Security-Policy'), /script-src 'sha256-/);
     assert.doesNotMatch(shellResponse.headers.get('Content-Security-Policy'), /script-src 'unsafe-inline'/);
+
+    const loginScriptHash = sha256Base64(extractInlineScript(loginHtml));
+    assert.match(loginResponse.headers.get('Content-Security-Policy'), new RegExp(loginScriptHash.replaceAll('+', '\\+').replaceAll('/', '\\/')));
+
+    const dashboardScriptHash = sha256Base64(extractInlineScript(shellHtml));
+    assert.match(shellResponse.headers.get('Content-Security-Policy'), new RegExp(dashboardScriptHash.replaceAll('+', '\\+').replaceAll('/', '\\/')));
 });
 
 test('handleSummary returns empty shapes on an empty database', async () => {
@@ -328,6 +370,13 @@ test('dispatchRequest creates and clears dashboard sessions', async () => {
     );
     assert.equal(logoutResponse.status, 204);
     assert.match(logoutResponse.headers.get('Set-Cookie'), /Max-Age=0/);
+});
+
+test('logout is not blocked by the dashboard rate limiter', async () => {
+    const env = createEnv({ rateLimitSuccess: false });
+    const response = await dispatchRequest(createRequest(SESSION_PATH, { method: 'DELETE' }), env, DASHBOARD_HTML);
+
+    assert.equal(response.status, 204);
 });
 
 test('createErrorResponse turns unexpected failures into JSON 500 payloads', async () => {

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -9,11 +9,13 @@ import {
     SUMMARY_PATH,
     SUBSCRIBERS_PATH,
     authenticate,
+    createSignedSessionValue,
     createErrorResponse,
     dispatchRequest,
     handleDashboard,
     handleSubscribers,
-    handleSummary
+    handleSummary,
+    verifySignedSessionValue
 } from '../workers/dashboard/src/lib.mjs';
 
 const DASHBOARD_HTML = '<!doctype html><html><body data-dashboard-shell="true">dashboard</body></html>';
@@ -30,10 +32,6 @@ function extractInlineScript(html) {
 
 function sha256Base64(value) {
     return crypto.createHash('sha256').update(value).digest('base64');
-}
-
-function sha256Hex(value) {
-    return crypto.createHash('sha256').update(value).digest('hex');
 }
 
 function createEnv({ subscribers = [], token = 'secret-token', rateLimitSuccess = true } = {}) {
@@ -216,8 +214,20 @@ test('authenticate rejects missing and wrong tokens, accepts matching token', as
     const cookieValue = decodeURIComponent(
         sessionLogin.headers.get('Set-Cookie').match(/myradone_dashboard_token=([^;]+)/)[1]
     );
-    assert.equal(cookieValue, sha256Hex('secret-token'));
+    assert.match(cookieValue, /^v1\.\d+\.[0-9a-f]{64}$/);
+    assert.equal(await verifySignedSessionValue(cookieValue, 'secret-token'), true);
     assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { cookieToken: cookieValue }), env), true);
+});
+
+test('signed session values expire server-side', async () => {
+    const nowMs = Date.UTC(2026, 3, 12, 12, 0, 0);
+    const value = await createSignedSessionValue('secret-token', nowMs);
+
+    assert.equal(await verifySignedSessionValue(value, 'secret-token', nowMs + 1_000), true);
+    assert.equal(
+        await verifySignedSessionValue(value, 'secret-token', nowMs + 12 * 60 * 60 * 1000 + 1),
+        false
+    );
 });
 
 test('handleDashboard returns login page without auth and shell with auth', async () => {
@@ -304,7 +314,7 @@ test('handleSubscribers invalid integer errors do not reflect raw input', async 
     try {
         await handleSubscribers(request, env);
     } catch (error) {
-        response = createErrorResponse(request, error);
+        response = await createErrorResponse(request, error);
     }
 
     assert.ok(response);
@@ -384,7 +394,7 @@ test('createErrorResponse turns unexpected failures into JSON 500 payloads', asy
     const originalConsoleError = console.error;
     console.error = () => {};
 
-    const response = createErrorResponse(request, new Error('boom'));
+    const response = await createErrorResponse(request, new Error('boom'));
 
     console.error = originalConsoleError;
 

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -239,6 +239,11 @@ test('tampered session values are rejected', async () => {
     assert.equal(await verifySignedSessionValue(tampered, 'secret-token'), false);
 });
 
+test('malformed session values are rejected', async () => {
+    assert.equal(await verifySignedSessionValue('v1.123abc.'.concat('0'.repeat(64)), 'secret-token'), false);
+    assert.equal(await verifySignedSessionValue('v1.123456.short', 'secret-token'), false);
+});
+
 test('handleDashboard returns login page without auth and shell with auth', async () => {
     const env = createEnv();
 

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -199,6 +199,10 @@ function createRequest(path, { token = null, cookieToken = null, method = 'GET' 
     });
 }
 
+function extractCookieValue(setCookieHeader) {
+    return decodeURIComponent(setCookieHeader.match(/myradone_dashboard_token=([^;]+)/)[1]);
+}
+
 test('authenticate rejects missing and wrong tokens, accepts matching token', async () => {
     const env = createEnv();
 
@@ -211,9 +215,7 @@ test('authenticate rejects missing and wrong tokens, accepts matching token', as
         env,
         DASHBOARD_HTML
     );
-    const cookieValue = decodeURIComponent(
-        sessionLogin.headers.get('Set-Cookie').match(/myradone_dashboard_token=([^;]+)/)[1]
-    );
+    const cookieValue = extractCookieValue(sessionLogin.headers.get('Set-Cookie'));
     assert.match(cookieValue, /^v1\.\d+\.[0-9a-f]{64}$/);
     assert.equal(await verifySignedSessionValue(cookieValue, 'secret-token'), true);
     assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { cookieToken: cookieValue }), env), true);
@@ -230,6 +232,13 @@ test('signed session values expire server-side', async () => {
     );
 });
 
+test('tampered session values are rejected', async () => {
+    const value = await createSignedSessionValue('secret-token', Date.UTC(2026, 3, 12, 12, 0, 0));
+    const tampered = value.replace(/\.[0-9a-f]{64}$/, '.'.concat('0'.repeat(64)));
+
+    assert.equal(await verifySignedSessionValue(tampered, 'secret-token'), false);
+});
+
 test('handleDashboard returns login page without auth and shell with auth', async () => {
     const env = createEnv();
 
@@ -244,9 +253,7 @@ test('handleDashboard returns login page without auth and shell with auth', asyn
         env,
         REAL_DASHBOARD_HTML
     );
-    const cookieValue = decodeURIComponent(
-        sessionLogin.headers.get('Set-Cookie').match(/myradone_dashboard_token=([^;]+)/)[1]
-    );
+    const cookieValue = extractCookieValue(sessionLogin.headers.get('Set-Cookie'));
     const shellResponse = await handleDashboard(createRequest(DASHBOARD_PATH, { cookieToken: cookieValue }), env, REAL_DASHBOARD_HTML);
     assert.equal(shellResponse.status, 200);
     const shellHtml = await shellResponse.text();
@@ -364,6 +371,7 @@ test('dispatchRequest creates and clears dashboard sessions', async () => {
     );
     assert.equal(loginResponse.status, 204);
     assert.match(loginResponse.headers.get('Set-Cookie'), /HttpOnly/);
+    assert.match(loginResponse.headers.get('Set-Cookie'), /Expires=/);
     assert.match(loginResponse.headers.get('Set-Cookie'), /myradone_dashboard_token=/);
 
     const rejectedLogin = await dispatchRequest(
@@ -372,6 +380,7 @@ test('dispatchRequest creates and clears dashboard sessions', async () => {
         DASHBOARD_HTML
     );
     assert.equal(rejectedLogin.status, 401);
+    assert.equal(rejectedLogin.headers.get('WWW-Authenticate'), 'Bearer realm="myradone-dashboard"');
 
     const logoutResponse = await dispatchRequest(
         createRequest(SESSION_PATH, { method: 'DELETE' }),
@@ -379,6 +388,7 @@ test('dispatchRequest creates and clears dashboard sessions', async () => {
         DASHBOARD_HTML
     );
     assert.equal(logoutResponse.status, 204);
+    assert.match(logoutResponse.headers.get('Set-Cookie'), /Expires=Thu, 01 Jan 1970 00:00:00 GMT/);
     assert.match(logoutResponse.headers.get('Set-Cookie'), /Max-Age=0/);
 });
 
@@ -387,6 +397,19 @@ test('logout is not blocked by the dashboard rate limiter', async () => {
     const response = await dispatchRequest(createRequest(SESSION_PATH, { method: 'DELETE' }), env, DASHBOARD_HTML);
 
     assert.equal(response.status, 204);
+});
+
+test('tampered dashboard cookies fall back to login and get cleared', async () => {
+    const env = createEnv();
+    const response = await handleDashboard(
+        createRequest(DASHBOARD_PATH, { cookieToken: 'v1.9999999999999.'.concat('0'.repeat(64)) }),
+        env,
+        REAL_DASHBOARD_HTML
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Set-Cookie'), /Max-Age=0/);
+    assert.match(await response.text(), /Open dashboard/);
 });
 
 test('createErrorResponse turns unexpected failures into JSON 500 payloads', async () => {

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
     DASHBOARD_PATH,
+    SESSION_PATH,
     SUMMARY_PATH,
     SUBSCRIBERS_PATH,
     authenticate,
@@ -166,10 +167,13 @@ function buildDailyRows(subscribers) {
     return rows;
 }
 
-function createRequest(path, { token = null, method = 'GET' } = {}) {
+function createRequest(path, { token = null, cookieToken = null, method = 'GET' } = {}) {
     const headers = new Headers();
     if (token) {
         headers.set('Authorization', `Bearer ${token}`);
+    }
+    if (cookieToken) {
+        headers.set('Cookie', `myradone_dashboard_token=${encodeURIComponent(cookieToken)}`);
     }
     return new Request(`https://dashboard.myradone.com${path}`, {
         method,
@@ -183,6 +187,7 @@ test('authenticate rejects missing and wrong tokens, accepts matching token', ()
     assert.equal(authenticate(createRequest(DASHBOARD_PATH), env), false);
     assert.equal(authenticate(createRequest(DASHBOARD_PATH, { token: 'wrong' }), env), false);
     assert.equal(authenticate(createRequest(DASHBOARD_PATH, { token: 'secret-token' }), env), true);
+    assert.equal(authenticate(createRequest(DASHBOARD_PATH, { cookieToken: 'secret-token' }), env), true);
 });
 
 test('handleDashboard returns login page without auth and shell with auth', async () => {
@@ -191,14 +196,17 @@ test('handleDashboard returns login page without auth and shell with auth', asyn
     const loginResponse = await handleDashboard(createRequest(DASHBOARD_PATH), env, DASHBOARD_HTML);
     assert.equal(loginResponse.status, 200);
     assert.match(await loginResponse.text(), /Open dashboard/);
+    assert.match(loginResponse.headers.get('Set-Cookie'), /Max-Age=0/);
 
     const shellResponse = await handleDashboard(
-        createRequest(DASHBOARD_PATH, { token: 'secret-token' }),
+        createRequest(DASHBOARD_PATH, { cookieToken: 'secret-token' }),
         env,
         DASHBOARD_HTML
     );
     assert.equal(shellResponse.status, 200);
     assert.match(await shellResponse.text(), /data-dashboard-shell="true"/);
+    assert.match(shellResponse.headers.get('Content-Security-Policy'), /script-src 'sha256-/);
+    assert.doesNotMatch(shellResponse.headers.get('Content-Security-Policy'), /script-src 'unsafe-inline'/);
 });
 
 test('handleSummary returns empty shapes on an empty database', async () => {
@@ -244,6 +252,23 @@ test('handleSubscribers enforces per_page <= 100', async () => {
     );
 });
 
+test('handleSubscribers invalid integer errors do not reflect raw input', async () => {
+    const env = createEnv();
+    const request = createRequest(`${SUBSCRIBERS_PATH}?page=%3Cscript%3Ealert(1)%3C/script%3E`, {
+        cookieToken: 'secret-token'
+    });
+
+    let response = null;
+    try {
+        await handleSubscribers(request, env);
+    } catch (error) {
+        response = createErrorResponse(request, error);
+    }
+
+    assert.ok(response);
+    assert.deepEqual(await response.json(), { error: 'Invalid integer parameter' });
+});
+
 test('handleSubscribers paginates and sorts seeded subscribers', async () => {
     const env = createEnv({
         subscribers: [
@@ -270,10 +295,39 @@ test('dispatchRequest returns 401 for unauthenticated API requests and 429 when 
     const unauthorized = await dispatchRequest(createRequest(SUMMARY_PATH), env, DASHBOARD_HTML);
     assert.equal(unauthorized.status, 401);
     assert.deepEqual(await unauthorized.json(), { error: 'Unauthorized' });
+    assert.match(unauthorized.headers.get('Set-Cookie'), /Max-Age=0/);
 
     const rateLimitedEnv = createEnv({ rateLimitSuccess: false });
     const rateLimited = await dispatchRequest(createRequest(SUMMARY_PATH), rateLimitedEnv, DASHBOARD_HTML);
     assert.equal(rateLimited.status, 429);
+});
+
+test('dispatchRequest creates and clears dashboard sessions', async () => {
+    const env = createEnv();
+
+    const loginResponse = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'POST', token: 'secret-token' }),
+        env,
+        DASHBOARD_HTML
+    );
+    assert.equal(loginResponse.status, 204);
+    assert.match(loginResponse.headers.get('Set-Cookie'), /HttpOnly/);
+    assert.match(loginResponse.headers.get('Set-Cookie'), /myradone_dashboard_token=/);
+
+    const rejectedLogin = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'POST', token: 'wrong' }),
+        env,
+        DASHBOARD_HTML
+    );
+    assert.equal(rejectedLogin.status, 401);
+
+    const logoutResponse = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'DELETE' }),
+        env,
+        DASHBOARD_HTML
+    );
+    assert.equal(logoutResponse.status, 204);
+    assert.match(logoutResponse.headers.get('Set-Cookie'), /Max-Age=0/);
 });
 
 test('createErrorResponse turns unexpected failures into JSON 500 payloads', async () => {

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -13,8 +13,11 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 
 ## Endpoints
 
-- `GET /` - Protected dashboard shell. Without a valid bearer token, returns a
-  minimal login page.
+- `GET /` - Protected dashboard shell. Without a valid dashboard session cookie
+  or bearer token, returns a minimal login page.
+- `POST /api/session` - Validates a bearer token and mints the browser session
+  cookie used by the dashboard shell.
+- `DELETE /api/session` - Clears the dashboard session cookie.
 - `GET /api/summary` - Aggregate subscriber counts, source mix, and 30-day daily
   signup totals.
 - `GET /api/subscribers` - Paginated subscriber list with allowlisted
@@ -32,9 +35,13 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 ## Security Notes
 
 - The dashboard uses a single shared bearer token from `DASHBOARD_TOKEN`.
+- Browser login exchanges that token for a same-site `HttpOnly` session cookie
+  via `POST /api/session`, so the full dashboard flow does not depend on
+  `sessionStorage` or `document.write`.
 - Rate limiting runs before auth and applies to the entire worker.
 - Every response is `Cache-Control: no-store`.
 - The worker sets CSP, frame, referrer, and content-type hardening headers.
+  HTML responses use script hashes instead of `script-src 'unsafe-inline'`.
 - D1 access is read-only by convention, not by enforced binding mode. This
   worker only issues `SELECT` queries.
 
@@ -118,7 +125,8 @@ Manual:
 3. Enter the token and confirm the summary cards, recent signups, and full table
    render.
 4. Exercise filters, sorting, and pagination.
-5. Confirm invalid tokens fail with `401` on API requests.
+5. Confirm invalid login attempts stay on the login page and valid logout returns
+   you there.
 6. Inspect headers with:
 
    ```bash

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -45,6 +45,8 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 - The worker sets CSP, frame, referrer, and content-type hardening headers.
   HTML responses derive script hashes from the inline scripts they actually
   serve instead of relying on hand-maintained hash constants.
+- `401` API responses include `WWW-Authenticate: Bearer realm="myradone-dashboard"`
+  so CLI and browser tooling get a clearer auth signal.
 - D1 access is read-only by convention, not by enforced binding mode. This
   worker only issues `SELECT` queries.
 

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -38,12 +38,13 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 - Browser login exchanges that token for a same-site `HttpOnly` session cookie
   via `POST /api/session`, so the full dashboard flow does not depend on
   `sessionStorage` or `document.write`.
-- The session cookie stores a derived verifier rather than the raw shared
-  secret, and expires after 12 hours.
+- The session cookie stores a signed, time-bound verifier rather than the raw
+  shared secret, and the worker enforces the 12-hour expiry server-side.
 - Rate limiting runs before auth and applies to the entire worker.
 - Every response is `Cache-Control: no-store`.
 - The worker sets CSP, frame, referrer, and content-type hardening headers.
-  HTML responses use script hashes instead of `script-src 'unsafe-inline'`.
+  HTML responses derive script hashes from the inline scripts they actually
+  serve instead of relying on hand-maintained hash constants.
 - D1 access is read-only by convention, not by enforced binding mode. This
   worker only issues `SELECT` queries.
 

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -1,0 +1,126 @@
+# myRadOne Subscriber Dashboard
+
+Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
+`myradone-subscribers` D1 database.
+
+## Files
+
+- `src/index.mjs` - Worker entrypoint and Cloudflare HTML shell wrapper
+- `src/lib.mjs` - Auth, rate limiting, headers, and D1 query logic
+- `src/dashboard.html` - Self-contained authenticated dashboard shell
+- `migrations/0001_subscriber_indexes.sql` - Indexes for dashboard query paths
+- `wrangler.toml` - Worker configuration
+
+## Endpoints
+
+- `GET /` - Protected dashboard shell. Without a valid bearer token, returns a
+  minimal login page.
+- `GET /api/summary` - Aggregate subscriber counts, source mix, and 30-day daily
+  signup totals.
+- `GET /api/subscribers` - Paginated subscriber list with allowlisted
+  filters/sorts.
+
+`/api/subscribers` supports these optional query parameters:
+
+- `page` - default `1`, minimum `1`
+- `per_page` - default `50`, maximum `100`
+- `status` - `active` or `unsubscribed`
+- `source` - `landing`, `demo`, or `app`
+- `sort` - `subscribed_at`, `email`, `source`, or `status`
+- `order` - `asc` or `desc`
+
+## Security Notes
+
+- The dashboard uses a single shared bearer token from `DASHBOARD_TOKEN`.
+- Rate limiting runs before auth and applies to the entire worker.
+- Every response is `Cache-Control: no-store`.
+- The worker sets CSP, frame, referrer, and content-type hardening headers.
+- D1 access is read-only by convention, not by enforced binding mode. This
+  worker only issues `SELECT` queries.
+
+## Production Setup
+
+1. Set the dashboard token secret:
+
+   ```bash
+   npx wrangler secret put DASHBOARD_TOKEN --config workers/dashboard/wrangler.toml
+   ```
+
+2. Apply the subscriber index migration remotely:
+
+   ```bash
+   npx wrangler d1 migrations apply myradone-subscribers --remote --config workers/dashboard/wrangler.toml
+   ```
+
+3. Deploy the worker:
+
+   ```bash
+   npx wrangler deploy --config workers/dashboard/wrangler.toml
+   ```
+
+4. Add a custom domain route in Cloudflare:
+
+   - Worker: `myradone-dashboard`
+   - Domain: `dashboard.myradone.com`
+
+## Local Development
+
+Wrangler uses a local D1 database during `wrangler dev`, so seed local rows if
+you want meaningful dashboard output.
+
+1. Create `workers/dashboard/.dev.vars`:
+
+   ```dotenv
+   DASHBOARD_TOKEN=localtest123
+   ```
+
+2. Apply the existing subscriber schema locally:
+
+   ```bash
+   npx wrangler d1 execute myradone-subscribers --local --config workers/dashboard/wrangler.toml --file workers/subscribe/migrations/0001_create_subscribers.sql
+   ```
+
+3. Apply the dashboard indexes locally:
+
+   ```bash
+   npx wrangler d1 migrations apply myradone-subscribers --local --config workers/dashboard/wrangler.toml
+   ```
+
+4. Seed test rows:
+
+   ```bash
+   npx wrangler d1 execute myradone-subscribers --local --config workers/dashboard/wrangler.toml \
+     --command "INSERT INTO subscribers (email, source) VALUES ('test@example.com', 'landing'), ('demo@example.com', 'demo');"
+   ```
+
+5. Run the worker:
+
+   ```bash
+   npx wrangler dev --config workers/dashboard/wrangler.toml
+   ```
+
+6. Visit [http://localhost:8787/](http://localhost:8787/) and enter
+   `localtest123`.
+
+## Verification
+
+Automated:
+
+```bash
+node --test tests/dashboard-worker.test.mjs
+```
+
+Manual:
+
+1. Start `wrangler dev` with seeded local data.
+2. Load `http://localhost:8787/` without a token and confirm the login page is
+   shown.
+3. Enter the token and confirm the summary cards, recent signups, and full table
+   render.
+4. Exercise filters, sorting, and pagination.
+5. Confirm invalid tokens fail with `401` on API requests.
+6. Inspect headers with:
+
+   ```bash
+   curl -I http://localhost:8787/
+   ```

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -38,6 +38,8 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 - Browser login exchanges that token for a same-site `HttpOnly` session cookie
   via `POST /api/session`, so the full dashboard flow does not depend on
   `sessionStorage` or `document.write`.
+- The session cookie stores a derived verifier rather than the raw shared
+  secret, and expires after 12 hours.
 - Rate limiting runs before auth and applies to the entire worker.
 - Every response is `Cache-Control: no-store`.
 - The worker sets CSP, frame, referrer, and content-type hardening headers.

--- a/workers/dashboard/migrations/0001_subscriber_indexes.sql
+++ b/workers/dashboard/migrations/0001_subscriber_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_subscribers_status ON subscribers(status);
+CREATE INDEX IF NOT EXISTS idx_subscribers_source ON subscribers(source);
+CREATE INDEX IF NOT EXISTS idx_subscribers_subscribed_at ON subscribers(subscribed_at);

--- a/workers/dashboard/src/dashboard.html
+++ b/workers/dashboard/src/dashboard.html
@@ -545,13 +545,28 @@
         unsubscribedCount: document.getElementById('unsubscribedCount')
       };
 
-      function getToken() {
-        return sessionStorage.getItem('dashboardToken') || '';
+      let redirecting = false;
+
+      async function clearSession() {
+        try {
+          await fetch('/api/session', {
+            method: 'DELETE',
+            cache: 'no-store',
+            credentials: 'same-origin'
+          });
+        } catch (error) {
+          return null;
+        }
+        return null;
       }
 
-      function clearTokenAndReload() {
-        sessionStorage.removeItem('dashboardToken');
-        window.location.reload();
+      async function clearSessionAndRedirect() {
+        if (redirecting) {
+          return;
+        }
+        redirecting = true;
+        await clearSession();
+        window.location.replace('/');
       }
 
       function normalizeTimestamp(value) {
@@ -625,24 +640,18 @@
       }
 
       async function apiJson(path) {
-        const token = getToken();
-        if (!token) {
-          clearTokenAndReload();
-          throw new Error('Dashboard token missing.');
-        }
-
         const response = await fetch(path, {
           method: 'GET',
           headers: {
-            Accept: 'application/json',
-            Authorization: 'Bearer ' + token
+            Accept: 'application/json'
           },
-          cache: 'no-store'
+          cache: 'no-store',
+          credentials: 'same-origin'
         });
 
         if (response.status === 401) {
-          clearTokenAndReload();
-          throw new Error('Dashboard token expired.');
+          await clearSessionAndRedirect();
+          throw new Error('Dashboard session expired.');
         }
 
         let payload = null;
@@ -693,7 +702,12 @@
 
           const topline = document.createElement('div');
           topline.className = 'source-topline';
-          topline.innerHTML = '<span>' + row.source + '</span><span>' + row.total + '</span>';
+          const sourceLabel = document.createElement('span');
+          sourceLabel.textContent = row.source;
+          const sourceTotal = document.createElement('span');
+          sourceTotal.textContent = String(row.total);
+          topline.appendChild(sourceLabel);
+          topline.appendChild(sourceTotal);
 
           const meta = document.createElement('div');
           meta.className = 'source-meta';
@@ -870,13 +884,8 @@
       });
 
       elements.logoutButton.addEventListener('click', function () {
-        clearTokenAndReload();
+        clearSessionAndRedirect();
       });
-
-      if (!getToken()) {
-        clearTokenAndReload();
-        return;
-      }
 
       refreshAll();
       state.refreshHandle = window.setInterval(refreshAll, 60000);

--- a/workers/dashboard/src/dashboard.html
+++ b/workers/dashboard/src/dashboard.html
@@ -1,0 +1,886 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>myRadOne Subscriber Dashboard</title>
+  <style>
+    :root {
+      --bg: #fff8f3;
+      --text: #3d3a36;
+      --text-muted: #a09b8f;
+      --accent: #f08c00;
+      --accent-strong: #d67d00;
+      --border: #e5e0d4;
+      --surface: #ffffff;
+      --surface-alt: #fff4e6;
+      --shadow: 0 18px 45px rgba(30, 28, 26, 0.08);
+      --danger-bg: #fff0eb;
+      --danger-text: #a33d18;
+      --sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at top right, rgba(240, 140, 0, 0.12), transparent 35%),
+        linear-gradient(180deg, #fffdfb 0%, var(--bg) 100%);
+      color: var(--text);
+      font-family: var(--sans);
+    }
+
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+
+    .shell {
+      width: min(1200px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 32px 0 40px;
+    }
+
+    .page-header {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: end;
+      justify-content: space-between;
+      gap: 18px;
+      margin-bottom: 22px;
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2rem, 3vw, 2.6rem);
+      line-height: 1.04;
+    }
+
+    .subtitle {
+      margin: 12px 0 0;
+      color: var(--text-muted);
+      max-width: 56ch;
+      line-height: 1.5;
+    }
+
+    .header-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .meta {
+      color: var(--text-muted);
+      font-size: 0.92rem;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 42px;
+      padding: 0 16px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      color: var(--text);
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .button:hover {
+      border-color: var(--accent);
+      color: var(--accent-strong);
+    }
+
+    .button-accent {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: white;
+    }
+
+    .button-accent:hover {
+      background: var(--accent-strong);
+      border-color: var(--accent-strong);
+      color: white;
+    }
+
+    .banner {
+      display: none;
+      margin-bottom: 18px;
+      padding: 14px 16px;
+      border: 1px solid rgba(163, 61, 24, 0.2);
+      border-radius: 14px;
+      background: var(--danger-bg);
+      color: var(--danger-text);
+      font-weight: 600;
+    }
+
+    .banner.visible {
+      display: block;
+    }
+
+    .cards,
+    .grid {
+      display: grid;
+      gap: 18px;
+    }
+
+    .cards {
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      margin-bottom: 18px;
+    }
+
+    .grid-two {
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      margin-bottom: 18px;
+    }
+
+    .panel,
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+
+    .card {
+      padding: 22px;
+    }
+
+    .card-label {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.92rem;
+      font-weight: 600;
+    }
+
+    .card-value {
+      margin: 14px 0 0;
+      font-size: clamp(2rem, 4vw, 2.7rem);
+      font-weight: 800;
+      line-height: 1;
+    }
+
+    .panel {
+      padding: 20px;
+    }
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-bottom: 18px;
+    }
+
+    .panel-title {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .panel-copy {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.92rem;
+    }
+
+    .source-list {
+      display: grid;
+      gap: 12px;
+    }
+
+    .source-row {
+      display: grid;
+      gap: 6px;
+      padding: 14px;
+      border-radius: 16px;
+      background: #fffdfa;
+      border: 1px solid var(--border);
+    }
+
+    .source-topline {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      font-weight: 700;
+    }
+
+    .source-meta {
+      color: var(--text-muted);
+      font-size: 0.92rem;
+    }
+
+    .chart {
+      display: grid;
+      grid-template-columns: repeat(30, minmax(0, 1fr));
+      gap: 6px;
+      align-items: end;
+      min-height: 210px;
+      padding-top: 14px;
+    }
+
+    .chart-bar {
+      display: flex;
+      align-items: end;
+      justify-content: center;
+      min-height: 180px;
+    }
+
+    .chart-bar-fill {
+      width: 100%;
+      min-height: 2px;
+      border-radius: 999px 999px 6px 6px;
+      background: linear-gradient(180deg, rgba(240, 140, 0, 0.45), var(--accent));
+    }
+
+    .chart-empty {
+      color: var(--text-muted);
+      font-size: 0.92rem;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th,
+    td {
+      padding: 12px 10px;
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+      vertical-align: top;
+      font-size: 0.94rem;
+    }
+
+    th {
+      color: var(--text-muted);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    tbody tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .sort-button {
+      padding: 0;
+      border: 0;
+      background: none;
+      color: inherit;
+      font: inherit;
+      font-weight: inherit;
+      letter-spacing: inherit;
+      text-transform: inherit;
+      cursor: pointer;
+    }
+
+    .sort-button:hover {
+      color: var(--accent-strong);
+    }
+
+    .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-bottom: 18px;
+      align-items: end;
+    }
+
+    .field {
+      display: grid;
+      gap: 6px;
+      min-width: 160px;
+    }
+
+    .field label {
+      color: var(--text-muted);
+      font-size: 0.86rem;
+      font-weight: 600;
+    }
+
+    .field select {
+      min-height: 42px;
+      padding: 0 12px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: #fffdfa;
+      color: var(--text);
+    }
+
+    .table-wrap {
+      overflow-x: auto;
+    }
+
+    .pagination {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-top: 16px;
+    }
+
+    .pagination-buttons {
+      display: flex;
+      gap: 10px;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 5px 9px;
+      border-radius: 999px;
+      background: var(--surface-alt);
+      color: var(--accent-strong);
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .empty-row td {
+      color: var(--text-muted);
+      text-align: center;
+      padding: 28px 16px;
+    }
+
+    @media (max-width: 720px) {
+      .shell {
+        width: min(100%, calc(100% - 20px));
+        padding-top: 22px;
+      }
+
+      .panel,
+      .card {
+        padding: 18px;
+      }
+
+      th,
+      td {
+        padding-left: 8px;
+        padding-right: 8px;
+      }
+    }
+  </style>
+</head>
+<body data-dashboard-shell="true">
+  <main class="shell">
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">Internal</p>
+        <h1>myRadOne Subscribers</h1>
+        <p class="subtitle">Read-only visibility into email signup activity, source mix, and recent growth.</p>
+      </div>
+      <div class="header-actions">
+        <span id="lastUpdated" class="meta">Waiting for data…</span>
+        <button id="refreshButton" class="button" type="button">Refresh</button>
+        <button id="logoutButton" class="button button-accent" type="button">Log out</button>
+      </div>
+    </header>
+
+    <div id="errorBanner" class="banner" role="alert"></div>
+
+    <section class="cards">
+      <article class="card">
+        <p class="card-label">Total subscribers</p>
+        <p id="totalCount" class="card-value">—</p>
+      </article>
+      <article class="card">
+        <p class="card-label">Active</p>
+        <p id="activeCount" class="card-value">—</p>
+      </article>
+      <article class="card">
+        <p class="card-label">Unsubscribed</p>
+        <p id="unsubscribedCount" class="card-value">—</p>
+      </article>
+    </section>
+
+    <section class="grid grid-two">
+      <article class="panel">
+        <div class="panel-header">
+          <div>
+            <h2 class="panel-title">Source breakdown</h2>
+            <p class="panel-copy">Current mix by signup source.</p>
+          </div>
+        </div>
+        <div id="sourceBreakdown" class="source-list"></div>
+      </article>
+
+      <article class="panel">
+        <div class="panel-header">
+          <div>
+            <h2 class="panel-title">Last 30 days</h2>
+            <p class="panel-copy">Daily signup volume.</p>
+          </div>
+        </div>
+        <div id="dailyChart" class="chart"></div>
+      </article>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">Recent signups</h2>
+          <p class="panel-copy">Latest entries, powered by the same subscriber listing endpoint.</p>
+        </div>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Status</th>
+              <th>Source</th>
+              <th>Subscribed</th>
+            </tr>
+          </thead>
+          <tbody id="recentBody"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="panel" style="margin-top: 18px;">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">All subscribers</h2>
+          <p class="panel-copy">Filterable, sortable, paginated list.</p>
+        </div>
+      </div>
+
+      <form id="filtersForm" class="filters">
+        <div class="field">
+          <label for="statusFilter">Status</label>
+          <select id="statusFilter" name="status">
+            <option value="">All statuses</option>
+            <option value="active">Active</option>
+            <option value="unsubscribed">Unsubscribed</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="sourceFilter">Source</label>
+          <select id="sourceFilter" name="source">
+            <option value="">All sources</option>
+            <option value="landing">Landing</option>
+            <option value="demo">Demo</option>
+            <option value="app">App</option>
+          </select>
+        </div>
+        <button type="submit" class="button">Apply filters</button>
+        <button id="clearFiltersButton" type="button" class="button">Clear</button>
+      </form>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th><button class="sort-button" data-sort="email" type="button">Email</button></th>
+              <th><button class="sort-button" data-sort="status" type="button">Status</button></th>
+              <th><button class="sort-button" data-sort="source" type="button">Source</button></th>
+              <th><button class="sort-button" data-sort="subscribed_at" type="button">Subscribed</button></th>
+              <th>Consent</th>
+            </tr>
+          </thead>
+          <tbody id="subscribersBody"></tbody>
+        </table>
+      </div>
+
+      <div class="pagination">
+        <span id="paginationLabel" class="meta">Page 1</span>
+        <div class="pagination-buttons">
+          <button id="prevPageButton" class="button" type="button">Previous</button>
+          <button id="nextPageButton" class="button" type="button">Next</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      const state = {
+        page: 1,
+        perPage: 50,
+        sort: 'subscribed_at',
+        order: 'desc',
+        status: '',
+        source: '',
+        totalPages: 1,
+        refreshHandle: null
+      };
+
+      const elements = {
+        activeCount: document.getElementById('activeCount'),
+        clearFiltersButton: document.getElementById('clearFiltersButton'),
+        dailyChart: document.getElementById('dailyChart'),
+        errorBanner: document.getElementById('errorBanner'),
+        filtersForm: document.getElementById('filtersForm'),
+        lastUpdated: document.getElementById('lastUpdated'),
+        logoutButton: document.getElementById('logoutButton'),
+        nextPageButton: document.getElementById('nextPageButton'),
+        paginationLabel: document.getElementById('paginationLabel'),
+        prevPageButton: document.getElementById('prevPageButton'),
+        recentBody: document.getElementById('recentBody'),
+        refreshButton: document.getElementById('refreshButton'),
+        sourceBreakdown: document.getElementById('sourceBreakdown'),
+        sourceFilter: document.getElementById('sourceFilter'),
+        sortButtons: Array.from(document.querySelectorAll('.sort-button')),
+        statusFilter: document.getElementById('statusFilter'),
+        subscribersBody: document.getElementById('subscribersBody'),
+        totalCount: document.getElementById('totalCount'),
+        unsubscribedCount: document.getElementById('unsubscribedCount')
+      };
+
+      function getToken() {
+        return sessionStorage.getItem('dashboardToken') || '';
+      }
+
+      function clearTokenAndReload() {
+        sessionStorage.removeItem('dashboardToken');
+        window.location.reload();
+      }
+
+      function normalizeTimestamp(value) {
+        if (!value) {
+          return null;
+        }
+
+        const candidate = value.includes('T') ? value : value.replace(' ', 'T') + 'Z';
+        const parsed = new Date(candidate);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      }
+
+      function formatDateTime(value) {
+        const date = normalizeTimestamp(value);
+        if (!date) {
+          return '—';
+        }
+        return new Intl.DateTimeFormat(undefined, {
+          dateStyle: 'medium',
+          timeStyle: 'short'
+        }).format(date);
+      }
+
+      function formatDay(value) {
+        const date = normalizeTimestamp(value + 'T00:00:00Z');
+        if (!date) {
+          return value;
+        }
+        return new Intl.DateTimeFormat(undefined, {
+          month: 'short',
+          day: 'numeric'
+        }).format(date);
+      }
+
+      function showError(message) {
+        if (!message) {
+          elements.errorBanner.textContent = '';
+          elements.errorBanner.classList.remove('visible');
+          return;
+        }
+        elements.errorBanner.textContent = message;
+        elements.errorBanner.classList.add('visible');
+      }
+
+      function buildSubscribersPath(overrides) {
+        const params = new URLSearchParams();
+        const query = Object.assign(
+          {
+            page: state.page,
+            per_page: state.perPage,
+            sort: state.sort,
+            order: state.order
+          },
+          overrides || {}
+        );
+
+        if (state.status) {
+          params.set('status', state.status);
+        }
+        if (state.source) {
+          params.set('source', state.source);
+        }
+
+        Object.keys(query).forEach(function (key) {
+          if (query[key] !== '' && query[key] != null) {
+            params.set(key, String(query[key]));
+          }
+        });
+
+        return '/api/subscribers?' + params.toString();
+      }
+
+      async function apiJson(path) {
+        const token = getToken();
+        if (!token) {
+          clearTokenAndReload();
+          throw new Error('Dashboard token missing.');
+        }
+
+        const response = await fetch(path, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            Authorization: 'Bearer ' + token
+          },
+          cache: 'no-store'
+        });
+
+        if (response.status === 401) {
+          clearTokenAndReload();
+          throw new Error('Dashboard token expired.');
+        }
+
+        let payload = null;
+        try {
+          payload = await response.json();
+        } catch (error) {
+          payload = null;
+        }
+
+        if (!response.ok) {
+          throw new Error((payload && payload.error) || 'Dashboard request failed.');
+        }
+
+        return payload;
+      }
+
+      function createCellRow(row, columns) {
+        const tr = document.createElement('tr');
+        columns.forEach(function (column) {
+          const td = document.createElement('td');
+          if (column === 'status') {
+            const pill = document.createElement('span');
+            pill.className = 'status-pill';
+            pill.textContent = row.status;
+            td.appendChild(pill);
+          } else if (column === 'subscribed_at') {
+            td.textContent = formatDateTime(row.subscribed_at);
+          } else {
+            td.textContent = row[column] || '—';
+          }
+          tr.appendChild(td);
+        });
+        return tr;
+      }
+
+      function renderSummary(summary) {
+        elements.totalCount.textContent = String(summary.counts.total);
+        elements.activeCount.textContent = String(summary.counts.active);
+        elements.unsubscribedCount.textContent = String(summary.counts.unsubscribed);
+      }
+
+      function renderSourceBreakdown(sources) {
+        elements.sourceBreakdown.replaceChildren();
+
+        sources.forEach(function (row) {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'source-row';
+
+          const topline = document.createElement('div');
+          topline.className = 'source-topline';
+          topline.innerHTML = '<span>' + row.source + '</span><span>' + row.total + '</span>';
+
+          const meta = document.createElement('div');
+          meta.className = 'source-meta';
+          meta.textContent = row.active + ' active • ' + row.unsubscribed + ' unsubscribed';
+
+          wrapper.appendChild(topline);
+          wrapper.appendChild(meta);
+          elements.sourceBreakdown.appendChild(wrapper);
+        });
+      }
+
+      function renderDailyChart(daily) {
+        elements.dailyChart.replaceChildren();
+
+        if (!daily.length) {
+          const empty = document.createElement('p');
+          empty.className = 'chart-empty';
+          empty.textContent = 'No signup data yet.';
+          elements.dailyChart.appendChild(empty);
+          return;
+        }
+
+        const maxCount = Math.max.apply(
+          null,
+          daily.map(function (entry) {
+            return Number(entry.count) || 0;
+          })
+        ) || 1;
+
+        daily.forEach(function (entry) {
+          const bar = document.createElement('div');
+          bar.className = 'chart-bar';
+          bar.title = formatDay(entry.day) + ': ' + entry.count;
+
+          const fill = document.createElement('div');
+          fill.className = 'chart-bar-fill';
+          fill.style.height = (entry.count / maxCount) * 100 + '%';
+
+          bar.appendChild(fill);
+          elements.dailyChart.appendChild(bar);
+        });
+      }
+
+      function renderRecent(payload) {
+        elements.recentBody.replaceChildren();
+
+        if (!payload.subscribers.length) {
+          const row = document.createElement('tr');
+          row.className = 'empty-row';
+          row.innerHTML = '<td colspan="4">No subscribers yet.</td>';
+          elements.recentBody.appendChild(row);
+          return;
+        }
+
+        payload.subscribers.forEach(function (subscriber) {
+          elements.recentBody.appendChild(createCellRow(subscriber, ['email', 'status', 'source', 'subscribed_at']));
+        });
+      }
+
+      function renderSubscribers(payload) {
+        elements.subscribersBody.replaceChildren();
+
+        state.totalPages = payload.pagination.total_pages;
+        elements.paginationLabel.textContent =
+          'Page ' + payload.pagination.page + ' of ' + payload.pagination.total_pages + ' • ' + payload.pagination.total + ' total';
+        elements.prevPageButton.disabled = payload.pagination.page <= 1;
+        elements.nextPageButton.disabled = payload.pagination.page >= payload.pagination.total_pages;
+
+        if (!payload.subscribers.length) {
+          const row = document.createElement('tr');
+          row.className = 'empty-row';
+          row.innerHTML = '<td colspan="5">No subscribers match the current filters.</td>';
+          elements.subscribersBody.appendChild(row);
+          return;
+        }
+
+        payload.subscribers.forEach(function (subscriber) {
+          elements.subscribersBody.appendChild(
+            createCellRow(subscriber, ['email', 'status', 'source', 'subscribed_at', 'consent_version'])
+          );
+        });
+      }
+
+      function syncSortButtons() {
+        elements.sortButtons.forEach(function (button) {
+          const field = button.dataset.sort;
+          const isActive = field === state.sort;
+          const arrow = !isActive ? '' : state.order === 'asc' ? ' ▲' : ' ▼';
+          button.textContent = button.textContent.replace(/ [▲▼]$/, '') + arrow;
+        });
+      }
+
+      async function loadSubscribers() {
+        const payload = await apiJson(buildSubscribersPath());
+        renderSubscribers(payload);
+      }
+
+      async function refreshAll() {
+        elements.refreshButton.disabled = true;
+        showError('');
+
+        try {
+          const [summary, recentPayload, subscriberPayload] = await Promise.all([
+            apiJson('/api/summary'),
+            apiJson('/api/subscribers?per_page=10&sort=subscribed_at&order=desc'),
+            apiJson(buildSubscribersPath())
+          ]);
+
+          renderSummary(summary);
+          renderSourceBreakdown(summary.sources);
+          renderDailyChart(summary.daily);
+          renderRecent(recentPayload);
+          renderSubscribers(subscriberPayload);
+          syncSortButtons();
+          elements.lastUpdated.textContent =
+            'Updated ' +
+            new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
+        } catch (error) {
+          showError(error.message || 'Dashboard request failed.');
+        } finally {
+          elements.refreshButton.disabled = false;
+        }
+      }
+
+      elements.filtersForm.addEventListener('submit', function (event) {
+        event.preventDefault();
+        state.page = 1;
+        state.status = elements.statusFilter.value;
+        state.source = elements.sourceFilter.value;
+        refreshAll();
+      });
+
+      elements.clearFiltersButton.addEventListener('click', function () {
+        state.page = 1;
+        state.status = '';
+        state.source = '';
+        elements.statusFilter.value = '';
+        elements.sourceFilter.value = '';
+        refreshAll();
+      });
+
+      elements.sortButtons.forEach(function (button) {
+        button.addEventListener('click', function () {
+          const field = button.dataset.sort;
+          if (state.sort === field) {
+            state.order = state.order === 'asc' ? 'desc' : 'asc';
+          } else {
+            state.sort = field;
+            state.order = field === 'subscribed_at' ? 'desc' : 'asc';
+          }
+          state.page = 1;
+          refreshAll();
+        });
+      });
+
+      elements.prevPageButton.addEventListener('click', function () {
+        if (state.page <= 1) {
+          return;
+        }
+        state.page -= 1;
+        refreshAll();
+      });
+
+      elements.nextPageButton.addEventListener('click', function () {
+        if (state.page >= state.totalPages) {
+          return;
+        }
+        state.page += 1;
+        refreshAll();
+      });
+
+      elements.refreshButton.addEventListener('click', function () {
+        refreshAll();
+      });
+
+      elements.logoutButton.addEventListener('click', function () {
+        clearTokenAndReload();
+      });
+
+      if (!getToken()) {
+        clearTokenAndReload();
+        return;
+      }
+
+      refreshAll();
+      state.refreshHandle = window.setInterval(refreshAll, 60000);
+    }());
+  </script>
+</body>
+</html>

--- a/workers/dashboard/src/index.mjs
+++ b/workers/dashboard/src/index.mjs
@@ -20,7 +20,7 @@ export default {
         try {
             return await dispatchRequest(request, env, dashboardHtml);
         } catch (error) {
-            return createErrorResponse(request, error);
+            return await createErrorResponse(request, error);
         }
     }
 };

--- a/workers/dashboard/src/index.mjs
+++ b/workers/dashboard/src/index.mjs
@@ -4,11 +4,12 @@ import {
     createErrorResponse,
     dispatchRequest,
     handleDashboard as handleDashboardImpl,
+    handleSession,
     handleSubscribers,
     handleSummary
 } from './lib.mjs';
 
-export { authenticate, handleSubscribers, handleSummary };
+export { authenticate, handleSession, handleSubscribers, handleSummary };
 
 export async function handleDashboard(request, env) {
     return handleDashboardImpl(request, env, dashboardHtml);

--- a/workers/dashboard/src/index.mjs
+++ b/workers/dashboard/src/index.mjs
@@ -1,0 +1,25 @@
+import dashboardHtml from './dashboard.html';
+import {
+    authenticate,
+    createErrorResponse,
+    dispatchRequest,
+    handleDashboard as handleDashboardImpl,
+    handleSubscribers,
+    handleSummary
+} from './lib.mjs';
+
+export { authenticate, handleSubscribers, handleSummary };
+
+export async function handleDashboard(request, env) {
+    return handleDashboardImpl(request, env, dashboardHtml);
+}
+
+export default {
+    async fetch(request, env) {
+        try {
+            return await dispatchRequest(request, env, dashboardHtml);
+        } catch (error) {
+            return createErrorResponse(request, error);
+        }
+    }
+};

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -17,6 +17,7 @@ const SOURCE_ORDER = ['landing', 'demo', 'app'];
 const SOURCE_ORDER_SQL = "CASE source WHEN 'landing' THEN 0 WHEN 'demo' THEN 1 WHEN 'app' THEN 2 ELSE 3 END";
 const STATUS_ORDER_SQL = "CASE status WHEN 'active' THEN 0 ELSE 1 END";
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
+const UNAUTHORIZED_WWW_AUTHENTICATE = 'Bearer realm="myradone-dashboard"';
 const textEncoder = new TextEncoder();
 const signingKeyCache = new Map();
 const inlineScriptCspCache = new Map();
@@ -255,8 +256,10 @@ function getCookieToken(request) {
 }
 
 async function buildSessionCookie(request, token) {
+    const expiresAtMs = Date.now() + SESSION_MAX_AGE_SECONDS * 1000;
     const attributes = [
         'HttpOnly',
+        `Expires=${new Date(expiresAtMs).toUTCString()}`,
         `Max-Age=${SESSION_MAX_AGE_SECONDS}`,
         'Path=/',
         'SameSite=Strict'
@@ -270,7 +273,13 @@ async function buildSessionCookie(request, token) {
 }
 
 function buildClearSessionCookie(request) {
-    const attributes = ['HttpOnly', 'Max-Age=0', 'Path=/', 'SameSite=Strict'];
+    const attributes = [
+        'HttpOnly',
+        'Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+        'Max-Age=0',
+        'Path=/',
+        'SameSite=Strict'
+    ];
     if (new URL(request.url).protocol === 'https:') {
         attributes.push('Secure');
     }
@@ -684,7 +693,10 @@ export async function handleSession(request, env) {
         return jsonResponse(
             { error: 'Unauthorized' },
             401,
-            { 'Set-Cookie': buildClearSessionCookie(request) }
+            {
+                'Set-Cookie': buildClearSessionCookie(request),
+                'WWW-Authenticate': UNAUTHORIZED_WWW_AUTHENTICATE
+            }
         );
     }
 
@@ -695,7 +707,8 @@ export async function handleSession(request, env) {
 
 async function createUnauthorizedResponse(pathname, request) {
     const headers = {
-        'Set-Cookie': buildClearSessionCookie(request)
+        'Set-Cookie': buildClearSessionCookie(request),
+        'WWW-Authenticate': UNAUTHORIZED_WWW_AUTHENTICATE
     };
 
     if (pathname === DASHBOARD_PATH) {

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -1,0 +1,595 @@
+export const DASHBOARD_PATH = '/';
+export const SUMMARY_PATH = '/api/summary';
+export const SUBSCRIBERS_PATH = '/api/subscribers';
+
+const VALID_STATUSES = new Set(['active', 'unsubscribed']);
+const VALID_SOURCES = new Set(['landing', 'demo', 'app']);
+const VALID_ORDERS = new Set(['asc', 'desc']);
+const SORT_COLUMNS = new Map([
+    ['subscribed_at', 'subscribed_at'],
+    ['email', 'email'],
+    ['source', 'source'],
+    ['status', 'status']
+]);
+const SOURCE_ORDER = ['landing', 'demo', 'app'];
+const SOURCE_ORDER_SQL = "CASE source WHEN 'landing' THEN 0 WHEN 'demo' THEN 1 WHEN 'app' THEN 2 ELSE 3 END";
+const STATUS_ORDER_SQL = "CASE status WHEN 'active' THEN 0 ELSE 1 END";
+const textEncoder = new TextEncoder();
+
+class HttpError extends Error {
+    constructor(status, message) {
+        super(message);
+        this.name = 'HttpError';
+        this.status = status;
+    }
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;');
+}
+
+function createHeaders(contentType) {
+    return new Headers({
+        'Cache-Control': 'no-store',
+        'Content-Security-Policy':
+            "default-src 'self'; base-uri 'none'; connect-src 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'",
+        'Content-Type': contentType,
+        'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+        'Referrer-Policy': 'no-referrer',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY'
+    });
+}
+
+export function jsonResponse(payload, status = 200) {
+    return new Response(JSON.stringify(payload), {
+        status,
+        headers: createHeaders('application/json; charset=UTF-8')
+    });
+}
+
+export function htmlResponse(html, status = 200) {
+    return new Response(html, {
+        status,
+        headers: createHeaders('text/html; charset=UTF-8')
+    });
+}
+
+function timingSafeEqual(left, right) {
+    const leftBytes = textEncoder.encode(left || '');
+    const rightBytes = textEncoder.encode(right || '');
+    const length = Math.max(leftBytes.length, rightBytes.length);
+    let mismatch = leftBytes.length ^ rightBytes.length;
+
+    for (let index = 0; index < length; index += 1) {
+        mismatch |= (leftBytes[index] || 0) ^ (rightBytes[index] || 0);
+    }
+
+    return mismatch === 0;
+}
+
+function getBearerToken(request) {
+    const header = request.headers.get('Authorization') || '';
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    return match ? match[1].trim() : '';
+}
+
+export function authenticate(request, env) {
+    const providedToken = getBearerToken(request);
+    const expectedToken = typeof env.DASHBOARD_TOKEN === 'string' ? env.DASHBOARD_TOKEN.trim() : '';
+
+    if (!providedToken || !expectedToken) {
+        return false;
+    }
+
+    return timingSafeEqual(providedToken, expectedToken);
+}
+
+async function isRateLimited(request, env) {
+    if (!env.DASHBOARD_RATE_LIMIT?.limit) {
+        return false;
+    }
+
+    const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+    const { success } = await env.DASHBOARD_RATE_LIMIT.limit({
+        key: `dashboard:${ip}`
+    });
+
+    return !success;
+}
+
+function createLoginHtml(errorMessage = '') {
+    const safeError = escapeHtml(errorMessage);
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>myRadOne Subscriber Dashboard Login</title>
+  <style>
+    :root {
+      --bg: #fff8f3;
+      --text: #3d3a36;
+      --text-muted: #a09b8f;
+      --accent: #f08c00;
+      --accent-strong: #d67d00;
+      --border: #e5e0d4;
+      --surface: #ffffff;
+      --shadow: 0 20px 50px rgba(30, 28, 26, 0.08);
+      --sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      background:
+        radial-gradient(circle at top left, rgba(240, 140, 0, 0.1), transparent 40%),
+        linear-gradient(180deg, #fffdfb 0%, var(--bg) 100%);
+      color: var(--text);
+      font-family: var(--sans);
+    }
+    .card {
+      width: min(100%, 420px);
+      padding: 28px;
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+    .eyebrow {
+      margin: 0 0 12px;
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    h1 {
+      margin: 0;
+      font-size: 1.9rem;
+      line-height: 1.1;
+    }
+    p {
+      margin: 14px 0 0;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    form {
+      display: grid;
+      gap: 14px;
+      margin-top: 24px;
+    }
+    label {
+      display: grid;
+      gap: 8px;
+      font-size: 0.92rem;
+      font-weight: 600;
+    }
+    input {
+      width: 100%;
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      font: inherit;
+      background: #fffdfa;
+      color: var(--text);
+    }
+    button {
+      padding: 12px 16px;
+      border: 0;
+      border-radius: 12px;
+      background: var(--accent);
+      color: white;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    button:hover { background: var(--accent-strong); }
+    button:disabled { opacity: 0.7; cursor: wait; }
+    .error {
+      min-height: 1.3rem;
+      margin-top: 14px;
+      color: #b64519;
+      font-size: 0.92rem;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <p class="eyebrow">Internal</p>
+    <h1>myRadOne Subscribers</h1>
+    <p>Enter the dashboard token to load the protected subscriber analytics view.</p>
+    <form id="loginForm">
+      <label>
+        Dashboard token
+        <input id="tokenInput" type="password" autocomplete="current-password" required>
+      </label>
+      <button id="submitButton" type="submit">Open dashboard</button>
+    </form>
+    <div id="errorMessage" class="error" role="alert">${safeError}</div>
+  </main>
+  <script>
+    (function () {
+      const form = document.getElementById('loginForm');
+      const tokenInput = document.getElementById('tokenInput');
+      const submitButton = document.getElementById('submitButton');
+      const errorMessage = document.getElementById('errorMessage');
+
+      async function loadDashboardShell(token) {
+        const response = await fetch(window.location.pathname, {
+          method: 'GET',
+          headers: { Authorization: 'Bearer ' + token },
+          cache: 'no-store'
+        });
+
+        const html = await response.text();
+        if (!response.ok || !html.includes('data-dashboard-shell="true"')) {
+          throw new Error(response.status === 429 ? 'Too many requests. Please try again shortly.' : 'Invalid dashboard token.');
+        }
+
+        document.open();
+        document.write(html);
+        document.close();
+      }
+
+      async function verifyToken(token) {
+        const response = await fetch('/api/summary', {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            Authorization: 'Bearer ' + token
+          },
+          cache: 'no-store'
+        });
+
+        if (response.status === 401) {
+          throw new Error('Invalid dashboard token.');
+        }
+
+        if (response.status === 429) {
+          throw new Error('Too many requests. Please try again shortly.');
+        }
+
+        if (!response.ok) {
+          throw new Error('Dashboard request failed.');
+        }
+      }
+
+      async function submitToken(token) {
+        submitButton.disabled = true;
+        errorMessage.textContent = '';
+
+        try {
+          await verifyToken(token);
+          sessionStorage.setItem('dashboardToken', token);
+          await loadDashboardShell(token);
+        } catch (error) {
+          sessionStorage.removeItem('dashboardToken');
+          errorMessage.textContent = error.message || 'Dashboard request failed.';
+        } finally {
+          submitButton.disabled = false;
+        }
+      }
+
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        const token = tokenInput.value.trim();
+        if (!token) {
+          errorMessage.textContent = 'Dashboard token is required.';
+          return;
+        }
+        submitToken(token);
+      });
+
+      const storedToken = sessionStorage.getItem('dashboardToken');
+      if (storedToken) {
+        tokenInput.value = storedToken;
+        submitToken(storedToken);
+      }
+    }());
+  </script>
+</body>
+</html>`;
+}
+
+function badRequest(message) {
+    throw new HttpError(400, message);
+}
+
+function methodNotAllowed() {
+    throw new HttpError(405, 'Method not allowed');
+}
+
+function requireGet(request) {
+    if (request.method !== 'GET') {
+        methodNotAllowed();
+    }
+}
+
+function parseIntegerParam(rawValue, fallback, { min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+    if (rawValue == null || rawValue === '') {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(rawValue, 10);
+    if (!Number.isFinite(parsed) || String(parsed) !== String(rawValue).trim()) {
+        badRequest(`Invalid integer parameter: ${rawValue}`);
+    }
+
+    if (parsed < min || parsed > max) {
+        badRequest(`Integer parameter out of range: ${rawValue}`);
+    }
+
+    return parsed;
+}
+
+function parseSubscribersQuery(request) {
+    const url = new URL(request.url);
+    const page = parseIntegerParam(url.searchParams.get('page'), 1, { min: 1 });
+    const perPage = parseIntegerParam(url.searchParams.get('per_page'), 50, { min: 1, max: 100 });
+    const status = url.searchParams.get('status') || '';
+    const source = url.searchParams.get('source') || '';
+    const sort = (url.searchParams.get('sort') || 'subscribed_at').toLowerCase();
+    const order = (url.searchParams.get('order') || 'desc').toLowerCase();
+
+    if (status && !VALID_STATUSES.has(status)) {
+        badRequest('Invalid status filter');
+    }
+
+    if (source && !VALID_SOURCES.has(source)) {
+        badRequest('Invalid source filter');
+    }
+
+    if (!SORT_COLUMNS.has(sort)) {
+        badRequest('Invalid sort column');
+    }
+
+    if (!VALID_ORDERS.has(order)) {
+        badRequest('Invalid sort order');
+    }
+
+    return {
+        page,
+        perPage,
+        source,
+        sort,
+        status,
+        order
+    };
+}
+
+function normalizeCount(value) {
+    const count = Number(value);
+    return Number.isFinite(count) ? count : 0;
+}
+
+function buildSubscribersWhereClause(filters) {
+    const clauses = [];
+    const bindings = [];
+
+    if (filters.status) {
+        clauses.push('status = ?');
+        bindings.push(filters.status);
+    }
+
+    if (filters.source) {
+        clauses.push('source = ?');
+        bindings.push(filters.source);
+    }
+
+    return {
+        whereSql: clauses.length ? `WHERE ${clauses.join(' AND ')}` : '',
+        bindings
+    };
+}
+
+function normalizeSubscriberRow(row) {
+    return {
+        id: Number(row.id),
+        email: row.email,
+        status: row.status,
+        subscribed_at: row.subscribed_at,
+        source: row.source,
+        consent_version: row.consent_version
+    };
+}
+
+function toSourceSummary(rows) {
+    const grouped = new Map(SOURCE_ORDER.map((source) => [source, { source, total: 0, active: 0, unsubscribed: 0 }]));
+
+    for (const row of rows) {
+        const current = grouped.get(row.source) || {
+            source: row.source,
+            total: 0,
+            active: 0,
+            unsubscribed: 0
+        };
+        current.total += normalizeCount(row.count);
+        current[row.status] = normalizeCount(row.count);
+        grouped.set(row.source, current);
+    }
+
+    return [...grouped.values()];
+}
+
+export async function handleSummary(env) {
+    const countsRow =
+        (await env.SUBSCRIBERS_DB.prepare(
+            `SELECT
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS active,
+                SUM(CASE WHEN status = 'unsubscribed' THEN 1 ELSE 0 END) AS unsubscribed
+             FROM subscribers`
+        ).first()) || {};
+
+    const sourceRows =
+        (
+            await env.SUBSCRIBERS_DB.prepare(
+                `SELECT source, status, COUNT(*) AS count
+                 FROM subscribers
+                 GROUP BY source, status
+                 ORDER BY ${SOURCE_ORDER_SQL}, ${STATUS_ORDER_SQL}`
+            ).all()
+        ).results || [];
+
+    const dailyRows =
+        (
+            await env.SUBSCRIBERS_DB.prepare(
+                `WITH RECURSIVE days(day) AS (
+                    SELECT date('now', '-29 days')
+                    UNION ALL
+                    SELECT date(day, '+1 day')
+                    FROM days
+                    WHERE day < date('now')
+                )
+                SELECT days.day AS day, COALESCE(counts.count, 0) AS count
+                FROM days
+                LEFT JOIN (
+                    SELECT date(subscribed_at) AS day, COUNT(*) AS count
+                    FROM subscribers
+                    WHERE subscribed_at >= datetime('now', '-29 days')
+                    GROUP BY date(subscribed_at)
+                ) AS counts
+                  ON counts.day = days.day
+                ORDER BY days.day ASC`
+            ).all()
+        ).results || [];
+
+    return {
+        counts: {
+            total: normalizeCount(countsRow.total),
+            active: normalizeCount(countsRow.active),
+            unsubscribed: normalizeCount(countsRow.unsubscribed)
+        },
+        sources: toSourceSummary(sourceRows).map((row) => ({
+            source: row.source,
+            total: row.total,
+            active: row.active,
+            unsubscribed: row.unsubscribed
+        })),
+        daily: dailyRows.map((row) => ({
+            day: row.day,
+            count: normalizeCount(row.count)
+        }))
+    };
+}
+
+export async function handleSubscribers(request, env) {
+    const query = parseSubscribersQuery(request);
+    const { whereSql, bindings } = buildSubscribersWhereClause(query);
+    const sortColumn = SORT_COLUMNS.get(query.sort);
+    const sortDirection = query.order.toUpperCase();
+    const offset = (query.page - 1) * query.perPage;
+
+    const countRow =
+        (await env.SUBSCRIBERS_DB.prepare(`SELECT COUNT(*) AS total FROM subscribers ${whereSql}`)
+            .bind(...bindings)
+            .first()) || {};
+
+    const rows =
+        (
+            await env.SUBSCRIBERS_DB.prepare(
+                `SELECT id, email, status, subscribed_at, source, consent_version
+                 FROM subscribers
+                 ${whereSql}
+                 ORDER BY ${sortColumn} ${sortDirection}, id ${sortDirection}
+                 LIMIT ? OFFSET ?`
+            )
+                .bind(...bindings, query.perPage, offset)
+                .all()
+        ).results || [];
+
+    const total = normalizeCount(countRow.total);
+    const totalPages = Math.max(1, Math.ceil(total / query.perPage || 1));
+
+    return {
+        subscribers: rows.map(normalizeSubscriberRow),
+        pagination: {
+            page: query.page,
+            per_page: query.perPage,
+            total,
+            total_pages: totalPages
+        }
+    };
+}
+
+export async function handleDashboard(request, env, dashboardHtml) {
+    requireGet(request);
+
+    if (!authenticate(request, env)) {
+        return htmlResponse(createLoginHtml(), 200);
+    }
+
+    return htmlResponse(dashboardHtml, 200);
+}
+
+function createUnauthorizedResponse(pathname) {
+    if (pathname === DASHBOARD_PATH) {
+        return htmlResponse(createLoginHtml(), 200);
+    }
+
+    return jsonResponse({ error: 'Unauthorized' }, 401);
+}
+
+function createRateLimitResponse(pathname) {
+    if (pathname === DASHBOARD_PATH) {
+        return htmlResponse(createLoginHtml('Too many requests. Please try again shortly.'), 429);
+    }
+
+    return jsonResponse({ error: 'Too many requests. Please try again later.' }, 429);
+}
+
+export async function dispatchRequest(request, env, dashboardHtml) {
+    const { pathname } = new URL(request.url);
+
+    if (await isRateLimited(request, env)) {
+        return createRateLimitResponse(pathname);
+    }
+
+    if (pathname === DASHBOARD_PATH) {
+        return handleDashboard(request, env, dashboardHtml);
+    }
+
+    if (pathname === SUMMARY_PATH) {
+        requireGet(request);
+        if (!authenticate(request, env)) {
+            return createUnauthorizedResponse(pathname);
+        }
+        return jsonResponse(await handleSummary(env));
+    }
+
+    if (pathname === SUBSCRIBERS_PATH) {
+        requireGet(request);
+        if (!authenticate(request, env)) {
+            return createUnauthorizedResponse(pathname);
+        }
+        return jsonResponse(await handleSubscribers(request, env));
+    }
+
+    return jsonResponse({ error: 'Not found' }, 404);
+}
+
+export function createErrorResponse(request, error) {
+    const pathname = new URL(request.url).pathname;
+
+    if (error instanceof HttpError) {
+        return pathname === DASHBOARD_PATH
+            ? htmlResponse(createLoginHtml(error.message), error.status)
+            : jsonResponse({ error: error.message }, error.status);
+    }
+
+    console.error('dashboard worker failed', error);
+    return pathname === DASHBOARD_PATH
+        ? htmlResponse(createLoginHtml('Server error.'), 500)
+        : jsonResponse({ error: 'Server error' }, 500);
+}

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -1,7 +1,9 @@
 export const DASHBOARD_PATH = '/';
+export const SESSION_PATH = '/api/session';
 export const SUMMARY_PATH = '/api/summary';
 export const SUBSCRIBERS_PATH = '/api/subscribers';
 
+const DASHBOARD_SESSION_COOKIE = 'myradone_dashboard_token';
 const VALID_STATUSES = new Set(['active', 'unsubscribed']);
 const VALID_SOURCES = new Set(['landing', 'demo', 'app']);
 const VALID_ORDERS = new Set(['asc', 'desc']);
@@ -15,6 +17,66 @@ const SOURCE_ORDER = ['landing', 'demo', 'app'];
 const SOURCE_ORDER_SQL = "CASE source WHEN 'landing' THEN 0 WHEN 'demo' THEN 1 WHEN 'app' THEN 2 ELSE 3 END";
 const STATUS_ORDER_SQL = "CASE status WHEN 'active' THEN 0 ELSE 1 END";
 const textEncoder = new TextEncoder();
+const JSON_RESPONSE_CSP = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
+const LOGIN_PAGE_SCRIPT = `(function () {
+  const form = document.getElementById('loginForm');
+  const tokenInput = document.getElementById('tokenInput');
+  const submitButton = document.getElementById('submitButton');
+  const errorMessage = document.getElementById('errorMessage');
+
+  async function createSession(token) {
+    return fetch('${SESSION_PATH}', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + token
+      },
+      cache: 'no-store',
+      credentials: 'same-origin'
+    });
+  }
+
+  async function submitToken(token) {
+    submitButton.disabled = true;
+    errorMessage.textContent = '';
+
+    try {
+      const response = await createSession(token);
+
+      if (response.status === 401) {
+        throw new Error('Invalid dashboard token.');
+      }
+
+      if (response.status === 429) {
+        throw new Error('Too many requests. Please try again shortly.');
+      }
+
+      if (!response.ok) {
+        throw new Error('Dashboard request failed.');
+      }
+
+      window.location.replace('/');
+    } catch (error) {
+      errorMessage.textContent = error.message || 'Dashboard request failed.';
+    } finally {
+      submitButton.disabled = false;
+    }
+  }
+
+  form.addEventListener('submit', function (event) {
+    event.preventDefault();
+    const token = tokenInput.value.trim();
+    if (!token) {
+      errorMessage.textContent = 'Dashboard token is required.';
+      return;
+    }
+    submitToken(token);
+  });
+}());`;
+// Keep these hashes in sync with the inline scripts in LOGIN_PAGE_SCRIPT and dashboard.html.
+const LOGIN_PAGE_CSP =
+    "default-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'sha256-eFTzCI9iuo4BrRDWpekD3Zcjuh71IkGU48bivkfumTY='; style-src 'unsafe-inline'";
+const DASHBOARD_PAGE_CSP =
+    "default-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'sha256-VfEhTEHh27hhls/PX5RzOmFm8XzH3IXvg6LSK6hiSs8='; style-src 'unsafe-inline'";
 
 class HttpError extends Error {
     constructor(status, message) {
@@ -32,30 +94,46 @@ function escapeHtml(value) {
         .replaceAll('"', '&quot;');
 }
 
-function createHeaders(contentType) {
-    return new Headers({
+function createHeaders(contentType, csp, extraHeaders = {}) {
+    const headers = new Headers({
         'Cache-Control': 'no-store',
-        'Content-Security-Policy':
-            "default-src 'self'; base-uri 'none'; connect-src 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'",
-        'Content-Type': contentType,
+        'Content-Security-Policy': csp,
         'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
         'Referrer-Policy': 'no-referrer',
+        Vary: 'Authorization, Cookie',
         'X-Content-Type-Options': 'nosniff',
         'X-Frame-Options': 'DENY'
     });
+
+    if (contentType) {
+        headers.set('Content-Type', contentType);
+    }
+
+    for (const [name, value] of Object.entries(extraHeaders)) {
+        headers.set(name, value);
+    }
+
+    return headers;
 }
 
-export function jsonResponse(payload, status = 200) {
+export function jsonResponse(payload, status = 200, extraHeaders = {}) {
     return new Response(JSON.stringify(payload), {
         status,
-        headers: createHeaders('application/json; charset=UTF-8')
+        headers: createHeaders('application/json; charset=UTF-8', JSON_RESPONSE_CSP, extraHeaders)
     });
 }
 
-export function htmlResponse(html, status = 200) {
+export function htmlResponse(html, status = 200, csp = LOGIN_PAGE_CSP, extraHeaders = {}) {
     return new Response(html, {
         status,
-        headers: createHeaders('text/html; charset=UTF-8')
+        headers: createHeaders('text/html; charset=UTF-8', csp, extraHeaders)
+    });
+}
+
+function emptyResponse(status = 204, extraHeaders = {}) {
+    return new Response(null, {
+        status,
+        headers: createHeaders(null, JSON_RESPONSE_CSP, extraHeaders)
     });
 }
 
@@ -78,8 +156,38 @@ function getBearerToken(request) {
     return match ? match[1].trim() : '';
 }
 
+function getCookieToken(request) {
+    const cookieHeader = request.headers.get('Cookie') || '';
+
+    for (const fragment of cookieHeader.split(';')) {
+        const [name, ...rest] = fragment.trim().split('=');
+        if (name !== DASHBOARD_SESSION_COOKIE) continue;
+        return decodeURIComponent(rest.join('='));
+    }
+
+    return '';
+}
+
+function buildSessionCookie(request, token) {
+    const attributes = ['HttpOnly', 'Path=/', 'SameSite=Strict'];
+    if (new URL(request.url).protocol === 'https:') {
+        attributes.push('Secure');
+    }
+
+    return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(token)}; ${attributes.join('; ')}`;
+}
+
+function buildClearSessionCookie(request) {
+    const attributes = ['HttpOnly', 'Max-Age=0', 'Path=/', 'SameSite=Strict'];
+    if (new URL(request.url).protocol === 'https:') {
+        attributes.push('Secure');
+    }
+
+    return `${DASHBOARD_SESSION_COOKIE}=; ${attributes.join('; ')}`;
+}
+
 export function authenticate(request, env) {
-    const providedToken = getBearerToken(request);
+    const providedToken = getBearerToken(request) || getCookieToken(request);
     const expectedToken = typeof env.DASHBOARD_TOKEN === 'string' ? env.DASHBOARD_TOKEN.trim() : '';
 
     if (!providedToken || !expectedToken) {
@@ -218,86 +326,7 @@ function createLoginHtml(errorMessage = '') {
     </form>
     <div id="errorMessage" class="error" role="alert">${safeError}</div>
   </main>
-  <script>
-    (function () {
-      const form = document.getElementById('loginForm');
-      const tokenInput = document.getElementById('tokenInput');
-      const submitButton = document.getElementById('submitButton');
-      const errorMessage = document.getElementById('errorMessage');
-
-      async function loadDashboardShell(token) {
-        const response = await fetch(window.location.pathname, {
-          method: 'GET',
-          headers: { Authorization: 'Bearer ' + token },
-          cache: 'no-store'
-        });
-
-        const html = await response.text();
-        if (!response.ok || !html.includes('data-dashboard-shell="true"')) {
-          throw new Error(response.status === 429 ? 'Too many requests. Please try again shortly.' : 'Invalid dashboard token.');
-        }
-
-        document.open();
-        document.write(html);
-        document.close();
-      }
-
-      async function verifyToken(token) {
-        const response = await fetch('/api/summary', {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            Authorization: 'Bearer ' + token
-          },
-          cache: 'no-store'
-        });
-
-        if (response.status === 401) {
-          throw new Error('Invalid dashboard token.');
-        }
-
-        if (response.status === 429) {
-          throw new Error('Too many requests. Please try again shortly.');
-        }
-
-        if (!response.ok) {
-          throw new Error('Dashboard request failed.');
-        }
-      }
-
-      async function submitToken(token) {
-        submitButton.disabled = true;
-        errorMessage.textContent = '';
-
-        try {
-          await verifyToken(token);
-          sessionStorage.setItem('dashboardToken', token);
-          await loadDashboardShell(token);
-        } catch (error) {
-          sessionStorage.removeItem('dashboardToken');
-          errorMessage.textContent = error.message || 'Dashboard request failed.';
-        } finally {
-          submitButton.disabled = false;
-        }
-      }
-
-      form.addEventListener('submit', function (event) {
-        event.preventDefault();
-        const token = tokenInput.value.trim();
-        if (!token) {
-          errorMessage.textContent = 'Dashboard token is required.';
-          return;
-        }
-        submitToken(token);
-      });
-
-      const storedToken = sessionStorage.getItem('dashboardToken');
-      if (storedToken) {
-        tokenInput.value = storedToken;
-        submitToken(storedToken);
-      }
-    }());
-  </script>
+  <script>${LOGIN_PAGE_SCRIPT}</script>
 </body>
 </html>`;
 }
@@ -323,11 +352,11 @@ function parseIntegerParam(rawValue, fallback, { min = 1, max = Number.MAX_SAFE_
 
     const parsed = Number.parseInt(rawValue, 10);
     if (!Number.isFinite(parsed) || String(parsed) !== String(rawValue).trim()) {
-        badRequest(`Invalid integer parameter: ${rawValue}`);
+        badRequest('Invalid integer parameter');
     }
 
     if (parsed < min || parsed > max) {
-        badRequest(`Integer parameter out of range: ${rawValue}`);
+        badRequest('Integer parameter out of range');
     }
 
     return parsed;
@@ -527,18 +556,51 @@ export async function handleDashboard(request, env, dashboardHtml) {
     requireGet(request);
 
     if (!authenticate(request, env)) {
-        return htmlResponse(createLoginHtml(), 200);
+        return htmlResponse(
+            createLoginHtml(),
+            200,
+            LOGIN_PAGE_CSP,
+            { 'Set-Cookie': buildClearSessionCookie(request) }
+        );
     }
 
-    return htmlResponse(dashboardHtml, 200);
+    return htmlResponse(dashboardHtml, 200, DASHBOARD_PAGE_CSP);
 }
 
-function createUnauthorizedResponse(pathname) {
-    if (pathname === DASHBOARD_PATH) {
-        return htmlResponse(createLoginHtml(), 200);
+export async function handleSession(request, env) {
+    if (request.method === 'DELETE') {
+        return emptyResponse(204, {
+            'Set-Cookie': buildClearSessionCookie(request)
+        });
     }
 
-    return jsonResponse({ error: 'Unauthorized' }, 401);
+    if (request.method !== 'POST') {
+        methodNotAllowed();
+    }
+
+    if (!authenticate(request, env)) {
+        return jsonResponse(
+            { error: 'Unauthorized' },
+            401,
+            { 'Set-Cookie': buildClearSessionCookie(request) }
+        );
+    }
+
+    return emptyResponse(204, {
+        'Set-Cookie': buildSessionCookie(request, env.DASHBOARD_TOKEN.trim())
+    });
+}
+
+function createUnauthorizedResponse(pathname, request) {
+    const headers = {
+        'Set-Cookie': buildClearSessionCookie(request)
+    };
+
+    if (pathname === DASHBOARD_PATH) {
+        return htmlResponse(createLoginHtml(), 200, LOGIN_PAGE_CSP, headers);
+    }
+
+    return jsonResponse({ error: 'Unauthorized' }, 401, headers);
 }
 
 function createRateLimitResponse(pathname) {
@@ -556,6 +618,10 @@ export async function dispatchRequest(request, env, dashboardHtml) {
         return createRateLimitResponse(pathname);
     }
 
+    if (pathname === SESSION_PATH) {
+        return handleSession(request, env);
+    }
+
     if (pathname === DASHBOARD_PATH) {
         return handleDashboard(request, env, dashboardHtml);
     }
@@ -563,7 +629,7 @@ export async function dispatchRequest(request, env, dashboardHtml) {
     if (pathname === SUMMARY_PATH) {
         requireGet(request);
         if (!authenticate(request, env)) {
-            return createUnauthorizedResponse(pathname);
+            return createUnauthorizedResponse(pathname, request);
         }
         return jsonResponse(await handleSummary(env));
     }
@@ -571,7 +637,7 @@ export async function dispatchRequest(request, env, dashboardHtml) {
     if (pathname === SUBSCRIBERS_PATH) {
         requireGet(request);
         if (!authenticate(request, env)) {
-            return createUnauthorizedResponse(pathname);
+            return createUnauthorizedResponse(pathname, request);
         }
         return jsonResponse(await handleSubscribers(request, env));
     }

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -159,6 +159,9 @@ function bytesToHex(bytes) {
 }
 
 function bytesToBase64(bytes) {
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.from(bytes).toString('base64');
+    }
     let binary = '';
     for (const byte of bytes) {
         binary += String.fromCharCode(byte);
@@ -234,6 +237,10 @@ export async function verifySignedSessionValue(value, secret, nowMs = Date.now()
         return false;
     }
 
+    if (!/^\d+$/.test(expiresAtRaw) || !/^[0-9a-f]{64}$/.test(signature)) {
+        return false;
+    }
+
     const expiresAtMs = Number.parseInt(expiresAtRaw, 10);
     if (!Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs) {
         return false;
@@ -256,7 +263,8 @@ function getCookieToken(request) {
 }
 
 async function buildSessionCookie(request, token) {
-    const expiresAtMs = Date.now() + SESSION_MAX_AGE_SECONDS * 1000;
+    const nowMs = Date.now();
+    const expiresAtMs = nowMs + SESSION_MAX_AGE_SECONDS * 1000;
     const attributes = [
         'HttpOnly',
         `Expires=${new Date(expiresAtMs).toUTCString()}`,
@@ -268,7 +276,7 @@ async function buildSessionCookie(request, token) {
         attributes.push('Secure');
     }
 
-    const signedValue = await createSignedSessionValue(token);
+    const signedValue = await createSignedSessionValue(token, nowMs);
     return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(signedValue)}; ${attributes.join('; ')}`;
 }
 

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -16,7 +16,9 @@ const SORT_COLUMNS = new Map([
 const SOURCE_ORDER = ['landing', 'demo', 'app'];
 const SOURCE_ORDER_SQL = "CASE source WHEN 'landing' THEN 0 WHEN 'demo' THEN 1 WHEN 'app' THEN 2 ELSE 3 END";
 const STATUS_ORDER_SQL = "CASE status WHEN 'active' THEN 0 ELSE 1 END";
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
 const textEncoder = new TextEncoder();
+const sessionHashCache = new Map();
 const JSON_RESPONSE_CSP = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
 const LOGIN_PAGE_SCRIPT = `(function () {
   const form = document.getElementById('loginForm');
@@ -156,6 +158,21 @@ function getBearerToken(request) {
     return match ? match[1].trim() : '';
 }
 
+async function hashSessionToken(token) {
+    if (sessionHashCache.has(token)) {
+        return sessionHashCache.get(token);
+    }
+
+    const hashedTokenPromise = crypto.subtle
+        .digest('SHA-256', textEncoder.encode(token))
+        .then((digest) =>
+            [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+        );
+
+    sessionHashCache.set(token, hashedTokenPromise);
+    return hashedTokenPromise;
+}
+
 function getCookieToken(request) {
     const cookieHeader = request.headers.get('Cookie') || '';
 
@@ -168,13 +185,19 @@ function getCookieToken(request) {
     return '';
 }
 
-function buildSessionCookie(request, token) {
-    const attributes = ['HttpOnly', 'Path=/', 'SameSite=Strict'];
+async function buildSessionCookie(request, token) {
+    const attributes = [
+        'HttpOnly',
+        `Max-Age=${SESSION_MAX_AGE_SECONDS}`,
+        'Path=/',
+        'SameSite=Strict'
+    ];
     if (new URL(request.url).protocol === 'https:') {
         attributes.push('Secure');
     }
 
-    return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(token)}; ${attributes.join('; ')}`;
+    const hashedToken = await hashSessionToken(token);
+    return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(hashedToken)}; ${attributes.join('; ')}`;
 }
 
 function buildClearSessionCookie(request) {
@@ -186,15 +209,24 @@ function buildClearSessionCookie(request) {
     return `${DASHBOARD_SESSION_COOKIE}=; ${attributes.join('; ')}`;
 }
 
-export function authenticate(request, env) {
-    const providedToken = getBearerToken(request) || getCookieToken(request);
+export async function authenticate(request, env) {
+    const bearerToken = getBearerToken(request);
+    const cookieToken = getCookieToken(request);
     const expectedToken = typeof env.DASHBOARD_TOKEN === 'string' ? env.DASHBOARD_TOKEN.trim() : '';
 
-    if (!providedToken || !expectedToken) {
+    if (!expectedToken) {
         return false;
     }
 
-    return timingSafeEqual(providedToken, expectedToken);
+    if (bearerToken) {
+        return timingSafeEqual(bearerToken, expectedToken);
+    }
+
+    if (!cookieToken) {
+        return false;
+    }
+
+    return timingSafeEqual(cookieToken, await hashSessionToken(expectedToken));
 }
 
 async function isRateLimited(request, env) {
@@ -555,7 +587,7 @@ export async function handleSubscribers(request, env) {
 export async function handleDashboard(request, env, dashboardHtml) {
     requireGet(request);
 
-    if (!authenticate(request, env)) {
+    if (!(await authenticate(request, env))) {
         return htmlResponse(
             createLoginHtml(),
             200,
@@ -578,7 +610,7 @@ export async function handleSession(request, env) {
         methodNotAllowed();
     }
 
-    if (!authenticate(request, env)) {
+    if (!(await authenticate(request, env))) {
         return jsonResponse(
             { error: 'Unauthorized' },
             401,
@@ -587,7 +619,7 @@ export async function handleSession(request, env) {
     }
 
     return emptyResponse(204, {
-        'Set-Cookie': buildSessionCookie(request, env.DASHBOARD_TOKEN.trim())
+        'Set-Cookie': await buildSessionCookie(request, env.DASHBOARD_TOKEN.trim())
     });
 }
 
@@ -614,6 +646,10 @@ function createRateLimitResponse(pathname) {
 export async function dispatchRequest(request, env, dashboardHtml) {
     const { pathname } = new URL(request.url);
 
+    if (pathname === SESSION_PATH && request.method === 'DELETE') {
+        return handleSession(request, env);
+    }
+
     if (await isRateLimited(request, env)) {
         return createRateLimitResponse(pathname);
     }
@@ -628,7 +664,7 @@ export async function dispatchRequest(request, env, dashboardHtml) {
 
     if (pathname === SUMMARY_PATH) {
         requireGet(request);
-        if (!authenticate(request, env)) {
+        if (!(await authenticate(request, env))) {
             return createUnauthorizedResponse(pathname, request);
         }
         return jsonResponse(await handleSummary(env));
@@ -636,7 +672,7 @@ export async function dispatchRequest(request, env, dashboardHtml) {
 
     if (pathname === SUBSCRIBERS_PATH) {
         requireGet(request);
-        if (!authenticate(request, env)) {
+        if (!(await authenticate(request, env))) {
             return createUnauthorizedResponse(pathname, request);
         }
         return jsonResponse(await handleSubscribers(request, env));

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -18,7 +18,8 @@ const SOURCE_ORDER_SQL = "CASE source WHEN 'landing' THEN 0 WHEN 'demo' THEN 1 W
 const STATUS_ORDER_SQL = "CASE status WHEN 'active' THEN 0 ELSE 1 END";
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
 const textEncoder = new TextEncoder();
-const sessionHashCache = new Map();
+const signingKeyCache = new Map();
+const inlineScriptCspCache = new Map();
 const JSON_RESPONSE_CSP = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
 const LOGIN_PAGE_SCRIPT = `(function () {
   const form = document.getElementById('loginForm');
@@ -74,12 +75,6 @@ const LOGIN_PAGE_SCRIPT = `(function () {
     submitToken(token);
   });
 }());`;
-// Keep these hashes in sync with the inline scripts in LOGIN_PAGE_SCRIPT and dashboard.html.
-const LOGIN_PAGE_CSP =
-    "default-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'sha256-eFTzCI9iuo4BrRDWpekD3Zcjuh71IkGU48bivkfumTY='; style-src 'unsafe-inline'";
-const DASHBOARD_PAGE_CSP =
-    "default-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'sha256-VfEhTEHh27hhls/PX5RzOmFm8XzH3IXvg6LSK6hiSs8='; style-src 'unsafe-inline'";
-
 class HttpError extends Error {
     constructor(status, message) {
         super(message);
@@ -125,7 +120,7 @@ export function jsonResponse(payload, status = 200, extraHeaders = {}) {
     });
 }
 
-export function htmlResponse(html, status = 200, csp = LOGIN_PAGE_CSP, extraHeaders = {}) {
+export function htmlResponse(html, status = 200, csp = JSON_RESPONSE_CSP, extraHeaders = {}) {
     return new Response(html, {
         status,
         headers: createHeaders('text/html; charset=UTF-8', csp, extraHeaders)
@@ -158,19 +153,93 @@ function getBearerToken(request) {
     return match ? match[1].trim() : '';
 }
 
-async function hashSessionToken(token) {
-    if (sessionHashCache.has(token)) {
-        return sessionHashCache.get(token);
+function bytesToHex(bytes) {
+    return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function bytesToBase64(bytes) {
+    let binary = '';
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+    return btoa(binary);
+}
+
+function extractInlineScript(html) {
+    const match = html.match(/<script>([\s\S]*?)<\/script>/);
+    if (!match) {
+        throw new Error('Expected an inline dashboard script');
+    }
+    return match[1];
+}
+
+async function getSigningKey(secret) {
+    if (signingKeyCache.has(secret)) {
+        return signingKeyCache.get(secret);
     }
 
-    const hashedTokenPromise = crypto.subtle
-        .digest('SHA-256', textEncoder.encode(token))
-        .then((digest) =>
-            [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
-        );
+    const signingKeyPromise = crypto.subtle.importKey(
+        'raw',
+        textEncoder.encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+    );
 
-    sessionHashCache.set(token, hashedTokenPromise);
-    return hashedTokenPromise;
+    signingKeyCache.set(secret, signingKeyPromise);
+    return signingKeyPromise;
+}
+
+async function signSessionPayload(secret, payload) {
+    const signingKey = await getSigningKey(secret);
+    const signature = await crypto.subtle.sign('HMAC', signingKey, textEncoder.encode(payload));
+    return bytesToHex(new Uint8Array(signature));
+}
+
+async function buildInlineScriptCsp(html) {
+    const script = extractInlineScript(html);
+
+    if (inlineScriptCspCache.has(script)) {
+        return inlineScriptCspCache.get(script);
+    }
+
+    const cspPromise = crypto.subtle.digest('SHA-256', textEncoder.encode(script)).then((digest) => {
+        const hash = bytesToBase64(new Uint8Array(digest));
+        return `default-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'sha256-${hash}'; style-src 'unsafe-inline'`;
+    });
+
+    inlineScriptCspCache.set(script, cspPromise);
+    return cspPromise;
+}
+
+function buildSessionPayload(expiresAtMs) {
+    return `v1:${expiresAtMs}`;
+}
+
+export async function createSignedSessionValue(secret, nowMs = Date.now()) {
+    const expiresAtMs = nowMs + SESSION_MAX_AGE_SECONDS * 1000;
+    const payload = buildSessionPayload(expiresAtMs);
+    const signature = await signSessionPayload(secret, payload);
+    return `v1.${expiresAtMs}.${signature}`;
+}
+
+export async function verifySignedSessionValue(value, secret, nowMs = Date.now()) {
+    if (typeof value !== 'string' || !value) {
+        return false;
+    }
+
+    const [version, expiresAtRaw, signature] = value.split('.');
+    if (version !== 'v1' || !expiresAtRaw || !signature) {
+        return false;
+    }
+
+    const expiresAtMs = Number.parseInt(expiresAtRaw, 10);
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs) {
+        return false;
+    }
+
+    const expectedSignature = await signSessionPayload(secret, buildSessionPayload(expiresAtMs));
+    return timingSafeEqual(signature, expectedSignature);
 }
 
 function getCookieToken(request) {
@@ -196,8 +265,8 @@ async function buildSessionCookie(request, token) {
         attributes.push('Secure');
     }
 
-    const hashedToken = await hashSessionToken(token);
-    return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(hashedToken)}; ${attributes.join('; ')}`;
+    const signedValue = await createSignedSessionValue(token);
+    return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(signedValue)}; ${attributes.join('; ')}`;
 }
 
 function buildClearSessionCookie(request) {
@@ -226,7 +295,7 @@ export async function authenticate(request, env) {
         return false;
     }
 
-    return timingSafeEqual(cookieToken, await hashSessionToken(expectedToken));
+    return verifySignedSessionValue(cookieToken, expectedToken);
 }
 
 async function isRateLimited(request, env) {
@@ -586,17 +655,18 @@ export async function handleSubscribers(request, env) {
 
 export async function handleDashboard(request, env, dashboardHtml) {
     requireGet(request);
+    const loginHtml = createLoginHtml();
 
     if (!(await authenticate(request, env))) {
         return htmlResponse(
-            createLoginHtml(),
+            loginHtml,
             200,
-            LOGIN_PAGE_CSP,
+            await buildInlineScriptCsp(loginHtml),
             { 'Set-Cookie': buildClearSessionCookie(request) }
         );
     }
 
-    return htmlResponse(dashboardHtml, 200, DASHBOARD_PAGE_CSP);
+    return htmlResponse(dashboardHtml, 200, await buildInlineScriptCsp(dashboardHtml));
 }
 
 export async function handleSession(request, env) {
@@ -623,21 +693,23 @@ export async function handleSession(request, env) {
     });
 }
 
-function createUnauthorizedResponse(pathname, request) {
+async function createUnauthorizedResponse(pathname, request) {
     const headers = {
         'Set-Cookie': buildClearSessionCookie(request)
     };
 
     if (pathname === DASHBOARD_PATH) {
-        return htmlResponse(createLoginHtml(), 200, LOGIN_PAGE_CSP, headers);
+        const loginHtml = createLoginHtml();
+        return htmlResponse(loginHtml, 200, await buildInlineScriptCsp(loginHtml), headers);
     }
 
     return jsonResponse({ error: 'Unauthorized' }, 401, headers);
 }
 
-function createRateLimitResponse(pathname) {
+async function createRateLimitResponse(pathname) {
     if (pathname === DASHBOARD_PATH) {
-        return htmlResponse(createLoginHtml('Too many requests. Please try again shortly.'), 429);
+        const loginHtml = createLoginHtml('Too many requests. Please try again shortly.');
+        return htmlResponse(loginHtml, 429, await buildInlineScriptCsp(loginHtml));
     }
 
     return jsonResponse({ error: 'Too many requests. Please try again later.' }, 429);
@@ -651,7 +723,7 @@ export async function dispatchRequest(request, env, dashboardHtml) {
     }
 
     if (await isRateLimited(request, env)) {
-        return createRateLimitResponse(pathname);
+        return await createRateLimitResponse(pathname);
     }
 
     if (pathname === SESSION_PATH) {
@@ -665,7 +737,7 @@ export async function dispatchRequest(request, env, dashboardHtml) {
     if (pathname === SUMMARY_PATH) {
         requireGet(request);
         if (!(await authenticate(request, env))) {
-            return createUnauthorizedResponse(pathname, request);
+            return await createUnauthorizedResponse(pathname, request);
         }
         return jsonResponse(await handleSummary(env));
     }
@@ -673,7 +745,7 @@ export async function dispatchRequest(request, env, dashboardHtml) {
     if (pathname === SUBSCRIBERS_PATH) {
         requireGet(request);
         if (!(await authenticate(request, env))) {
-            return createUnauthorizedResponse(pathname, request);
+            return await createUnauthorizedResponse(pathname, request);
         }
         return jsonResponse(await handleSubscribers(request, env));
     }
@@ -681,17 +753,21 @@ export async function dispatchRequest(request, env, dashboardHtml) {
     return jsonResponse({ error: 'Not found' }, 404);
 }
 
-export function createErrorResponse(request, error) {
+export async function createErrorResponse(request, error) {
     const pathname = new URL(request.url).pathname;
 
     if (error instanceof HttpError) {
-        return pathname === DASHBOARD_PATH
-            ? htmlResponse(createLoginHtml(error.message), error.status)
-            : jsonResponse({ error: error.message }, error.status);
+        if (pathname === DASHBOARD_PATH) {
+            const loginHtml = createLoginHtml(error.message);
+            return htmlResponse(loginHtml, error.status, await buildInlineScriptCsp(loginHtml));
+        }
+        return jsonResponse({ error: error.message }, error.status);
     }
 
     console.error('dashboard worker failed', error);
-    return pathname === DASHBOARD_PATH
-        ? htmlResponse(createLoginHtml('Server error.'), 500)
-        : jsonResponse({ error: 'Server error' }, 500);
+    if (pathname === DASHBOARD_PATH) {
+        const loginHtml = createLoginHtml('Server error.');
+        return htmlResponse(loginHtml, 500, await buildInlineScriptCsp(loginHtml));
+    }
+    return jsonResponse({ error: 'Server error' }, 500);
 }

--- a/workers/dashboard/wrangler.toml
+++ b/workers/dashboard/wrangler.toml
@@ -1,0 +1,23 @@
+name = "myradone-dashboard"
+main = "src/index.mjs"
+compatibility_date = "2026-04-07"
+workers_dev = false
+preview_urls = false
+
+[[rules]]
+type = "Text"
+globs = ["**/*.html"]
+fallthrough = false
+
+[[d1_databases]]
+binding = "SUBSCRIBERS_DB"
+database_name = "myradone-subscribers"
+database_id = "33a16c5c-0618-47a8-b351-7af2f4f979e9"
+
+[[ratelimits]]
+name = "DASHBOARD_RATE_LIMIT"
+namespace_id = "2026041201"
+
+  [ratelimits.simple]
+  limit = 30
+  period = 60


### PR DESCRIPTION
## What changed
- added a new `workers/dashboard/` Cloudflare Worker for the internal subscriber admin dashboard
- added bearer-token auth, rate limiting, hardened response headers, summary and paginated subscriber APIs, and a self-contained HTML dashboard shell
- added a D1 migration for subscriber query indexes and a focused `node:test` worker test suite
- updated ADR 012 to note the new protected read path for subscriber data

## Why
The subscriber write path existed, but the only way to inspect signup data was ad hoc `wrangler d1 execute` access. This adds a lightweight internal read surface for subscriber analytics without expanding scope into instrumentation or download tracking.

## Impact
- internal users can review subscriber counts, source mix, recent signups, and the full subscriber list from a protected dashboard
- local development is documented with a local token and seed-data workflow
- the dashboard query paths now have explicit supporting indexes

## Validation
- `node --test tests/dashboard-worker.test.mjs`
- `npx wrangler deploy --dry-run --config workers/dashboard/wrangler.toml`

## Notes
- this PR is intentionally scoped to subscribers only
- instrumentation and download analytics remain separate future work with different data models
