### PR TITLE
[codex] Document design closeout hook workflow

### DIFF
--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -108,6 +108,9 @@ Important notes:
 - Stale dirty files from older sessions should not trigger reminders by
   themselves; they only count when the current session also shows active design
   discussion.
+- Once a marker exists for the session, file recency is anchored to the
+  marker's own `first_seen_at` / `first_design_signal_at` timestamps instead of
+  repeatedly inferring freshness from transcript file metadata alone.
 - The local `.claude/` hook files are machine-local in this clone family because
   `.git/info/exclude` ignores `.claude/`; that is not a global repo guarantee.
 

--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -98,13 +98,19 @@ Marker states:
 - `resolved`: closeout completed and recorded
 - `stale`: unresolved marker older than the local TTL and no longer active
 
+The marker is a machine-readable trigger and recovery record; the dated session
+scratch note under `sessions/YYYY-MM-DD.md` remains the human-readable handoff
+artifact that captures the actual frontier and best next starting point.
+
 Important notes:
 
 - The transcript-size threshold is only a heuristic and may need recalibration.
 - The design signal is intentionally conservative: explicit design paths,
   transcript references to `divergent-designer`, `docs/design/`,
   `brand-system`, `logo`, `palette`, `typography`, or `wordmark`, and recent
-  file changes only.
+  file changes only. In practice the local hooks combine allowlisted file
+  paths, recent file mtimes anchored to the session marker, and a small
+  transcript-tail keyword check to avoid false positives.
 - Stale dirty files from older sessions should not trigger reminders by
   themselves; they only count when the current session also shows active design
   discussion.
@@ -113,10 +119,12 @@ Important notes:
   repeatedly inferring freshness from transcript file metadata alone.
 - The local `.claude/` hook files are machine-local in this clone family because
   `.git/info/exclude` ignores `.claude/`; that is not a global repo guarantee.
+  In a fresh clone, add `.claude/` to your local `.git/info/exclude` (or an
+  equivalent local exclude file) before using project-local hook scripts.
 
 ## Manual Flush Prompt
 
-Use this explicit prompt when a design session may compact or end, or whenever
+Use this explicit prompt whenever a design session may compact or end, or when
 the local hooks are not configured:
 
 ```text

--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -101,6 +101,13 @@ Marker states:
 Important notes:
 
 - The transcript-size threshold is only a heuristic and may need recalibration.
+- The design signal is intentionally conservative: explicit design paths,
+  transcript references to `divergent-designer`, `docs/design/`,
+  `brand-system`, `logo`, `palette`, `typography`, or `wordmark`, and recent
+  file changes only.
+- Stale dirty files from older sessions should not trigger reminders by
+  themselves; they only count when the current session also shows active design
+  discussion.
 - The local `.claude/` hook files are machine-local in this clone family because
   `.git/info/exclude` ignores `.claude/`; that is not a global repo guarantee.
 

--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -60,6 +60,8 @@ Before making design recommendations or changes:
 - Report back what was saved to repo docs and what was saved to private memory.
 - If an automated closeout reminder appears, treat closeout as the next task
   instead of normal work continuation.
+- Treat the hook reminder itself as the go signal for closeout; do not wait for
+  a second confirmation before saving the session state.
 
 ## Promotion Loop
 

--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -58,6 +58,8 @@ Before making design recommendations or changes:
 - If nothing was approved yet, still capture the current frontier and the best
   next starting point in session scratch.
 - Report back what was saved to repo docs and what was saved to private memory.
+- If an automated closeout reminder appears, treat closeout as the next task
+  instead of normal work continuation.
 
 ## Promotion Loop
 
@@ -71,9 +73,39 @@ Use this after each real design session.
    in `docs/design/patterns/`.
 5. Periodically compress `docs/design/core.md` so it stays short and useful.
 
-## Pre-Compaction Flush
+## Automated Closeout Hooks
 
-Use this explicit prompt when a design session may compact or end:
+This project can use machine-local Claude hooks to reduce the chance of losing
+design state across compaction boundaries.
+
+- `UserPromptSubmit` can inject a proactive reminder when the transcript gets
+  large and recent design work is detected.
+- `PreCompact` can capture mechanical state into a marker file before
+  compaction.
+- `SessionStart` with `source=compact` can re-inject a recovery reminder after
+  compaction by pointing the agent at the marker and transcript path.
+
+The marker lives under:
+
+`~/.claude/agent-memory/divergent-designer/workspaces/dicom-viewer/pending-closeout/`
+
+Marker states:
+
+- `pending`: design signal detected, closeout not yet completed
+- `reminded`: a proactive or post-compaction reminder was injected
+- `resolved`: closeout completed and recorded
+- `stale`: unresolved marker older than the local TTL and no longer active
+
+Important notes:
+
+- The transcript-size threshold is only a heuristic and may need recalibration.
+- The local `.claude/` hook files are machine-local in this clone family because
+  `.git/info/exclude` ignores `.claude/`; that is not a global repo guarantee.
+
+## Manual Flush Prompt
+
+Use this explicit prompt when a design session may compact or end, or whenever
+the local hooks are not configured:
 
 ```text
 Before this session compacts, run design closeout:


### PR DESCRIPTION
## What changed

- documents the machine-local automated design closeout flow in `docs/design/workflow.md`
- clarifies that hook-triggered closeout reminders are the go signal and should not wait for a second confirmation
- documents the marker lifecycle, conservative design-signal policy, and the marker-based recency gate used to ignore stale file changes
- keeps the manual flush prompt as the explicit fallback when hooks are unavailable

## Why

We added a persistent designer system for this project, then validated a machine-local closeout hook spike to keep design context from getting lost across compaction. The repo needed a durable description of that behavior so future sessions understand the intended closeout flow, even though the hook scripts themselves remain local-only.

## Impact

- designers and coding agents have a clearer closeout contract for design sessions
- the docs now distinguish canonical repo memory from private scratch and explain how automated reminders fit into that loop
- reviewers can see the intended local hook behavior without treating `.claude/` files as repo-owned implementation

## Validation

- live Claude sessions validated both the proactive reminder path (`UserPromptSubmit`) and the post-compaction recovery path (`PreCompact` + `SessionStart(source=compact)`)
- local hook scripts were syntax-checked with `bash -n` after the recency-gate updates
