### PR TITLE
Document closeout hook kill switch

### DIFF
--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -121,6 +121,12 @@ Important notes:
   `.git/info/exclude` ignores `.claude/`; that is not a global repo guarantee.
   In a fresh clone, add `.claude/` to your local `.git/info/exclude` (or an
   equivalent local exclude file) before using project-local hook scripts.
+- **Kill switch**: to silence all closeout hooks instantly without removing
+  wiring, set `CLOSEOUT_HOOKS_DISABLED=1` in your shell before launching Claude.
+  This causes every hook script to exit immediately with no side effects. Unset
+  the variable or set it to `0` to re-enable. Use this if the hooks are
+  producing false positives or otherwise interfering with non-design work during
+  the observation period.
 
 ## Manual Flush Prompt
 


### PR DESCRIPTION
## Summary

- Documents the `CLOSEOUT_HOOKS_DISABLED=1` env var kill switch in `docs/design/workflow.md`
- All three hook scripts (`design-prompt-submit.sh`, `design-precompact.sh`, `design-session-start.sh`) already check this variable and exit immediately when set
- Provides a fast mute during the observation period if hooks produce false positives

## Context

First live run of the hooks produced a false positive (stale uncommitted design files from a prior session). The kill switch was added to the scripts and now needs to be documented alongside the rest of the hook system.

## Test plan

- [ ] Docs-only change, no automated tests needed
- [ ] Verify kill switch works: `export CLOSEOUT_HOOKS_DISABLED=1`, send a message, confirm no hook reminder appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)