### PR TITLE
[codex] Fix audit findings across desktop, sync, and persistence

### DIFF
--- a/desktop/src-tauri/src/decode.rs
+++ b/desktop/src-tauri/src/decode.rs
@@ -270,9 +270,10 @@ pub async fn decode_frame<R: Runtime>(
     let pixel_data_length = decode_result.metadata.pixel_data_length;
     let decode_id = store.insert(decode_result.pixel_bytes);
     if native_decode_debug {
+        let redacted_path = redact_path_for_log(&scoped_path);
         eprintln!(
             "[native-decode] response path={} frame={} decode_id={} pixel_bytes={} store_pending={} elapsed_ms={}",
-            scoped_path.display(),
+            redacted_path,
             frame_index,
             decode_id,
             pixel_data_length,
@@ -306,9 +307,10 @@ pub async fn decode_frame_with_pixels<R: Runtime>(
     let pixel_data_length = decoded_frame.metadata.pixel_data_length;
     let response = build_decode_frame_with_pixels_response(decoded_frame)?;
     if native_decode_debug {
+        let redacted_path = redact_path_for_log(&scoped_path);
         eprintln!(
             "[native-decode] response-with-pixels path={} frame={} pixel_bytes={} elapsed_ms={}",
-            scoped_path.display(),
+            redacted_path,
             frame_index,
             pixel_data_length,
             started_at.elapsed().as_millis()
@@ -450,6 +452,7 @@ fn decode_frame_impl_with_cache(
     native_decode_debug: bool,
 ) -> DecodeResult<DecodedFrame> {
     let started_at = Instant::now();
+    let redacted_path = redact_path_for_log(path);
     let object = open_file(path).map_err(|error| {
         DecodeError::new("decode", format!("Failed to open DICOM file: {error}"))
     })?;
@@ -473,7 +476,7 @@ fn decode_frame_impl_with_cache(
             if native_decode_debug {
                 eprintln!(
                     "[native-decode] cache-hit path={} frame={} pixel_bytes={} rows={} cols={} elapsed_ms={}",
-                    path.display(),
+                    redacted_path,
                     frame_index,
                     cached_frame.metadata.pixel_data_length,
                     cached_frame.metadata.rows,
@@ -497,8 +500,7 @@ fn decode_frame_impl_with_cache(
         if let Err(error) = cache_write_result {
             eprintln!(
                 "Skipping decode cache write for {}: {}",
-                path.display(),
-                error
+                redacted_path, error
             );
         }
     }
@@ -506,7 +508,7 @@ fn decode_frame_impl_with_cache(
     if native_decode_debug {
         eprintln!(
             "[native-decode] cache-miss path={} frame={} pixel_bytes={} rows={} cols={} elapsed_ms={}",
-            path.display(),
+            redacted_path,
             frame_index,
             decoded_frame.metadata.pixel_data_length,
             decoded_frame.metadata.rows,
@@ -516,6 +518,10 @@ fn decode_frame_impl_with_cache(
     }
 
     Ok(decoded_frame)
+}
+
+fn redact_path_for_log(path: &Path) -> String {
+    crate::path_util::redact_path(path.to_string_lossy().as_ref()).to_string()
 }
 
 fn build_cache_key(
@@ -1239,5 +1245,12 @@ mod tests {
         assert_eq!(read.len(), MAX_SCAN_HEADER_BYTES);
 
         let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn redact_path_for_log_only_keeps_the_filename() {
+        let path = PathBuf::from("/Users/test/Patient Name/study/series/image-001.dcm");
+
+        assert_eq!(redact_path_for_log(&path), "image-001.dcm");
     }
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6,6 +6,8 @@ mod persistence;
 mod scan;
 mod secure_store;
 
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 use tauri::{
     menu::{AboutMetadata, Menu, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder},
@@ -47,6 +49,7 @@ const EVENT_SHOW_LIBRARY: &str = "desktop://show-library-in-finder";
 const EVENT_CHECK_UPDATES: &str = "desktop://check-for-updates";
 const EVENT_OPEN_HELP: &str = "desktop://open-help";
 const DESKTOP_DB_URL: &str = "sqlite:viewer.db";
+const MAX_FRONTEND_DECODE_LOG_BYTES: usize = 4096;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -127,8 +130,29 @@ fn get_debug_settings(settings: tauri::State<'_, DebugSettings>) -> DebugSetting
 #[tauri::command]
 fn log_frontend_decode_event(settings: tauri::State<'_, DebugSettings>, message: String) {
     if settings.frontend_decode_trace {
-        eprintln!("[frontend-decode] {message}");
+        eprintln!(
+            "[frontend-decode] {}",
+            truncate_frontend_decode_log_message(&message)
+        );
     }
+}
+
+fn truncate_frontend_decode_log_message(message: &str) -> Cow<'_, str> {
+    if message.len() <= MAX_FRONTEND_DECODE_LOG_BYTES {
+        return Cow::Borrowed(message);
+    }
+
+    const SUFFIX: &str = "...";
+    let max_prefix_bytes = MAX_FRONTEND_DECODE_LOG_BYTES.saturating_sub(SUFFIX.len());
+    let mut cutoff = max_prefix_bytes;
+    while cutoff > 0 && !message.is_char_boundary(cutoff) {
+        cutoff -= 1;
+    }
+
+    let mut truncated = String::with_capacity(cutoff + SUFFIX.len());
+    truncated.push_str(&message[..cutoff]);
+    truncated.push_str(SUFFIX);
+    Cow::Owned(truncated)
 }
 
 fn build_menu<R: Runtime, M: Manager<R>>(manager: &M) -> tauri::Result<Menu<R>> {
@@ -523,4 +547,27 @@ fn main() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_frontend_decode_log_message_leaves_short_messages_intact() {
+        let message = "short decode trace";
+
+        assert_eq!(truncate_frontend_decode_log_message(message), message);
+    }
+
+    #[test]
+    fn truncate_frontend_decode_log_message_caps_bytes_and_preserves_utf8() {
+        let message = "é".repeat(MAX_FRONTEND_DECODE_LOG_BYTES);
+
+        let truncated = truncate_frontend_decode_log_message(&message);
+
+        assert!(truncated.len() <= MAX_FRONTEND_DECODE_LOG_BYTES);
+        assert!(truncated.ends_with("..."));
+        assert!(std::str::from_utf8(truncated.as_bytes()).is_ok());
+    }
 }

--- a/desktop/src-tauri/src/persistence.rs
+++ b/desktop/src-tauri/src/persistence.rs
@@ -325,12 +325,31 @@ pub async fn apply_desktop_migration(
 
     for row in &batch.comments {
         sqlx::query(
-            r#"INSERT OR IGNORE INTO comments (study_uid, series_uid, text, time)
-               VALUES (?, ?, ?, ?)"#,
+            r#"INSERT OR IGNORE INTO comments (
+                   study_uid,
+                   series_uid,
+                   text,
+                   time,
+                   record_uuid,
+                   created_at,
+                   updated_at
+               )
+               VALUES (
+                   ?, ?, ?, ?,
+                   lower(hex(randomblob(4))) || '-' ||
+                   lower(hex(randomblob(2))) || '-' ||
+                   '4' || substr(lower(hex(randomblob(2))), 2) || '-' ||
+                   substr('89ab', abs(random()) % 4 + 1, 1) ||
+                   substr(lower(hex(randomblob(2))), 2) || '-' ||
+                   lower(hex(randomblob(6))),
+                   ?, ?
+               )"#,
         )
         .bind(&row.study_uid)
         .bind(&row.series_uid)
         .bind(&row.text)
+        .bind(row.time)
+        .bind(row.time)
         .bind(row.time)
         .execute(&mut *tx)
         .await

--- a/desktop/src-tauri/src/scan.rs
+++ b/desktop/src-tauri/src/scan.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 use serde::Serialize;
+use tauri::Runtime;
+use tauri_plugin_fs::FsExt;
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ScanManifestEntry {
@@ -16,23 +18,40 @@ pub struct ScanManifestEntry {
 }
 
 #[tauri::command]
-pub async fn read_scan_manifest(
+pub async fn read_scan_manifest<R: Runtime>(
+    app: tauri::AppHandle<R>,
     roots: Vec<String>,
     max_depth: usize,
     allowed: tauri::State<'_, crate::path_util::AllowedPaths>,
 ) -> Result<Vec<ScanManifestEntry>, String> {
+    let fs_scope = app.fs_scope();
     let scoped_roots = roots
         .iter()
-        .map(|root| {
-            let canonical = crate::path_util::resolve_canonical_path(root, "scan-manifest")?;
-            allowed.add_root(canonical.clone());
-            Ok(canonical)
-        })
+        .map(|root| resolve_authorized_root(root, &allowed, |path| fs_scope.is_allowed(path)))
         .collect::<Result<Vec<_>, String>>()?;
 
     tokio::task::spawn_blocking(move || read_scan_manifest_impl(&scoped_roots, max_depth))
         .await
         .map_err(|error| format!("Native scan manifest worker failed to join: {error}"))?
+}
+
+fn resolve_authorized_root<F>(
+    root: &str,
+    allowed: &crate::path_util::AllowedPaths,
+    is_allowed: F,
+) -> Result<PathBuf, String>
+where
+    F: FnOnce(&Path) -> bool,
+{
+    let canonical = crate::path_util::resolve_canonical_path(root, "scan-manifest")?;
+    if !is_allowed(&canonical) {
+        return Err(format!(
+            "scan-manifest: path is outside granted scope: {}",
+            crate::path_util::redact_path(root)
+        ));
+    }
+    allowed.add_root(canonical.clone());
+    Ok(canonical)
 }
 
 fn read_scan_manifest_impl(
@@ -158,6 +177,35 @@ mod tests {
         ));
         fs::create_dir_all(&dir).expect("temp dir should be creatable");
         dir
+    }
+
+    #[test]
+    fn resolve_authorized_root_requires_existing_fs_scope_access() {
+        let root = temp_dir("unauthorized-root");
+        let allowed = crate::path_util::AllowedPaths::default();
+
+        let error = resolve_authorized_root(root.to_string_lossy().as_ref(), &allowed, |_| false)
+            .expect_err("unauthorized root should be rejected");
+
+        assert!(error.contains("outside granted scope"));
+        assert!(!allowed.is_within_scope(&root));
+
+        fs::remove_dir_all(&root).expect("temp dir should be removable");
+    }
+
+    #[test]
+    fn resolve_authorized_root_registers_roots_only_after_scope_validation() {
+        let root = temp_dir("authorized-root");
+        let allowed = crate::path_util::AllowedPaths::default();
+        let canonical = root.canonicalize().expect("temp dir should resolve");
+
+        let resolved = resolve_authorized_root(root.to_string_lossy().as_ref(), &allowed, |_| true)
+            .expect("authorized root should succeed");
+
+        assert_eq!(resolved, canonical);
+        assert!(allowed.is_within_scope(&canonical));
+
+        fs::remove_dir_all(&root).expect("temp dir should be removable");
     }
 
     #[test]

--- a/docs/js/app/comments-ui.js
+++ b/docs/js/app/comments-ui.js
@@ -151,7 +151,20 @@
             } else if (saved.id !== undefined && saved.id !== null) {
                 comment.id = saved.id;
             }
+            if (saved.time) {
+                comment.time = saved.time;
+            }
             updateCommentListUI(studyUid, seriesUid);
+            return;
+        }
+
+        const idx = comments.indexOf(comment);
+        if (idx !== -1) {
+            comments.splice(idx, 1);
+        }
+        updateCommentListUI(studyUid, seriesUid);
+        if (notesApi.isEnabled()) {
+            alert('Failed to save comment. Please try again.');
         }
     }
 
@@ -163,11 +176,16 @@
 
         const idx = findCommentIndex(comments, commentId);
         if (idx === -1) return;
+        if (!String(commentId).startsWith('local-')) {
+            const deleted = await notesApi.deleteComment(studyUid, commentId);
+            if (!deleted) {
+                alert('Failed to delete comment. Please try again.');
+                return;
+            }
+        }
+
         comments.splice(idx, 1);
         updateCommentListUI(studyUid, seriesUid);
-        if (!String(commentId).startsWith('local-')) {
-            await notesApi.deleteComment(studyUid, commentId);
-        }
     }
 
     async function editComment(studyUid, seriesUid, commentId) {
@@ -182,14 +200,24 @@
         const newText = prompt('Edit comment:', comments[idx].text);
         const trimmedText = newText?.trim();
         if (trimmedText) {
+            const previous = {
+                text: comments[idx].text,
+                time: comments[idx].time,
+            };
             comments[idx].text = trimmedText;
             comments[idx].time = Date.now();
             updateCommentListUI(studyUid, seriesUid);
             if (!String(commentId).startsWith('local-')) {
-                await notesApi.updateComment(studyUid, commentId, {
+                const saved = await notesApi.updateComment(studyUid, commentId, {
                     text: comments[idx].text,
                     time: comments[idx].time,
                 });
+                if (!saved) {
+                    comments[idx].text = previous.text;
+                    comments[idx].time = previous.time;
+                    updateCommentListUI(studyUid, seriesUid);
+                    alert('Failed to update comment. Please try again.');
+                }
             }
         }
     }

--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -110,7 +110,9 @@
         if (existing) clearTimeout(existing);
         const handle = setTimeout(() => {
             descriptionSaveTimers.delete(key);
-            callback();
+            Promise.resolve(callback()).catch((error) => {
+                console.warn('Failed to persist description change:', error);
+            });
         }, 500);
         descriptionSaveTimers.set(key, handle);
     }
@@ -746,25 +748,52 @@
         });
 
         studiesBody.querySelectorAll('.description-input:not(.series-description)').forEach((textarea) => {
+            const studyUid = textarea.dataset.studyUid;
+            textarea.dataset.persistedValue = state.studies[studyUid]?.description || '';
             textarea.oninput = () => {
                 const studyUid = textarea.dataset.studyUid;
                 if (state.studies[studyUid]) {
+                    const rollbackValue = textarea.dataset.persistedValue || '';
+                    const nextValue = textarea.value;
                     state.studies[studyUid].description = textarea.value;
-                    scheduleDescriptionSave(`study:${studyUid}`, () => {
-                        notesApi.saveStudyDescription(studyUid, textarea.value);
+                    scheduleDescriptionSave(`study:${studyUid}`, async () => {
+                        const saved = await notesApi.saveStudyDescription(studyUid, nextValue);
+                        if (saved) {
+                            textarea.dataset.persistedValue = nextValue;
+                            return;
+                        }
+                        if (textarea.value === nextValue) {
+                            textarea.value = rollbackValue;
+                            state.studies[studyUid].description = rollbackValue;
+                        }
+                        alert('Failed to save study description. Please try again.');
                     });
                 }
             };
         });
 
         studiesBody.querySelectorAll('.series-description').forEach((textarea) => {
+            const studyUid = textarea.dataset.studyUid;
+            const seriesUid = textarea.dataset.seriesUid;
+            textarea.dataset.persistedValue = state.studies[studyUid]?.series[seriesUid]?.description || '';
             textarea.oninput = () => {
                 const studyUid = textarea.dataset.studyUid;
                 const seriesUid = textarea.dataset.seriesUid;
                 if (state.studies[studyUid]?.series[seriesUid]) {
+                    const rollbackValue = textarea.dataset.persistedValue || '';
+                    const nextValue = textarea.value;
                     state.studies[studyUid].series[seriesUid].description = textarea.value;
-                    scheduleDescriptionSave(`series:${studyUid}:${seriesUid}`, () => {
-                        notesApi.saveSeriesDescription(studyUid, seriesUid, textarea.value);
+                    scheduleDescriptionSave(`series:${studyUid}:${seriesUid}`, async () => {
+                        const saved = await notesApi.saveSeriesDescription(studyUid, seriesUid, nextValue);
+                        if (saved) {
+                            textarea.dataset.persistedValue = nextValue;
+                            return;
+                        }
+                        if (textarea.value === nextValue) {
+                            textarea.value = rollbackValue;
+                            state.studies[studyUid].series[seriesUid].description = rollbackValue;
+                        }
+                        alert('Failed to save series description. Please try again.');
                     });
                 }
             };

--- a/docs/js/app/notes-ui.js
+++ b/docs/js/app/notes-ui.js
@@ -150,7 +150,10 @@
                             if (!blob) return;
                             const filename = report.name || 'report';
                             const file = new File([blob], filename, { type: blob.type || '' });
-                            await notesApi.uploadReport(studyUid, file, report);
+                            const uploaded = await notesApi.uploadReport(studyUid, file, report);
+                            if (!uploaded) {
+                                throw new Error(`Failed to migrate legacy report ${report.id}`);
+                            }
                         })(),
                     );
                 }

--- a/docs/js/app/reports-ui.js
+++ b/docs/js/app/reports-ui.js
@@ -6,6 +6,7 @@
     window.DicomViewerApp = app;
     const { state } = app;
     const notesApi = window.NotesAPI;
+    const config = window.CONFIG;
     const { $, studiesBody } = app.dom;
     const { escapeHtml, generateUUID } = app.utils;
 
@@ -53,6 +54,9 @@
         const saved = await notesApi.uploadReport(studyUid, file, report);
         if (saved) {
             Object.assign(report, saved);
+        } else if (config?.deploymentMode === 'personal' || config?.deploymentMode === 'cloud') {
+            alert('Failed to upload report. Please try again.');
+            return;
         } else {
             report.blob = file;
         }
@@ -68,15 +72,14 @@
         const idx = reports.findIndex((report) => report.id === reportId);
         if (idx === -1) return;
 
-        const removed = reports.splice(idx, 1)[0];
-        updateReportListUI(studyUid);
-
         const result = await notesApi.deleteReport(studyUid, reportId);
         if (!result && notesApi.isEnabled()) {
-            reports.splice(idx, 0, removed);
-            updateReportListUI(studyUid);
             alert('Failed to delete report. Please try again.');
+            return;
         }
+
+        reports.splice(idx, 1);
+        updateReportListUI(studyUid);
     }
 
     function renderReports(reports, studyUid) {

--- a/docs/js/app/sync-engine.js
+++ b/docs/js/app/sync-engine.js
@@ -562,7 +562,9 @@ const _SyncEngine = (() => {
                 } else {
                     // Insert new comment from remote
                     const createdAt = data.created_at || Date.now();
-                    const targetComments = seriesUid ? ensureSeries(studyEntry, seriesUid).comments : studyEntry.comments;
+                    const targetComments = seriesUid
+                        ? ensureSeries(studyEntry, seriesUid).comments
+                        : studyEntry.comments;
                     targetComments.push({
                         id: recordKey,
                         record_uuid: recordKey,

--- a/docs/js/app/sync-engine.js
+++ b/docs/js/app/sync-engine.js
@@ -24,6 +24,19 @@ const _SyncEngine = (() => {
     // Backoff schedule: 30s, 60s, 120s, 300s (max 5 min)
     const BACKOFF_SCHEDULE_MS = [30000, 60000, 120000, 300000];
 
+    function parseSeriesRecordKey(recordKey) {
+        try {
+            const [studyUid, seriesUid] = JSON.parse(String(recordKey || ''));
+            if (!studyUid || !seriesUid) return null;
+            return {
+                studyUid: String(studyUid),
+                seriesUid: String(seriesUid),
+            };
+        } catch {
+            return null;
+        }
+    }
+
     /**
      * SyncEngine manages the periodic sync loop.
      *
@@ -445,7 +458,7 @@ const _SyncEngine = (() => {
          * @param {Map} [studyLookup] - Optional pre-built comment lookup map for O(1) access
          */
         _updateLocalSyncVersion(tableName, recordKey, syncVersion, studyLookup) {
-            const { loadStore, saveStore, ensureStudy } = window._NotesInternals;
+            const { loadStore, saveStore, ensureStudy, ensureSeries } = window._NotesInternals;
             const store = loadStore();
 
             if (tableName === 'study_notes') {
@@ -485,6 +498,17 @@ const _SyncEngine = (() => {
                 return;
             }
 
+            if (tableName === 'series_notes') {
+                const parsed = parseSeriesRecordKey(recordKey);
+                if (!parsed) return;
+                const studyEntry = store.studies[parsed.studyUid];
+                if (!studyEntry) return;
+                const seriesEntry = ensureSeries(studyEntry, parsed.seriesUid);
+                seriesEntry.sync_version = syncVersion;
+                saveStore(store);
+                return;
+            }
+
             if (tableName === 'reports') {
                 const { findReportMetadata } = window._NotesInternals;
                 const match = findReportMetadata(store, recordKey);
@@ -516,6 +540,38 @@ const _SyncEngine = (() => {
                     studyEntry.description = data.description;
                 }
                 studyEntry.sync_version = syncVersion;
+                saveStore(store);
+                return;
+            }
+
+            if (tableName === 'series_notes') {
+                const parsed = parseSeriesRecordKey(recordKey);
+                if (!parsed) return;
+                const deletedAt = data.deletedAt || data.deleted_at || null;
+                const existingStudy = store.studies[parsed.studyUid];
+
+                if (deletedAt) {
+                    if (!existingStudy) return;
+                    const existingSeries = existingStudy.series?.[parsed.seriesUid];
+                    if (!existingSeries) return;
+                    existingSeries.description = '';
+                    existingSeries.deletedAt = deletedAt;
+                    existingSeries.sync_version = syncVersion;
+                    saveStore(store);
+                    return;
+                }
+
+                const studyEntry = ensureStudy(store, parsed.studyUid);
+                const seriesEntry = ensureSeries(studyEntry, parsed.seriesUid);
+                if (data.description !== undefined) {
+                    seriesEntry.description = data.description;
+                }
+                if (data.updated_at !== undefined) {
+                    seriesEntry.updated_at = data.updated_at;
+                }
+                seriesEntry.sync_version = syncVersion;
+                delete seriesEntry.deletedAt;
+                delete seriesEntry.deleted_at;
                 saveStore(store);
                 return;
             }

--- a/docs/js/app/sync-engine.js
+++ b/docs/js/app/sync-engine.js
@@ -507,7 +507,7 @@ const _SyncEngine = (() => {
         _applyRemoteData(tableName, recordKey, data, syncVersion) {
             if (!data) return;
 
-            const { loadStore, saveStore, ensureStudy } = window._NotesInternals;
+            const { loadStore, saveStore, ensureStudy, ensureSeries } = window._NotesInternals;
             const store = loadStore();
 
             if (tableName === 'study_notes') {
@@ -523,6 +523,7 @@ const _SyncEngine = (() => {
             if (tableName === 'comments') {
                 const studyUid = data.study_uid;
                 if (!studyUid) return;
+                const seriesUid = data.series_uid || null;
                 const deletedAt = data.deletedAt || data.deleted_at || null;
 
                 if (deletedAt) {
@@ -543,15 +544,26 @@ const _SyncEngine = (() => {
                 const existing = this._findCommentByKey(studyEntry, recordKey);
 
                 if (existing) {
+                    this._removeCommentFromStudy(studyEntry, recordKey);
+                    const targetComments = seriesUid
+                        ? ensureSeries(studyEntry, seriesUid).comments
+                        : studyEntry.comments;
+                    targetComments.push(existing);
                     // Update existing comment
+                    existing.id = recordKey;
+                    existing.record_uuid = recordKey;
                     existing.text = data.text || '';
+                    existing.created_at = data.created_at || existing.created_at || existing.time || Date.now();
                     existing.updated_at = data.updated_at || Date.now();
-                    existing.time = data.created_at || existing.time || Date.now();
+                    existing.time = existing.created_at || existing.time || Date.now();
                     existing.sync_version = syncVersion;
+                    delete existing.deletedAt;
+                    delete existing.deleted_at;
                 } else {
                     // Insert new comment from remote
                     const createdAt = data.created_at || Date.now();
-                    studyEntry.comments.push({
+                    const targetComments = seriesUid ? ensureSeries(studyEntry, seriesUid).comments : studyEntry.comments;
+                    targetComments.push({
                         id: recordKey,
                         record_uuid: recordKey,
                         text: data.text || '',

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -52,7 +52,7 @@ const CONFIG = {
         }
 
         // Future cloud platform
-        if (hostname.includes('divergent.health') && !hostname.includes('localhost')) {
+        if (hostname === 'divergent.health' || hostname.endsWith('.divergent.health')) {
             return 'cloud';
         }
 

--- a/docs/js/persistence/desktop.js
+++ b/docs/js/persistence/desktop.js
@@ -1023,20 +1023,22 @@ const _NotesDesktop = (() => {
             if (!studyUid || commentId === undefined || commentId === null) return false;
             await initializeDesktopPersistence();
             const db = await getDesktopDb();
-            let result = await db.execute('DELETE FROM comments WHERE record_uuid = ? AND study_uid = ?', [
-                String(commentId),
-                studyUid,
-            ]);
+            const deletedAt = Date.now();
+            const commentKey = String(commentId);
+            let result = await db.execute(
+                'UPDATE comments SET deleted_at = ?, updated_at = ? WHERE record_uuid = ? AND study_uid = ?',
+                [deletedAt, deletedAt, commentKey, studyUid],
+            );
             if (!result?.rowsAffected) {
                 const legacyId = parseInteger(commentId, null);
                 if (legacyId !== null) {
-                    result = await db.execute('DELETE FROM comments WHERE id = ? AND study_uid = ?', [
-                        legacyId,
-                        studyUid,
-                    ]);
+                    result = await db.execute(
+                        'UPDATE comments SET deleted_at = ?, updated_at = ?, record_uuid = COALESCE(record_uuid, ?) WHERE id = ? AND study_uid = ?',
+                        [deletedAt, deletedAt, commentKey, legacyId, studyUid],
+                    );
                 }
             }
-            return true;
+            return !!result?.rowsAffected;
         },
 
         async uploadReport(studyUid, file, report = {}) {

--- a/docs/js/persistence/desktop.js
+++ b/docs/js/persistence/desktop.js
@@ -13,7 +13,6 @@
 const _NotesDesktop = (() => {
     const {
         createEmptyStore,
-        normalizeCommentId,
         ensureStudy,
         ensureSeries,
         normalizeReportId,
@@ -892,7 +891,7 @@ const _NotesDesktop = (() => {
                     ? ensureSeries(ensureStudy(notes, row.study_uid), row.series_uid)
                     : ensureStudy(notes, row.study_uid);
                 target.comments.push({
-                    id: row.id,
+                    id: row.record_uuid || row.id,
                     record_uuid: row.record_uuid || null,
                     text: row.text,
                     time: row.time,
@@ -972,14 +971,20 @@ const _NotesDesktop = (() => {
             if (!text) return null;
             const seriesUid = payload.seriesUid || '';
             const time = parseInteger(payload.time, Date.now());
+            const recordUuid = payload.record_uuid || crypto.randomUUID();
             const result = await db.execute(
-                'INSERT INTO comments (study_uid, series_uid, text, time) VALUES (?, ?, ?, ?)',
-                [studyUid, seriesUid, text, time],
+                `INSERT INTO comments (study_uid, series_uid, text, time, record_uuid, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+                [studyUid, seriesUid, text, time, recordUuid, time, time],
             );
             return {
-                id: result?.lastInsertId ?? null,
+                id: recordUuid,
+                record_uuid: recordUuid,
                 text,
                 time,
+                created_at: time,
+                updated_at: time,
+                legacy_id: result?.lastInsertId ?? null,
             };
         },
 
@@ -990,17 +995,27 @@ const _NotesDesktop = (() => {
             const text = (payload.text || '').trim();
             if (!text) return null;
             const time = parseInteger(payload.time, Date.now());
-            const result = await db.execute('UPDATE comments SET text = ?, time = ? WHERE id = ? AND study_uid = ?', [
-                text,
-                time,
-                normalizeCommentId(commentId),
-                studyUid,
-            ]);
+            const commentKey = String(commentId);
+            let result = await db.execute(
+                'UPDATE comments SET text = ?, time = ?, updated_at = ? WHERE record_uuid = ? AND study_uid = ?',
+                [text, time, time, commentKey, studyUid],
+            );
+            if (!result?.rowsAffected) {
+                const legacyId = parseInteger(commentId, null);
+                if (legacyId !== null) {
+                    result = await db.execute(
+                        'UPDATE comments SET text = ?, time = ?, updated_at = ? WHERE id = ? AND study_uid = ?',
+                        [text, time, time, legacyId, studyUid],
+                    );
+                }
+            }
             if (!result?.rowsAffected) return null;
             return {
-                id: normalizeCommentId(commentId),
+                id: commentKey,
+                record_uuid: commentKey,
                 text,
                 time,
+                updated_at: time,
             };
         },
 
@@ -1008,10 +1023,19 @@ const _NotesDesktop = (() => {
             if (!studyUid || commentId === undefined || commentId === null) return false;
             await initializeDesktopPersistence();
             const db = await getDesktopDb();
-            await db.execute('DELETE FROM comments WHERE id = ? AND study_uid = ?', [
-                normalizeCommentId(commentId),
+            let result = await db.execute('DELETE FROM comments WHERE record_uuid = ? AND study_uid = ?', [
+                String(commentId),
                 studyUid,
             ]);
+            if (!result?.rowsAffected) {
+                const legacyId = parseInteger(commentId, null);
+                if (legacyId !== null) {
+                    result = await db.execute('DELETE FROM comments WHERE id = ? AND study_uid = ?', [
+                        legacyId,
+                        studyUid,
+                    ]);
+                }
+            }
             return true;
         },
 

--- a/docs/js/persistence/dispatcher.js
+++ b/docs/js/persistence/dispatcher.js
@@ -69,6 +69,10 @@ const NotesAPI = (() => {
         return Number.isFinite(value) ? value : 0;
     }
 
+    function buildSeriesSyncKey(studyUid, seriesUid) {
+        return JSON.stringify([String(studyUid || ''), String(seriesUid || '')]);
+    }
+
     function findCommentRecord(studyUid, commentId) {
         const studyEntry = getStudyState(studyUid);
         if (!studyEntry) return null;
@@ -151,11 +155,18 @@ const NotesAPI = (() => {
 
     async function saveSeriesDescription(studyUid, seriesUid, description) {
         if (!isEnabled()) return null;
-        return await withFallback(
+        const studyEntry = getStudyState(studyUid);
+        const seriesEntry = studyEntry?.series?.[seriesUid] || null;
+        const baseSyncVersion = getBaseSyncVersion(seriesEntry);
+        const result = await withFallback(
             () => ServerBackend.saveSeriesDescription(studyUid, seriesUid, description),
             () => LocalBackend.saveSeriesDescription(studyUid, seriesUid, description),
             () => DesktopBackend.saveSeriesDescription(studyUid, seriesUid, description),
         );
+        if (result) {
+            enqueueSyncChange('series_notes', buildSeriesSyncKey(studyUid, seriesUid), 'update', baseSyncVersion);
+        }
+        return result;
     }
 
     async function addComment(studyUid, payload) {

--- a/docs/js/persistence/dispatcher.js
+++ b/docs/js/persistence/dispatcher.js
@@ -13,7 +13,7 @@
  */
 
 const NotesAPI = (() => {
-    const { LocalBackend } = window._NotesInternals;
+    const { LocalBackend, normalizeCommentId, normalizeReportId } = window._NotesInternals;
     const { ServerBackend, authenticatedFetch } = window._NotesServer;
     const {
         DesktopBackend,
@@ -28,22 +28,85 @@ const NotesAPI = (() => {
     } = window._NotesDesktop;
 
     // ---- Dispatcher ----
+    function getConfig() {
+        if (typeof window !== 'undefined' && window.CONFIG) {
+            return window.CONFIG;
+        }
+        if (typeof CONFIG !== 'undefined') {
+            return CONFIG;
+        }
+        return null;
+    }
+
     function getBackend() {
-        const mode = typeof CONFIG !== 'undefined' ? CONFIG.deploymentMode : 'personal';
+        const config = getConfig();
+        const mode = config?.deploymentMode || 'personal';
         if (mode === 'desktop') return 'desktop';
-        const hasServer =
-            typeof CONFIG !== 'undefined' && CONFIG.features
-                ? CONFIG.features.notesServer
-                : mode === 'personal' || mode === 'cloud';
+        const hasServer = config?.features ? config.features.notesServer : mode === 'personal' || mode === 'cloud';
         if (hasServer) return 'server';
         return 'local';
     }
 
     function isEnabled() {
-        if (typeof CONFIG !== 'undefined' && CONFIG.shouldPersistNotes) {
-            return CONFIG.shouldPersistNotes();
+        const config = getConfig();
+        if (config?.shouldPersistNotes) {
+            return config.shouldPersistNotes();
         }
         return true;
+    }
+
+    function isCloudSyncEnabled() {
+        const config = getConfig();
+        return (
+            !!config?.features?.cloudSync &&
+            typeof window._SyncOutbox?.enqueueChange === 'function'
+        );
+    }
+
+    function getStudyState(studyUid) {
+        return window.DicomViewerApp?.state?.studies?.[studyUid] || null;
+    }
+
+    function getBaseSyncVersion(record) {
+        const value = Number(record?.sync_version);
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    function findCommentRecord(studyUid, commentId) {
+        const studyEntry = getStudyState(studyUid);
+        if (!studyEntry) return null;
+        const target = normalizeCommentId(commentId);
+        if (target === null) return null;
+
+        const matches = (comment) => {
+            if (comment?.record_uuid && normalizeCommentId(comment.record_uuid) === target) return true;
+            return normalizeCommentId(comment?.id) === target;
+        };
+
+        if (Array.isArray(studyEntry.comments)) {
+            const found = studyEntry.comments.find(matches);
+            if (found) return found;
+        }
+        if (studyEntry.series && typeof studyEntry.series === 'object') {
+            for (const seriesEntry of Object.values(studyEntry.series)) {
+                if (!Array.isArray(seriesEntry?.comments)) continue;
+                const found = seriesEntry.comments.find(matches);
+                if (found) return found;
+            }
+        }
+        return null;
+    }
+
+    function findReportRecord(studyUid, reportId) {
+        const studyEntry = getStudyState(studyUid);
+        if (!studyEntry || !Array.isArray(studyEntry.reports)) return null;
+        const target = normalizeReportId(reportId);
+        return studyEntry.reports.find((report) => normalizeReportId(report?.id) === target) || null;
+    }
+
+    function enqueueSyncChange(tableName, recordKey, operation, baseSyncVersion = 0) {
+        if (!isCloudSyncEnabled()) return null;
+        return window._SyncOutbox.enqueueChange(tableName, recordKey, operation, baseSyncVersion);
     }
 
     async function withFallback(serverCall, localCall, desktopCall = localCall) {
@@ -77,11 +140,16 @@ const NotesAPI = (() => {
 
     async function saveStudyDescription(studyUid, description) {
         if (!isEnabled()) return null;
-        return await withFallback(
+        const baseSyncVersion = getBaseSyncVersion(getStudyState(studyUid));
+        const result = await withFallback(
             () => ServerBackend.saveStudyDescription(studyUid, description),
             () => LocalBackend.saveStudyDescription(studyUid, description),
             () => DesktopBackend.saveStudyDescription(studyUid, description),
         );
+        if (result) {
+            enqueueSyncChange('study_notes', studyUid, 'update', baseSyncVersion);
+        }
+        return result;
     }
 
     async function saveSeriesDescription(studyUid, seriesUid, description) {
@@ -95,47 +163,78 @@ const NotesAPI = (() => {
 
     async function addComment(studyUid, payload) {
         if (!isEnabled()) return null;
-        return await withFallback(
+        const result = await withFallback(
             () => ServerBackend.addComment(studyUid, payload),
             () => LocalBackend.addComment(studyUid, payload),
             () => DesktopBackend.addComment(studyUid, payload),
         );
+        const recordKey = result?.record_uuid || result?.id || null;
+        if (recordKey) {
+            enqueueSyncChange('comments', recordKey, 'insert', 0);
+        }
+        return result;
     }
 
     async function updateComment(studyUid, commentId, payload) {
         if (!isEnabled()) return null;
-        return await withFallback(
+        const comment = findCommentRecord(studyUid, commentId);
+        const baseSyncVersion = getBaseSyncVersion(comment);
+        const result = await withFallback(
             () => ServerBackend.updateComment(studyUid, commentId, payload),
             () => LocalBackend.updateComment(studyUid, commentId, payload),
             () => DesktopBackend.updateComment(studyUid, commentId, payload),
         );
+        const recordKey = result?.record_uuid || result?.id || comment?.record_uuid || comment?.id || commentId;
+        if (result && recordKey) {
+            enqueueSyncChange('comments', recordKey, 'update', baseSyncVersion);
+        }
+        return result;
     }
 
     async function deleteComment(studyUid, commentId) {
         if (!isEnabled()) return false;
-        return await withFallback(
+        const comment = findCommentRecord(studyUid, commentId);
+        const baseSyncVersion = getBaseSyncVersion(comment);
+        const result = await withFallback(
             () => ServerBackend.deleteComment(studyUid, commentId),
             () => LocalBackend.deleteComment(studyUid, commentId),
             () => DesktopBackend.deleteComment(studyUid, commentId),
         );
+        const recordKey = comment?.record_uuid || comment?.id || commentId;
+        if (result && recordKey) {
+            enqueueSyncChange('comments', recordKey, 'delete', baseSyncVersion);
+        }
+        return result;
     }
 
     async function uploadReport(studyUid, file, meta) {
         if (!isEnabled()) return null;
-        return await withFallback(
+        const result = await withFallback(
             () => ServerBackend.uploadReport(studyUid, file, meta),
             () => LocalBackend.uploadReport(studyUid, file, meta),
             () => DesktopBackend.uploadReport(studyUid, file, meta),
         );
+        const recordKey = result?.id || meta?.id || null;
+        if (recordKey) {
+            enqueueSyncChange('reports', recordKey, 'insert', 0);
+        }
+        return result;
     }
 
     async function deleteReport(studyUid, reportId) {
         if (!isEnabled()) return false;
-        return await withFallback(
+        const report = findReportRecord(studyUid, reportId);
+        const baseSyncVersion = getBaseSyncVersion(report);
+        const result = await withFallback(
             () => ServerBackend.deleteReport(studyUid, reportId),
             () => LocalBackend.deleteReport(studyUid, reportId),
             () => DesktopBackend.deleteReport(studyUid, reportId),
         );
+        const recordKey = report?.id || reportId;
+        if (result && recordKey) {
+            enqueueSyncChange('reports', recordKey, 'delete', baseSyncVersion);
+        }
+        return result;
     }
 
     async function migrate(payload) {

--- a/docs/js/persistence/dispatcher.js
+++ b/docs/js/persistence/dispatcher.js
@@ -57,10 +57,7 @@ const NotesAPI = (() => {
 
     function isCloudSyncEnabled() {
         const config = getConfig();
-        return (
-            !!config?.features?.cloudSync &&
-            typeof window._SyncOutbox?.enqueueChange === 'function'
-        );
+        return !!config?.features?.cloudSync && typeof window._SyncOutbox?.enqueueChange === 'function';
     }
 
     function getStudyState(studyUid) {

--- a/docs/js/persistence/sync.js
+++ b/docs/js/persistence/sync.js
@@ -526,6 +526,32 @@ const _SyncOutbox = (() => {
         return stores;
     }
 
+    function parseSeriesRecordKey(recordKey) {
+        try {
+            const [studyUid, seriesUid] = JSON.parse(String(recordKey || ''));
+            if (!studyUid || !seriesUid) return null;
+            return {
+                studyUid: String(studyUid),
+                seriesUid: String(seriesUid),
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    function findSeriesEntry(store, recordKey) {
+        const parsed = parseSeriesRecordKey(recordKey);
+        if (!parsed) return null;
+        const studyEntry = store?.studies?.[parsed.studyUid];
+        const seriesEntry = studyEntry?.series?.[parsed.seriesUid];
+        if (!seriesEntry) return null;
+        return {
+            studyUid: parsed.studyUid,
+            seriesUid: parsed.seriesUid,
+            seriesEntry,
+        };
+    }
+
     function findReportInStore(store, recordKey) {
         const normalizedKey = String(recordKey || '').trim();
         if (!normalizedKey) return null;
@@ -550,6 +576,18 @@ const _SyncOutbox = (() => {
                     return { description: studyEntry.description || '' };
                 }
                 continue;
+            }
+
+            if (tableName === 'series_notes') {
+                const match = findSeriesEntry(store, recordKey);
+                if (!match) continue;
+                return {
+                    study_uid: match.studyUid,
+                    series_uid: match.seriesUid,
+                    description: match.seriesEntry.description || '',
+                    updated_at: match.seriesEntry.updated_at || 0,
+                    deleted_at: match.seriesEntry.deletedAt || match.seriesEntry.deleted_at || null,
+                };
             }
 
             if (tableName === 'comments') {
@@ -604,6 +642,25 @@ const _SyncOutbox = (() => {
                 recordKey,
             ]);
             return rows[0] ? { description: rows[0].description || '' } : null;
+        }
+
+        if (tableName === 'series_notes') {
+            const parsed = parseSeriesRecordKey(recordKey);
+            if (!parsed) return null;
+            const rows = await db.select(
+                `SELECT study_uid, series_uid, description, updated_at, deleted_at
+                 FROM series_notes
+                 WHERE study_uid = ? AND series_uid = ? LIMIT 1`,
+                [parsed.studyUid, parsed.seriesUid],
+            );
+            if (!rows[0]) return null;
+            return {
+                study_uid: rows[0].study_uid,
+                series_uid: rows[0].series_uid,
+                description: rows[0].description || '',
+                updated_at: rows[0].updated_at || 0,
+                deleted_at: rows[0].deleted_at || null,
+            };
         }
 
         if (tableName === 'comments') {

--- a/docs/js/persistence/sync.js
+++ b/docs/js/persistence/sync.js
@@ -426,7 +426,7 @@ const _SyncOutbox = (() => {
         return next;
     }
 
-    function markSynced(entryIds, syncedAt) {
+    function markSynced(entryIds, _syncedAt) {
         const idSet = new Set(entryIds);
         if (isDesktopMode()) {
             const syncedEntries = desktopCache.outbox.filter((entry) => idSet.has(entry.id));
@@ -496,61 +496,94 @@ const _SyncOutbox = (() => {
             const found = studyEntry.comments.find(
                 (comment) => comment.record_uuid === recordUuid || comment.id === recordUuid,
             );
-            if (found) return found;
+            if (found) return { comment: found, seriesUid: null };
         }
         if (studyEntry.series && typeof studyEntry.series === 'object') {
-            for (const seriesEntry of Object.values(studyEntry.series)) {
+            for (const [seriesUid, seriesEntry] of Object.entries(studyEntry.series)) {
                 if (!Array.isArray(seriesEntry.comments)) continue;
                 const found = seriesEntry.comments.find(
                     (comment) => comment.record_uuid === recordUuid || comment.id === recordUuid,
                 );
-                if (found) return found;
+                if (found) return { comment: found, seriesUid };
             }
         }
         return null;
     }
 
-    function readRecordState(tableName, recordKey) {
-        const { loadStore, ensureStudy, findReportMetadata } = window._NotesInternals;
-        const store = loadStore();
-
-        if (tableName === 'study_notes') {
-            const studyEntry = store.studies[recordKey];
-            if (!studyEntry) return null;
-            return { description: studyEntry.description || '' };
+    function getReadableStores() {
+        const { loadStore } = window._NotesInternals;
+        const stores = [];
+        const persistedStore = loadStore();
+        if (persistedStore?.studies && typeof persistedStore.studies === 'object') {
+            stores.push(persistedStore);
         }
 
-        if (tableName === 'comments') {
-            for (const studyUid of Object.keys(store.studies)) {
-                const studyEntry = ensureStudy(store, studyUid);
-                const found = findCommentInStudy(studyEntry, recordKey);
-                if (found) {
-                    return {
-                        study_uid: studyUid,
-                        text: found.text || '',
-                        created_at: found.created_at || found.time || 0,
-                        updated_at: found.updated_at || found.time || 0,
-                        deleted_at: found.deletedAt || found.deleted_at || null,
-                    };
-                }
+        const appStudies = window.DicomViewerApp?.state?.studies;
+        if (appStudies && typeof appStudies === 'object' && appStudies !== persistedStore?.studies) {
+            stores.push({ studies: appStudies });
+        }
+
+        return stores;
+    }
+
+    function findReportInStore(store, recordKey) {
+        const normalizedKey = String(recordKey || '').trim();
+        if (!normalizedKey) return null;
+
+        for (const [studyUid, studyEntry] of Object.entries(store?.studies || {})) {
+            const report = Array.isArray(studyEntry?.reports)
+                ? studyEntry.reports.find((entry) => String(entry?.id || '').trim() === normalizedKey)
+                : null;
+            if (report) {
+                return { studyUid, report };
             }
-            return null;
         }
 
-        if (tableName === 'reports') {
-            const match = findReportMetadata(store, recordKey);
-            if (!match) return null;
-            const report = match.report;
-            return {
-                study_uid: match.studyUid,
-                name: report.name || '',
-                type: report.type || '',
-                size: report.size || 0,
-                content_hash: report.contentHash || null,
-                created_at: report.addedAt ? new Date(report.addedAt).getTime() : 0,
-                updated_at: report.updatedAt || 0,
-                deleted_at: report.deletedAt || report.deleted_at || null,
-            };
+        return null;
+    }
+
+    function readRecordState(tableName, recordKey) {
+        for (const store of getReadableStores()) {
+            if (tableName === 'study_notes') {
+                const studyEntry = store.studies?.[recordKey];
+                if (studyEntry) {
+                    return { description: studyEntry.description || '' };
+                }
+                continue;
+            }
+
+            if (tableName === 'comments') {
+                for (const [studyUid, studyEntry] of Object.entries(store.studies || {})) {
+                    const found = findCommentInStudy(studyEntry, recordKey);
+                    if (found) {
+                        return {
+                            study_uid: studyUid,
+                            series_uid: found.seriesUid || null,
+                            text: found.comment.text || '',
+                            created_at: found.comment.created_at || found.comment.time || 0,
+                            updated_at: found.comment.updated_at || found.comment.time || 0,
+                            deleted_at: found.comment.deletedAt || found.comment.deleted_at || null,
+                        };
+                    }
+                }
+                continue;
+            }
+
+            if (tableName === 'reports') {
+                const match = findReportInStore(store, recordKey);
+                if (!match) continue;
+                const report = match.report;
+                return {
+                    study_uid: match.studyUid,
+                    name: report.name || '',
+                    type: report.type || '',
+                    size: report.size || 0,
+                    content_hash: report.contentHash || null,
+                    created_at: report.addedAt ? new Date(report.addedAt).getTime() : 0,
+                    updated_at: report.updatedAt || 0,
+                    deleted_at: report.deletedAt || report.deleted_at || null,
+                };
+            }
         }
 
         return null;

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -43,6 +43,13 @@ from server.security import (
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+def _env_flag(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
 def create_app():
     """Flask application factory. Returns a fully configured app instance."""
     app = Flask(
@@ -53,6 +60,7 @@ def create_app():
     # Override root_path so DB paths and other root-relative logic stays correct
     app.root_path = _PROJECT_ROOT
     app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50 MB upload limit
+    app.config['TRUST_X_FORWARDED_FOR'] = _env_flag('TRUST_X_FORWARDED_FOR', False)
 
     # Initialize database paths and schema
     db_module.configure(app.root_path)

--- a/server/db.py
+++ b/server/db.py
@@ -11,6 +11,7 @@ import re
 import sqlite3
 import tempfile
 import threading
+import uuid
 
 from flask import g
 
@@ -479,6 +480,34 @@ def init_db():
                 created_at = time,
                 updated_at = time
             WHERE record_uuid IS NULL
+            """
+        )
+
+        duplicate_rows = db.execute(
+            """
+            SELECT record_uuid
+            FROM comments
+            WHERE record_uuid IS NOT NULL
+            GROUP BY record_uuid
+            HAVING COUNT(*) > 1
+            """
+        ).fetchall()
+        for duplicate in duplicate_rows:
+            rows = db.execute(
+                'SELECT id FROM comments WHERE record_uuid = ? ORDER BY id ASC',
+                (duplicate['record_uuid'],),
+            ).fetchall()
+            for row in rows[1:]:
+                db.execute(
+                    'UPDATE comments SET record_uuid = ? WHERE id = ?',
+                    (str(uuid.uuid4()), row['id']),
+                )
+
+        db.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_comments_record_uuid
+            ON comments(record_uuid)
+            WHERE record_uuid IS NOT NULL
             """
         )
 

--- a/server/db.py
+++ b/server/db.py
@@ -44,6 +44,8 @@ MAX_TIMESTAMP_DRIFT_MS = 365 * 24 * 60 * 60 * 1000  # 1 year
 
 # Settings/config synchronization
 SETTINGS_LOCK = threading.Lock()
+_SQLITE_IDENTIFIER_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+_SQLITE_COLUMN_DEFINITION_RE = re.compile(r"^[A-Z]+(?: [A-Z]+)*(?: DEFAULT (?:''|[0-9]+))?$")
 
 
 def configure(app_root_path):
@@ -519,8 +521,17 @@ def init_db():
 
 def _add_column(db, table, column, col_type):
     """Add a column to a table if it does not already exist. Idempotent."""
+    if not _SQLITE_IDENTIFIER_RE.fullmatch(table):
+        raise ValueError(f'Invalid SQLite table identifier: {table}')
+    if not _SQLITE_IDENTIFIER_RE.fullmatch(column):
+        raise ValueError(f'Invalid SQLite column identifier: {column}')
+
+    column_definition = ' '.join(str(col_type or '').split())
+    if not _SQLITE_COLUMN_DEFINITION_RE.fullmatch(column_definition):
+        raise ValueError(f'Invalid SQLite column definition: {col_type}')
+
     try:
-        db.execute(f'ALTER TABLE {table} ADD COLUMN {column} {col_type}')
+        db.execute(f'ALTER TABLE "{table}" ADD COLUMN "{column}" {column_definition}')
     except sqlite3.OperationalError as exc:
         # "duplicate column name" means it already exists -- safe to ignore
         if 'duplicate column' not in str(exc).lower():

--- a/server/db.py
+++ b/server/db.py
@@ -248,6 +248,31 @@ def init_db():
 
         db.execute(
             """
+            CREATE TABLE IF NOT EXISTS cloud_series_notes (
+                user_id INTEGER NOT NULL,
+                record_key TEXT NOT NULL,
+                study_uid TEXT NOT NULL,
+                series_uid TEXT NOT NULL,
+                description TEXT,
+                updated_at INTEGER,
+                deleted_at INTEGER,
+                device_id TEXT,
+                sync_version INTEGER NOT NULL DEFAULT 0,
+                last_operation TEXT NOT NULL DEFAULT 'update',
+                PRIMARY KEY (user_id, record_key),
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            )
+            """
+        )
+        db.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_cloud_series_notes_study_uid
+            ON cloud_series_notes(user_id, study_uid, series_uid)
+            """
+        )
+
+        db.execute(
+            """
             CREATE TABLE IF NOT EXISTS cloud_comments (
                 user_id INTEGER NOT NULL,
                 record_uuid TEXT NOT NULL,

--- a/server/db.py
+++ b/server/db.py
@@ -130,6 +130,7 @@ def close_db(exception=None):
 def init_db():
     _ensure_data_dirs()
     db = sqlite3.connect(DB_PATH)
+    db.row_factory = sqlite3.Row
     try:
         db.execute(
             """

--- a/server/routes/auth.py
+++ b/server/routes/auth.py
@@ -47,8 +47,10 @@ _EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
 # or broad test runs that create many unique users from the same machine.
 _AUTH_WINDOW_SECONDS = 15 * 60
 _AUTH_MAX_ATTEMPTS = 5
+_AUTH_SWEEP_INTERVAL_SECONDS = 60
 _AUTH_FAILURES = defaultdict(deque)
 _AUTH_FAILURES_LOCK = threading.Lock()
+_AUTH_LAST_SWEEP_AT = 0
 
 
 def _normalize_email(email):
@@ -73,12 +75,39 @@ def _prune_attempts(attempts, now_s):
         attempts.popleft()
 
 
+def _sweep_auth_failures(now_s):
+    stale_keys = []
+    for key, attempts in list(_AUTH_FAILURES.items()):
+        _prune_attempts(attempts, now_s)
+        if not attempts:
+            stale_keys.append(key)
+
+    for key in stale_keys:
+        _AUTH_FAILURES.pop(key, None)
+
+
+def _maybe_sweep_auth_failures(now_s):
+    global _AUTH_LAST_SWEEP_AT
+
+    if now_s - _AUTH_LAST_SWEEP_AT < _AUTH_SWEEP_INTERVAL_SECONDS and _AUTH_FAILURES:
+        return
+
+    _sweep_auth_failures(now_s)
+    _AUTH_LAST_SWEEP_AT = now_s
+
+
 def _rate_limit_retry_after(action, email):
     now_s = int(time.time())
     key = _auth_failure_key(action, email)
     with _AUTH_FAILURES_LOCK:
-        attempts = _AUTH_FAILURES[key]
+        _maybe_sweep_auth_failures(now_s)
+        attempts = _AUTH_FAILURES.get(key)
+        if attempts is None:
+            return None
         _prune_attempts(attempts, now_s)
+        if not attempts:
+            _AUTH_FAILURES.pop(key, None)
+            return None
         if len(attempts) < _AUTH_MAX_ATTEMPTS:
             return None
         return max(1, _AUTH_WINDOW_SECONDS - (now_s - attempts[0]))
@@ -88,6 +117,7 @@ def _record_auth_failure(action, email):
     now_s = int(time.time())
     key = _auth_failure_key(action, email)
     with _AUTH_FAILURES_LOCK:
+        _maybe_sweep_auth_failures(now_s)
         attempts = _AUTH_FAILURES[key]
         _prune_attempts(attempts, now_s)
         attempts.append(now_s)

--- a/server/routes/auth.py
+++ b/server/routes/auth.py
@@ -57,7 +57,7 @@ def _normalize_email(email):
 
 def _client_ip():
     forwarded = request.headers.get('X-Forwarded-For', '')
-    if forwarded:
+    if current_app.config.get('TRUST_X_FORWARDED_FOR') and forwarded:
         return forwarded.split(',')[0].strip() or 'unknown'
     return request.remote_addr or 'unknown'
 

--- a/server/routes/comments.py
+++ b/server/routes/comments.py
@@ -7,6 +7,7 @@ Deletes are soft (tombstoned with deleted_at) to support sync replication.
 Copyright (c) 2026 Divergent Health Technologies
 """
 
+import sqlite3
 import time
 import uuid
 
@@ -15,6 +16,16 @@ from flask import Blueprint, jsonify, request
 from server.db import MAX_TIMESTAMP_DRIFT_MS, get_db, parse_int
 
 comments_bp = Blueprint('comments', __name__)
+
+
+def _comment_uuid_exists(db, record_uuid):
+    if not record_uuid:
+        return False
+    row = db.execute(
+        'SELECT 1 FROM comments WHERE record_uuid = ? LIMIT 1',
+        (record_uuid,),
+    ).fetchone()
+    return row is not None
 
 
 @comments_bp.route('/api/notes/<study_uid>/comments', methods=['POST'])
@@ -33,19 +44,30 @@ def add_comment(study_uid):
     else:
         timestamp = now
 
-    record_uuid = data.get('record_uuid') or str(uuid.uuid4())
+    requested_uuid = (data.get('record_uuid') or '').strip()
+    record_uuid = requested_uuid or str(uuid.uuid4())
     # Validate record_uuid is never empty
     if not record_uuid or not record_uuid.strip():
         record_uuid = str(uuid.uuid4())
 
     db = get_db()
-    db.execute(
-        """INSERT INTO comments
-           (study_uid, series_uid, text, time, record_uuid, created_at, updated_at, sync_version)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 0)""",
-        (study_uid, series_uid, text, timestamp, record_uuid, timestamp, timestamp),
-    )
-    db.commit()
+    if requested_uuid and _comment_uuid_exists(db, record_uuid):
+        return jsonify({'error': 'Comment ID already exists'}), 409
+
+    try:
+        db.execute(
+            """
+            INSERT INTO comments (
+                study_uid, series_uid, text, time, record_uuid, created_at, updated_at, sync_version
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+            """,
+            (study_uid, series_uid, text, timestamp, record_uuid, timestamp, timestamp),
+        )
+        db.commit()
+    except sqlite3.IntegrityError:
+        db.rollback()
+        return jsonify({'error': 'Comment ID already exists'}), 409
 
     return jsonify(
         {

--- a/server/routes/reports.py
+++ b/server/routes/reports.py
@@ -6,7 +6,6 @@ Copyright (c) 2026 Divergent Health Technologies
 
 import hashlib
 import os
-import shutil
 import tempfile
 import time
 import uuid
@@ -139,6 +138,16 @@ def _build_notes_payload(study_uids, db):
     return {uid: data for uid, data in notes.items() if has_notes(data)}
 
 
+def _remove_file_if_present(path):
+    if not path:
+        return
+    try:
+        if os.path.exists(path):
+            os.remove(path)
+    except OSError:
+        pass
+
+
 @reports_bp.route('/api/notes/', methods=['GET'])
 def get_notes():
     studies_param = request.args.get('studies', '').strip()
@@ -170,7 +179,7 @@ def upload_report(study_uid):
     name = (request.form.get('name') or file.filename or 'report').strip()[:255]
 
     provided_type = request.form.get('type')
-    report_type, ext, mime = resolve_report_type(file.filename, provided_type, file.mimetype)
+    report_type, ext, _mime = resolve_report_type(file.filename, provided_type, file.mimetype)
     if not report_type:
         return jsonify({'error': 'Unsupported report file type'}), 400
 
@@ -180,8 +189,8 @@ def upload_report(study_uid):
 
     report_path = os.path.join(db_module.REPORTS_DIR, f'{report_id}.{ext}')
 
-    # Save upload to a temp file first, then commit DB, then move into place.
-    # This prevents orphan files if the DB operation fails.
+    # Save upload to a temp file first, then atomically install it before
+    # committing metadata. If the DB write fails, restore the previous file.
     _ensure_data_dirs()
     tmp_fd, tmp_path = tempfile.mkstemp(dir=db_module.REPORTS_DIR, suffix=f'.{ext}.tmp')
     try:
@@ -207,55 +216,68 @@ def upload_report(study_uid):
         if existing and existing['added_at'] and not request.form.get('addedAt'):
             added_at = existing['added_at']
 
-        # Upsert clears deleted_at (resurrection) and populates sync columns
-        db.execute(
-            """
-            INSERT INTO reports (id, study_uid, name, type, size, file_path,
-                                 added_at, updated_at, content_hash, device_id,
-                                 sync_version, deleted_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
-            ON CONFLICT(id) DO UPDATE SET
-                study_uid=excluded.study_uid,
-                name=excluded.name,
-                type=excluded.type,
-                size=excluded.size,
-                file_path=excluded.file_path,
-                added_at=excluded.added_at,
-                updated_at=excluded.updated_at,
-                content_hash=excluded.content_hash,
-                device_id=excluded.device_id,
-                sync_version=0,
-                deleted_at=NULL
-            """,
-            (
-                report_id,
-                study_uid,
-                name,
-                report_type,
-                size,
-                report_path,
-                added_at,
-                updated_at,
-                content_hash,
-                device_id,
-            ),
-        )
-        db.commit()
+        previous_path = existing['file_path'] if existing else None
+        backup_path = None
 
-        # DB committed successfully -- move temp file to final path
-        if existing and existing['file_path'] and existing['file_path'] != report_path:
-            try:
-                if os.path.exists(existing['file_path']):
-                    os.remove(existing['file_path'])
-            except OSError:
-                pass
-        shutil.move(tmp_path, report_path)
-    except Exception:
-        # Clean up temp file on any failure
         try:
-            os.remove(tmp_path)
-        except OSError:
-            pass
+            if previous_path and previous_path == report_path and os.path.exists(report_path):
+                backup_path = f'{report_path}.bak-{now}'
+                os.replace(report_path, backup_path)
+            os.replace(tmp_path, report_path)
+        except Exception:
+            _remove_file_if_present(tmp_path)
+            if backup_path and os.path.exists(backup_path):
+                os.replace(backup_path, report_path)
+            raise
+
+        try:
+            # Upsert clears deleted_at (resurrection) and populates sync columns
+            db.execute(
+                """
+                INSERT INTO reports (id, study_uid, name, type, size, file_path,
+                                     added_at, updated_at, content_hash, device_id,
+                                     sync_version, deleted_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
+                ON CONFLICT(id) DO UPDATE SET
+                    study_uid=excluded.study_uid,
+                    name=excluded.name,
+                    type=excluded.type,
+                    size=excluded.size,
+                    file_path=excluded.file_path,
+                    added_at=excluded.added_at,
+                    updated_at=excluded.updated_at,
+                    content_hash=excluded.content_hash,
+                    device_id=excluded.device_id,
+                    sync_version=0,
+                    deleted_at=NULL
+                """,
+                (
+                    report_id,
+                    study_uid,
+                    name,
+                    report_type,
+                    size,
+                    report_path,
+                    added_at,
+                    updated_at,
+                    content_hash,
+                    device_id,
+                ),
+            )
+            db.commit()
+        except Exception:
+            db.rollback()
+            _remove_file_if_present(report_path)
+            if backup_path and os.path.exists(backup_path):
+                os.replace(backup_path, report_path)
+            raise
+
+        if backup_path and os.path.exists(backup_path):
+            _remove_file_if_present(backup_path)
+        if previous_path and previous_path != report_path:
+            _remove_file_if_present(previous_path)
+    except Exception:
+        _remove_file_if_present(tmp_path)
         raise
 
     return jsonify(

--- a/server/security.py
+++ b/server/security.py
@@ -21,6 +21,15 @@ SESSION_TOKEN = secrets.token_urlsafe(32)
 # Routes that carry PHI and require session-token authentication.
 # /api/test-data/* is intentionally excluded (anonymized sample data).
 _PHI_ROUTE_PREFIXES = ('/api/notes', '/api/library/', '/api/maintenance')
+_TEST_MODE_DISABLED_ERROR = 'Test mode is only available when FLASK_ENV=test'
+
+
+def _is_test_environment():
+    return os.environ.get('FLASK_ENV') == 'test'
+
+
+def _is_test_mode_requested():
+    return request.args.get('test') is not None or request.headers.get('X-Test-Mode') == '1'
 
 
 def _is_test_mode_request():
@@ -31,11 +40,15 @@ def _is_test_mode_request():
     on the page load signals test mode. For direct API requests (Playwright's
     request fixture), we check for the X-Test-Mode header instead.
     """
-    if os.environ.get('FLASK_ENV') != 'test':
+    if not _is_test_environment():
         return False
-    if request.args.get('test') is not None:
-        return True
-    return request.headers.get('X-Test-Mode') == '1'
+    return _is_test_mode_requested()
+
+
+def _test_mode_misconfigured_response():
+    if _is_test_environment() or not _is_test_mode_requested():
+        return None
+    return jsonify({'error': _TEST_MODE_DISABLED_ERROR}), 403
 
 
 def csrf_origin_check():
@@ -52,6 +65,10 @@ def csrf_origin_check():
     which use bare API calls without browser context.
     """
     if request.method in ('POST', 'PUT', 'DELETE'):
+        misconfigured = _test_mode_misconfigured_response()
+        if misconfigured is not None:
+            return misconfigured
+
         origin = request.headers.get('Origin')
         if not origin:
             # Fall back to Referer if Origin is absent (some browsers strip it)
@@ -90,6 +107,10 @@ def session_token_check():
     needs_token = any(path.startswith(prefix) for prefix in _PHI_ROUTE_PREFIXES)
     if not needs_token:
         return
+
+    misconfigured = _test_mode_misconfigured_response()
+    if misconfigured is not None:
+        return misconfigured
 
     # Bypass for test mode (Playwright)
     if _is_test_mode_request():

--- a/server/sync/delta.py
+++ b/server/sync/delta.py
@@ -10,14 +10,16 @@ Handles:
 Copyright (c) 2026 Divergent Health Technologies
 """
 
+import json
 import time
 
 # Tables the sync protocol supports in v1
-SYNC_TABLES = {'study_notes', 'comments', 'reports'}
+SYNC_TABLES = {'study_notes', 'series_notes', 'comments', 'reports'}
 
 # Cloud-scoped storage tables used exclusively by /api/sync
 TABLE_STORAGE = {
     'study_notes': 'cloud_study_notes',
+    'series_notes': 'cloud_series_notes',
     'comments': 'cloud_comments',
     'reports': 'cloud_reports',
 }
@@ -25,6 +27,7 @@ TABLE_STORAGE = {
 # Column that serves as the primary key for each synced table
 TABLE_KEY_COLUMN = {
     'study_notes': 'study_uid',
+    'series_notes': 'record_key',
     'comments': 'record_uuid',
     'reports': 'id',
 }
@@ -32,6 +35,7 @@ TABLE_KEY_COLUMN = {
 # Columns to include in sync data payloads for each table.
 TABLE_DATA_COLUMNS = {
     'study_notes': ['study_uid', 'description', 'updated_at', 'deleted_at'],
+    'series_notes': ['study_uid', 'series_uid', 'description', 'updated_at', 'deleted_at'],
     'comments': [
         'record_uuid',
         'study_uid',
@@ -55,6 +59,18 @@ TABLE_DATA_COLUMNS = {
 }
 
 
+def _parse_series_record_key(record_key):
+    try:
+        study_uid, series_uid = json.loads(record_key)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f'Invalid series_notes record key: {record_key}') from exc
+
+    if not isinstance(study_uid, str) or not isinstance(series_uid, str):
+        raise ValueError(f'Invalid series_notes record key: {record_key}')
+
+    return study_uid, series_uid
+
+
 def process_change(db, user_id, device_id, change):
     """Process a single change from a client push."""
     operation_uuid = change['operation_uuid']
@@ -73,6 +89,19 @@ def process_change(db, user_id, device_id, change):
             'current_sync_version': 0,
             'current_data': {},
         }
+
+    if table == 'series_notes':
+        try:
+            _parse_series_record_key(key)
+        except ValueError:
+            return {
+                'status': 'rejected',
+                'operation_uuid': operation_uuid,
+                'key': key,
+                'reason': 'invalid_key',
+                'current_sync_version': 0,
+                'current_data': {},
+            }
 
     existing_op = db.execute(
         'SELECT sync_version FROM sync_processed_ops WHERE operation_uuid = ? AND user_id = ?',
@@ -280,6 +309,46 @@ def _apply_insert(db, table, user_id, key, data, device_id, new_version, now_ms)
         )
         return
 
+    if table == 'series_notes':
+        study_uid, series_uid = _parse_series_record_key(key)
+        db.execute(
+            """
+            INSERT INTO cloud_series_notes (
+                user_id,
+                record_key,
+                study_uid,
+                series_uid,
+                description,
+                updated_at,
+                deleted_at,
+                device_id,
+                sync_version,
+                last_operation
+            )
+            VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, 'insert')
+            ON CONFLICT(user_id, record_key) DO UPDATE SET
+                study_uid = excluded.study_uid,
+                series_uid = excluded.series_uid,
+                description = excluded.description,
+                updated_at = excluded.updated_at,
+                deleted_at = NULL,
+                device_id = excluded.device_id,
+                sync_version = excluded.sync_version,
+                last_operation = excluded.last_operation
+            """,
+            (
+                user_id,
+                key,
+                study_uid,
+                series_uid,
+                data.get('description', ''),
+                data.get('updated_at', now_ms),
+                device_id,
+                new_version,
+            ),
+        )
+        return
+
     if table == 'comments':
         created_at = data.get('created_at', now_ms)
         db.execute(
@@ -402,6 +471,46 @@ def _apply_update(db, table, user_id, key, data, device_id, new_version, now_ms)
             (
                 user_id,
                 key,
+                data.get('description', ''),
+                data.get('updated_at', now_ms),
+                device_id,
+                new_version,
+            ),
+        )
+        return
+
+    if table == 'series_notes':
+        study_uid, series_uid = _parse_series_record_key(key)
+        db.execute(
+            """
+            INSERT INTO cloud_series_notes (
+                user_id,
+                record_key,
+                study_uid,
+                series_uid,
+                description,
+                updated_at,
+                deleted_at,
+                device_id,
+                sync_version,
+                last_operation
+            )
+            VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, 'update')
+            ON CONFLICT(user_id, record_key) DO UPDATE SET
+                study_uid = excluded.study_uid,
+                series_uid = excluded.series_uid,
+                description = excluded.description,
+                updated_at = excluded.updated_at,
+                deleted_at = NULL,
+                device_id = excluded.device_id,
+                sync_version = excluded.sync_version,
+                last_operation = excluded.last_operation
+            """,
+            (
+                user_id,
+                key,
+                study_uid,
+                series_uid,
                 data.get('description', ''),
                 data.get('updated_at', now_ms),
                 device_id,
@@ -544,38 +653,151 @@ def _apply_delete(db, table, user_id, key, device_id, new_version, now_ms):
         )
         return
 
-    if table == 'comments':
+    if table == 'series_notes':
+        study_uid, series_uid = _parse_series_record_key(key)
+        existing = _read_cloud_row(db, 'cloud_series_notes', user_id, 'record_key', key)
         db.execute(
             """
-            UPDATE cloud_comments
-            SET deleted_at = ?,
-                updated_at = ?,
-                device_id = ?,
-                sync_version = ?,
-                last_operation = 'delete'
-            WHERE user_id = ? AND record_uuid = ?
+            INSERT INTO cloud_series_notes (
+                user_id,
+                record_key,
+                study_uid,
+                series_uid,
+                description,
+                updated_at,
+                deleted_at,
+                device_id,
+                sync_version,
+                last_operation
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'delete')
+            ON CONFLICT(user_id, record_key) DO UPDATE SET
+                study_uid = excluded.study_uid,
+                series_uid = excluded.series_uid,
+                description = excluded.description,
+                updated_at = excluded.updated_at,
+                deleted_at = excluded.deleted_at,
+                device_id = excluded.device_id,
+                sync_version = excluded.sync_version,
+                last_operation = excluded.last_operation
             """,
-            (now_ms, now_ms, device_id, new_version, user_id, key),
+            (
+                user_id,
+                key,
+                existing['study_uid'] if existing else study_uid,
+                existing['series_uid'] if existing else series_uid,
+                existing['description'] if existing else '',
+                now_ms,
+                now_ms,
+                device_id,
+                new_version,
+            ),
+        )
+        return
+
+    if table == 'comments':
+        existing = _read_cloud_row(db, 'cloud_comments', user_id, 'record_uuid', key)
+        db.execute(
+            """
+            INSERT INTO cloud_comments (
+                user_id,
+                record_uuid,
+                study_uid,
+                series_uid,
+                text,
+                time,
+                created_at,
+                updated_at,
+                deleted_at,
+                device_id,
+                sync_version,
+                last_operation
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'delete')
+            ON CONFLICT(user_id, record_uuid) DO UPDATE SET
+                study_uid = excluded.study_uid,
+                series_uid = excluded.series_uid,
+                text = excluded.text,
+                time = excluded.time,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
+                deleted_at = excluded.deleted_at,
+                device_id = excluded.device_id,
+                sync_version = excluded.sync_version,
+                last_operation = excluded.last_operation
+            """,
+            (
+                user_id,
+                key,
+                existing['study_uid'] if existing else '',
+                existing['series_uid'] if existing else None,
+                existing['text'] if existing else '',
+                existing['time'] if existing else now_ms,
+                existing['created_at'] if existing else now_ms,
+                now_ms,
+                now_ms,
+                device_id,
+                new_version,
+            ),
         )
         return
 
     if table == 'reports':
+        existing = _read_cloud_row(db, 'cloud_reports', user_id, 'id', key)
         db.execute(
             """
-            UPDATE cloud_reports
-            SET deleted_at = ?,
-                updated_at = ?,
-                device_id = ?,
-                sync_version = ?,
-                last_operation = 'delete'
-            WHERE user_id = ? AND id = ?
+            INSERT INTO cloud_reports (
+                user_id,
+                id,
+                study_uid,
+                name,
+                type,
+                size,
+                content_hash,
+                added_at,
+                updated_at,
+                deleted_at,
+                device_id,
+                sync_version,
+                last_operation
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'delete')
+            ON CONFLICT(user_id, id) DO UPDATE SET
+                study_uid = excluded.study_uid,
+                name = excluded.name,
+                type = excluded.type,
+                size = excluded.size,
+                content_hash = excluded.content_hash,
+                added_at = excluded.added_at,
+                updated_at = excluded.updated_at,
+                deleted_at = excluded.deleted_at,
+                device_id = excluded.device_id,
+                sync_version = excluded.sync_version,
+                last_operation = excluded.last_operation
             """,
-            (now_ms, now_ms, device_id, new_version, user_id, key),
+            (
+                user_id,
+                key,
+                existing['study_uid'] if existing else '',
+                existing['name'] if existing else '',
+                existing['type'] if existing else '',
+                existing['size'] if existing else 0,
+                existing['content_hash'] if existing else None,
+                existing['added_at'] if existing else now_ms,
+                now_ms,
+                now_ms,
+                device_id,
+                new_version,
+            ),
         )
 
 
 def _read_cloud_row(db, table_name, user_id, key_col, key):
     """Read a raw cloud-table row for upsert fallback behavior."""
+    if table_name not in TABLE_STORAGE.values():
+        raise ValueError(f'Unsupported cloud table: {table_name}')
+    if key_col not in {'study_uid', 'record_key', 'record_uuid', 'id'}:
+        raise ValueError(f'Unsupported cloud table key column: {key_col}')
     return db.execute(
         f'SELECT * FROM {table_name} WHERE user_id = ? AND {key_col} = ?',
         (user_id, key),

--- a/server/sync/delta.py
+++ b/server/sync/delta.py
@@ -531,16 +531,16 @@ def _apply_delete(db, table, user_id, key, device_id, new_version, now_ms):
                 sync_version,
                 last_operation
             )
-            VALUES (?, ?, '', ?, NULL, ?, ?, 'delete')
+            VALUES (?, ?, '', ?, ?, ?, ?, 'delete')
             ON CONFLICT(user_id, study_uid) DO UPDATE SET
                 description = '',
                 updated_at = excluded.updated_at,
-                deleted_at = NULL,
+                deleted_at = excluded.deleted_at,
                 device_id = excluded.device_id,
                 sync_version = excluded.sync_version,
                 last_operation = excluded.last_operation
             """,
-            (user_id, key, now_ms, device_id, new_version),
+            (user_id, key, now_ms, now_ms, device_id, new_version),
         )
         return
 

--- a/tests/auth-security.spec.js
+++ b/tests/auth-security.spec.js
@@ -529,6 +529,24 @@ test.describe('Test Suite 43: Auth Endpoint Hardening', () => {
         expect(Number(limited.headers()['retry-after'] || '0')).toBeGreaterThan(0);
     });
 
+    test('login rate limiting ignores spoofed X-Forwarded-For by default', async ({ request }) => {
+        const email = uniqueEmail();
+
+        for (let attempt = 1; attempt <= 5; attempt += 1) {
+            const response = await request.post(`${BASE_URL}/api/auth/login`, {
+                headers: sameOriginHeaders({ 'X-Forwarded-For': `203.0.113.${attempt}` }),
+                data: { email, password: 'wrong-password' },
+            });
+            expect(response.status()).toBe(401);
+        }
+
+        const limited = await request.post(`${BASE_URL}/api/auth/login`, {
+            headers: sameOriginHeaders({ 'X-Forwarded-For': '198.51.100.99' }),
+            data: { email, password: 'wrong-password' },
+        });
+        expect(limited.status()).toBe(429);
+    });
+
     test('signup returns the same accepted response for new and duplicate emails', async ({ request }) => {
         const email = uniqueEmail();
         const payload = {

--- a/tests/comment-record-uuid.spec.js
+++ b/tests/comment-record-uuid.spec.js
@@ -1,0 +1,149 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { test, expect } = require('@playwright/test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function resolvePythonCommand() {
+    const venvPython = path.join(REPO_ROOT, 'venv', 'bin', 'python');
+    if (fs.existsSync(venvPython)) {
+        return venvPython;
+    }
+    return process.env.PYTHON || 'python3';
+}
+
+const INIT_DB_MIGRATION_SCRIPT = `
+import json
+import os
+import sqlite3
+import sys
+
+repo_root = sys.argv[1]
+data_dir = sys.argv[2]
+
+os.environ["DICOM_VIEWER_DATA_DIR"] = data_dir
+sys.path.insert(0, repo_root)
+
+from server import db as db_module
+
+db_module.configure(repo_root)
+
+conn = sqlite3.connect(db_module.DB_PATH)
+conn.execute(
+    """
+    CREATE TABLE comments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        study_uid TEXT NOT NULL,
+        series_uid TEXT,
+        text TEXT NOT NULL,
+        time INTEGER NOT NULL,
+        record_uuid TEXT
+    )
+    """
+)
+conn.executemany(
+    "INSERT INTO comments (study_uid, series_uid, text, time, record_uuid) VALUES (?, ?, ?, ?, ?)",
+    [
+        ("study-a", None, "first", 101, "11111111-2222-4333-8444-555555555555"),
+        ("study-b", None, "second", 202, "11111111-2222-4333-8444-555555555555"),
+        ("study-c", None, "third", 303, None),
+    ],
+)
+conn.commit()
+conn.close()
+
+db_module.init_db()
+
+conn = sqlite3.connect(db_module.DB_PATH)
+conn.row_factory = sqlite3.Row
+rows = [
+    {
+        "id": row["id"],
+        "time": row["time"],
+        "record_uuid": row["record_uuid"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+    for row in conn.execute(
+        "SELECT id, time, record_uuid, created_at, updated_at FROM comments ORDER BY id ASC"
+    ).fetchall()
+]
+indexes = [
+    {
+        "name": row["name"],
+        "unique": row["unique"],
+        "partial": row["partial"],
+    }
+    for row in conn.execute("PRAGMA index_list('comments')").fetchall()
+]
+
+duplicate_insert_blocked = False
+try:
+    conn.execute(
+        """
+        INSERT INTO comments (
+            study_uid,
+            series_uid,
+            text,
+            time,
+            record_uuid,
+            created_at,
+            updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("study-d", None, "should fail", 404, rows[0]["record_uuid"], 404, 404),
+    )
+    conn.commit()
+except sqlite3.IntegrityError:
+    duplicate_insert_blocked = True
+
+print(
+    json.dumps(
+        {
+            "rows": rows,
+            "indexes": indexes,
+            "duplicate_insert_blocked": duplicate_insert_blocked,
+        }
+    )
+)
+`;
+
+test.describe('Comment record_uuid migration', () => {
+    test('init_db dedupes existing UUID collisions before creating the unique index', async () => {
+        const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dicom-viewer-comment-uuid-'));
+
+        try {
+            const output = execFileSync(resolvePythonCommand(), ['-c', INIT_DB_MIGRATION_SCRIPT, REPO_ROOT, dataDir], {
+                cwd: REPO_ROOT,
+                stdio: 'pipe',
+            });
+            const result = JSON.parse(output.toString('utf8'));
+            const uuids = result.rows.map((row) => row.record_uuid);
+
+            expect(result.indexes).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'idx_comments_record_uuid',
+                        unique: 1,
+                    }),
+                ]),
+            );
+            expect(result.rows).toHaveLength(3);
+            expect(uuids.every(Boolean)).toBe(true);
+            expect(new Set(uuids).size).toBe(uuids.length);
+            expect(result.rows[2]).toMatchObject({
+                time: 303,
+                created_at: 303,
+                updated_at: 303,
+            });
+            expect(result.duplicate_insert_blocked).toBe(true);
+        } finally {
+            fs.rmSync(dataDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/comments.spec.js
+++ b/tests/comments.spec.js
@@ -41,6 +41,24 @@ test.describe('Test Suite 28: POST /api/notes/<study_uid>/comments - Add Comment
         expect(body.seriesUid).toBeNull();
     });
 
+    test('rejects duplicate client-supplied record_uuid values', async ({ request }) => {
+        const studyUid = uniqueStudyUid();
+        const recordUuid = `11111111-2222-4333-8444-${Date.now().toString().padStart(12, '0')}`;
+
+        const first = await request.post(`${BASE_URL}/api/notes/${studyUid}/comments`, {
+            data: { text: 'first comment', record_uuid: recordUuid },
+        });
+        expect(first.status()).toBe(200);
+
+        const second = await request.post(`${BASE_URL}/api/notes/${studyUid}/comments`, {
+            data: { text: 'duplicate comment', record_uuid: recordUuid },
+        });
+        expect(second.status()).toBe(409);
+
+        const body = await second.json();
+        expect(body.error).toContain('exists');
+    });
+
     test('returns 400 when comment text is missing', async ({ request }) => {
         const studyUid = uniqueStudyUid();
         const response = await request.post(`${BASE_URL}/api/notes/${studyUid}/comments`, {

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -149,6 +149,53 @@ async function installMockTauri(page, options = {}) {
 }
 
 test.describe('Desktop report persistence', () => {
+    test('desktop comment writes use canonical UUID ids for update and delete', async ({ page }) => {
+        const studyUid = '1.2.840.desktop.comment-uuid.study';
+        const seriesUid = '1.2.840.desktop.comment-uuid.series';
+
+        await installMockTauri(page);
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(
+            async ({ studyUid, seriesUid }) => {
+                await window.NotesAPI.initializeDesktopStorage();
+
+                const saved = await window.NotesAPI.addComment(studyUid, {
+                    text: 'Desktop UUID comment',
+                    time: 123,
+                    seriesUid,
+                });
+                const updated = await window.NotesAPI.updateComment(studyUid, saved.record_uuid, {
+                    text: 'Desktop UUID comment edited',
+                    time: 456,
+                });
+                const sqlStoreBeforeDelete = JSON.parse(localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}');
+                const deleted = await window.NotesAPI.deleteComment(studyUid, saved.record_uuid);
+                const notes = await window.NotesAPI.loadNotes([studyUid]);
+                const sqlStoreAfterDelete = JSON.parse(localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}');
+
+                return {
+                    saved,
+                    updated,
+                    sqlStoreBeforeDelete,
+                    deleted,
+                    notes,
+                    sqlStoreAfterDelete,
+                };
+            },
+            { studyUid, seriesUid },
+        );
+
+        expect(result.saved.record_uuid).toBeTruthy();
+        expect(result.saved.id).toBe(result.saved.record_uuid);
+        expect(result.updated.record_uuid).toBe(result.saved.record_uuid);
+        expect(result.sqlStoreBeforeDelete.comments[0].record_uuid).toBe(result.saved.record_uuid);
+        expect(result.deleted).toBe(true);
+        expect(result.notes.studies).not.toHaveProperty(studyUid);
+        expect(result.sqlStoreAfterDelete.comments).toEqual([]);
+    });
+
     test('desktop NotesAPI.migrate imports legacy notes into sqlite without falling back', async ({ page }) => {
         const studyUid = '1.2.840.desktop.manual-migrate.study';
         const seriesUid = '1.2.840.desktop.manual-migrate.series';

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -195,7 +195,12 @@ test.describe('Desktop report persistence', () => {
         expect(result.sqlStoreBeforeDelete.comments[0].record_uuid).toBe(result.saved.record_uuid);
         expect(result.deleted).toBe(true);
         expect(result.notes.studies).not.toHaveProperty(studyUid);
-        expect(result.sqlStoreAfterDelete.comments).toEqual([]);
+        expect(result.sqlStoreAfterDelete.comments).toHaveLength(1);
+        expect(result.sqlStoreAfterDelete.comments[0]).toMatchObject({
+            record_uuid: result.saved.record_uuid,
+        });
+        expect(typeof result.sqlStoreAfterDelete.comments[0].deleted_at).toBe('number');
+        expect(result.sqlStoreAfterDelete.comments[0].deleted_at).toBeGreaterThan(0);
     });
 
     test('desktop NotesAPI.migrate imports legacy notes into sqlite without falling back', async ({ page }) => {

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -170,7 +170,9 @@ test.describe('Desktop report persistence', () => {
                     text: 'Desktop UUID comment edited',
                     time: 456,
                 });
-                const sqlStoreBeforeDelete = JSON.parse(localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}');
+                const sqlStoreBeforeDelete = JSON.parse(
+                    localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}',
+                );
                 const deleted = await window.NotesAPI.deleteComment(studyUid, saved.record_uuid);
                 const notes = await window.NotesAPI.loadNotes([studyUid]);
                 const sqlStoreAfterDelete = JSON.parse(localStorage.getItem('mock-tauri-sql:sqlite:viewer.db') || '{}');

--- a/tests/e2e-sync.spec.js
+++ b/tests/e2e-sync.spec.js
@@ -233,6 +233,42 @@ test.describe('E2E Authentication Flow', () => {
         expect(syncResult).toHaveProperty('delta_cursor');
     });
 
+    test('refresh endpoint rejects access tokens', async ({ request }) => {
+        const { email, password } = await createTestUser(request);
+        const loginResult = await loginUser(request, BASE_URL, email, password);
+
+        const refreshResponse = await request.post(`${BASE_URL}/api/auth/refresh`, {
+            data: { refresh_token: loginResult.access_token },
+        });
+        expect(refreshResponse.status()).toBe(401);
+
+        const body = await refreshResponse.json();
+        expect(body).toEqual({ error: 'Invalid refresh token' });
+    });
+
+    test('device list shows only the authenticated user devices', async ({ request }) => {
+        const userA = await setupDevice(request);
+        const userADevice2 = await setupSecondDevice(request, userA.email, userA.password);
+        const userB = await setupDevice(request);
+
+        const listAResponse = await request.get(`${BASE_URL}/api/auth/devices`, {
+            headers: { Authorization: `Bearer ${userA.access_token}` },
+        });
+        expect(listAResponse.status()).toBe(200);
+        const listABody = await listAResponse.json();
+        const userADeviceIds = listABody.devices.map((device) => device.id).sort();
+
+        expect(userADeviceIds).toEqual([userA.device_id, userADevice2.device_id].sort());
+        expect(userADeviceIds).not.toContain(userB.device_id);
+
+        const listBResponse = await request.get(`${BASE_URL}/api/auth/devices`, {
+            headers: { Authorization: `Bearer ${userB.access_token}` },
+        });
+        expect(listBResponse.status()).toBe(200);
+        const listBBody = await listBResponse.json();
+        expect(listBBody.devices.map((device) => device.id)).toEqual([userB.device_id]);
+    });
+
     test('invalid credentials return 401', async ({ request }) => {
         const { email } = await createTestUser(request);
 

--- a/tests/hardening-pass.spec.js
+++ b/tests/hardening-pass.spec.js
@@ -1,0 +1,161 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { test, expect } = require('@playwright/test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const HOME_URL = 'http://127.0.0.1:5001/?nolib';
+
+function resolvePythonCommand() {
+    const venvPython = path.join(REPO_ROOT, 'venv', 'bin', 'python');
+    if (fs.existsSync(venvPython)) {
+        return venvPython;
+    }
+    return process.env.PYTHON || 'python3';
+}
+
+function runPythonJson(script) {
+    const output = execFileSync(resolvePythonCommand(), ['-c', script, REPO_ROOT], {
+        cwd: REPO_ROOT,
+        stdio: 'pipe',
+    });
+    return JSON.parse(output.toString('utf8'));
+}
+
+test.describe('Hardening pass', () => {
+    test('db migration helper validates identifiers and column definitions', async () => {
+        const result = runPythonJson(`
+import json
+import sqlite3
+import sys
+
+sys.path.insert(0, sys.argv[1])
+
+from server import db as db_module
+
+conn = sqlite3.connect(':memory:')
+conn.execute("CREATE TABLE safe_table (id INTEGER PRIMARY KEY)")
+db_module._add_column(conn, 'safe_table', 'safe_column', 'TEXT')
+
+errors = {}
+for args in [
+    ('safe_table; DROP TABLE safe_table; --', 'oops', 'TEXT'),
+    ('safe_table', 'bad-column', 'TEXT'),
+    ('safe_table', 'still_bad', "TEXT); DROP TABLE safe_table; --"),
+]:
+    try:
+        db_module._add_column(conn, *args)
+    except Exception as exc:
+        errors['|'.join(args)] = type(exc).__name__
+
+columns = [row[1] for row in conn.execute("PRAGMA table_info('safe_table')").fetchall()]
+print(json.dumps({'columns': columns, 'errors': errors}))
+        `);
+
+        expect(result.columns).toEqual(expect.arrayContaining(['id', 'safe_column']));
+        expect(result.errors).toEqual({
+            'safe_table; DROP TABLE safe_table; --|oops|TEXT': 'ValueError',
+            'safe_table|bad-column|TEXT': 'ValueError',
+            'safe_table|still_bad|TEXT); DROP TABLE safe_table; --': 'ValueError',
+        });
+    });
+
+    test('auth throttling sweeps expired buckets and does not create empty lookup buckets', async () => {
+        const result = runPythonJson(`
+import json
+import sys
+from flask import Flask
+
+sys.path.insert(0, sys.argv[1])
+
+import server.routes.auth as auth_module
+
+auth_module._AUTH_FAILURES.clear()
+auth_module._AUTH_LAST_SWEEP_AT = 0
+now_s = int(auth_module.time.time())
+auth_module._AUTH_FAILURES['login:expired:*'].extend([now_s - auth_module._AUTH_WINDOW_SECONDS - 1])
+auth_module._AUTH_FAILURES['login:fresh:*'].extend([now_s])
+
+auth_module._maybe_sweep_auth_failures(now_s)
+keys_after_sweep = sorted(auth_module._AUTH_FAILURES.keys())
+
+app = Flask(__name__)
+with app.test_request_context('/api/auth/login'):
+    missing_retry_after = auth_module._rate_limit_retry_after('login', 'missing@example.com')
+
+print(json.dumps({
+    'keys_after_sweep': keys_after_sweep,
+    'missing_retry_after': missing_retry_after,
+    'keys_after_lookup': sorted(auth_module._AUTH_FAILURES.keys()),
+}))
+        `);
+
+        expect(result.keys_after_sweep).toEqual(['login:fresh:*']);
+        expect(result.missing_retry_after).toBeNull();
+        expect(result.keys_after_lookup).toEqual(['login:fresh:*']);
+    });
+
+    test('test-mode requests outside FLASK_ENV=test fail with an explicit error', async () => {
+        const result = runPythonJson(`
+import json
+import os
+import sys
+from flask import Flask
+
+sys.path.insert(0, sys.argv[1])
+os.environ['FLASK_ENV'] = 'development'
+
+import server.security as security_module
+
+app = Flask(__name__)
+responses = {}
+
+with app.app_context():
+    with app.test_request_context('/api/notes/?studies=abc&test=1', method='GET'):
+        response, status = security_module.session_token_check()
+        responses['query_param'] = {'status': status, 'body': response.get_json()}
+
+    with app.test_request_context('/api/notes/study/comments', method='POST', headers={'X-Test-Mode': '1'}):
+        response, status = security_module.session_token_check()
+        responses['header'] = {'status': status, 'body': response.get_json()}
+
+print(json.dumps(responses))
+        `);
+
+        expect(result.query_param).toEqual({
+            status: 403,
+            body: { error: 'Test mode is only available when FLASK_ENV=test' },
+        });
+        expect(result.header).toEqual({
+            status: 403,
+            body: { error: 'Test mode is only available when FLASK_ENV=test' },
+        });
+    });
+
+    test('deployment mode only treats divergent.health suffixes as cloud', async ({ page }) => {
+        await page.goto(HOME_URL);
+
+        const modes = await page.evaluate(() => ({
+            cloudApex: window.CONFIG.detectDeploymentMode({
+                location: { protocol: 'https:', hostname: 'divergent.health' },
+            }),
+            cloudSubdomain: window.CONFIG.detectDeploymentMode({
+                location: { protocol: 'https:', hostname: 'app.divergent.health' },
+            }),
+            attackerSuffix: window.CONFIG.detectDeploymentMode({
+                location: { protocol: 'https:', hostname: 'divergent.health.evil.test' },
+            }),
+            attackerPrefix: window.CONFIG.detectDeploymentMode({
+                location: { protocol: 'https:', hostname: 'evildivergent.health' },
+            }),
+        }));
+
+        expect(modes.cloudApex).toBe('cloud');
+        expect(modes.cloudSubdomain).toBe('cloud');
+        expect(modes.attackerSuffix).toBe('personal');
+        expect(modes.attackerPrefix).toBe('personal');
+    });
+});

--- a/tests/maintenance-cleanup.spec.js
+++ b/tests/maintenance-cleanup.spec.js
@@ -1,0 +1,228 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { test, expect } = require('@playwright/test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function resolvePythonCommand() {
+    const venvPython = path.join(REPO_ROOT, 'venv', 'bin', 'python');
+    if (fs.existsSync(venvPython)) {
+        return venvPython;
+    }
+    return process.env.PYTHON || 'python3';
+}
+
+function runPythonJson(script, dataDir) {
+    const output = execFileSync(resolvePythonCommand(), ['-c', script, REPO_ROOT, dataDir], {
+        cwd: REPO_ROOT,
+        stdio: 'pipe',
+    });
+    return JSON.parse(output.toString('utf8'));
+}
+
+test.describe('Maintenance cleanup', () => {
+    test('purge_tombstones(syncing=True) retains unsynced tombstones and purges synced ones', async () => {
+        const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dicom-viewer-maintenance-purge-'));
+
+        try {
+            const result = runPythonJson(
+                `
+import json
+import os
+import sqlite3
+import sys
+import time
+
+repo_root = sys.argv[1]
+data_dir = sys.argv[2]
+
+os.environ["DICOM_VIEWER_DATA_DIR"] = data_dir
+sys.path.insert(0, repo_root)
+
+from server import db as db_module
+from server import maintenance
+
+db_module.configure(repo_root)
+db_module.init_db()
+
+now_ms = int(time.time() * 1000)
+old_ms = now_ms - (40 * 86400 * 1000)
+
+conn = sqlite3.connect(db_module.DB_PATH)
+conn.executemany(
+    """
+    INSERT INTO comments (
+        study_uid,
+        series_uid,
+        text,
+        time,
+        record_uuid,
+        created_at,
+        updated_at,
+        deleted_at,
+        sync_version
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """,
+    [
+        ("study-a", None, "unsynced tombstone", old_ms - 3, "comment-unsynced", old_ms - 3, old_ms - 2, old_ms, 0),
+        ("study-a", None, "synced tombstone", old_ms - 2, "comment-synced", old_ms - 2, old_ms - 1, old_ms, 5),
+        ("study-a", None, "live comment", now_ms, "comment-live", now_ms, now_ms, None, 9),
+    ],
+)
+conn.executemany(
+    """
+    INSERT INTO reports (
+        id,
+        study_uid,
+        name,
+        type,
+        size,
+        file_path,
+        added_at,
+        updated_at,
+        deleted_at,
+        sync_version
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """,
+    [
+        ("report-unsynced", "study-a", "Unsynced", "pdf", 10, None, old_ms - 3, old_ms - 2, old_ms, 0),
+        ("report-synced", "study-a", "Synced", "pdf", 20, None, old_ms - 2, old_ms - 1, old_ms, 7),
+        ("report-live", "study-a", "Live", "pdf", 30, None, now_ms, now_ms, None, 11),
+    ],
+)
+conn.commit()
+conn.close()
+
+counts = maintenance.purge_tombstones(days=30, syncing=True)
+
+conn = sqlite3.connect(db_module.DB_PATH)
+comment_rows = conn.execute(
+    "SELECT record_uuid, sync_version, deleted_at FROM comments ORDER BY record_uuid"
+).fetchall()
+report_rows = conn.execute(
+    "SELECT id, sync_version, deleted_at FROM reports ORDER BY id"
+).fetchall()
+conn.close()
+
+print(
+    json.dumps(
+        {
+            "counts": counts,
+            "comments": [list(row) for row in comment_rows],
+            "reports": [list(row) for row in report_rows],
+        }
+    )
+)
+                `,
+                dataDir,
+            );
+
+            expect(result.counts).toEqual({ comments: 1, reports: 1 });
+            expect(result.comments).toEqual([
+                ['comment-live', 9, null],
+                ['comment-unsynced', 0, expect.any(Number)],
+            ]);
+            expect(result.reports).toEqual([
+                ['report-live', 11, null],
+                ['report-unsynced', 0, expect.any(Number)],
+            ]);
+        } finally {
+            fs.rmSync(dataDir, { recursive: true, force: true });
+        }
+    });
+
+    test('gc_report_blobs preserves live and recent tombstones while deleting orphaned files', async () => {
+        const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dicom-viewer-maintenance-gc-'));
+
+        try {
+            const result = runPythonJson(
+                `
+import json
+import os
+import sqlite3
+import sys
+import time
+
+repo_root = sys.argv[1]
+data_dir = sys.argv[2]
+
+os.environ["DICOM_VIEWER_DATA_DIR"] = data_dir
+sys.path.insert(0, repo_root)
+
+from server import db as db_module
+from server import maintenance
+
+db_module.configure(repo_root)
+db_module.init_db()
+
+now_ms = int(time.time() * 1000)
+recent_ms = now_ms - (5 * 86400 * 1000)
+old_ms = now_ms - (45 * 86400 * 1000)
+
+files = {
+    "live.pdf": b"live-data",
+    "recent.pdf": b"recent-data",
+    "old.pdf": b"old-data",
+    "orphan.pdf": b"orphan-data",
+    "upload.tmp": b"temp-data",
+}
+
+for name, contents in files.items():
+    with open(os.path.join(db_module.REPORTS_DIR, name), "wb") as handle:
+        handle.write(contents)
+
+conn = sqlite3.connect(db_module.DB_PATH)
+conn.executemany(
+    """
+    INSERT INTO reports (
+        id,
+        study_uid,
+        name,
+        type,
+        size,
+        file_path,
+        added_at,
+        updated_at,
+        deleted_at,
+        sync_version
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """,
+    [
+        ("report-live", "study-a", "Live", "pdf", len(files["live.pdf"]), os.path.join(db_module.REPORTS_DIR, "live.pdf"), now_ms, now_ms, None, 1),
+        ("report-recent", "study-a", "Recent", "pdf", len(files["recent.pdf"]), os.path.join(db_module.REPORTS_DIR, "recent.pdf"), recent_ms, recent_ms, recent_ms, 2),
+        ("report-old", "study-a", "Old", "pdf", len(files["old.pdf"]), os.path.join(db_module.REPORTS_DIR, "old.pdf"), old_ms, old_ms, old_ms, 3),
+    ],
+)
+conn.commit()
+conn.close()
+
+gc_result = maintenance.gc_report_blobs(purge_days=30)
+remaining_files = sorted(os.listdir(db_module.REPORTS_DIR))
+
+print(
+    json.dumps(
+        {
+            "gc_result": gc_result,
+            "remaining_files": remaining_files,
+        }
+    )
+)
+                `,
+                dataDir,
+            );
+
+            expect(result.gc_result).toEqual({
+                deleted_count: 2,
+                bytes_reclaimed: 'old-data'.length + 'orphan-data'.length,
+            });
+            expect(result.remaining_files).toEqual(['live.pdf', 'recent.pdf', 'upload.tmp']);
+        } finally {
+            fs.rmSync(dataDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/mock-tauri-sql-init.js
+++ b/tests/mock-tauri-sql-init.js
@@ -216,15 +216,18 @@
                     }
                     state.meta.lastCommentId += 1;
                     const id = state.meta.lastCommentId;
+                    const recordUuid = values[4] || `mock-comment-${id}`;
+                    const createdAt = values[5] ?? time;
+                    const updatedAt = values[6] ?? time;
                     state.comments.push({
                         id,
                         study_uid: studyUid,
                         series_uid: seriesUid,
                         text,
                         time,
-                        record_uuid: null,
-                        created_at: time,
-                        updated_at: time,
+                        record_uuid: recordUuid,
+                        created_at: createdAt,
+                        updated_at: updatedAt,
                         deleted_at: null,
                         device_id: null,
                         sync_version: 0,
@@ -234,24 +237,51 @@
                 }
 
                 if (normalized.startsWith('update comments set')) {
-                    const [text, time, id, studyUid] = values;
-                    const existing = state.comments.find((row) => row.id === Number(id) && row.study_uid === studyUid);
+                    let text;
+                    let time;
+                    let updatedAt;
+                    let existing;
+
+                    if (normalized.includes('where record_uuid = ? and study_uid = ?')) {
+                        const recordUuid = values[3];
+                        const studyUid = values[4];
+                        [text, time, updatedAt] = values;
+                        existing = state.comments.find(
+                            (row) => row.record_uuid === recordUuid && row.study_uid === studyUid,
+                        );
+                    } else {
+                        const legacyId = values.length >= 5 ? values[3] : values[2];
+                        const studyUid = values.length >= 5 ? values[4] : values[3];
+                        text = values[0];
+                        time = values[1];
+                        updatedAt = values.length >= 5 ? values[2] : time;
+                        existing = state.comments.find(
+                            (row) => row.id === Number(legacyId) && row.study_uid === studyUid,
+                        );
+                    }
                     if (!existing) {
                         return { rowsAffected: 0, lastInsertId: null };
                     }
                     existing.text = text;
                     existing.time = time;
-                    existing.updated_at = time;
+                    existing.updated_at = updatedAt;
                     persistState(db, state);
                     return { rowsAffected: 1, lastInsertId: null };
                 }
 
                 if (normalized.startsWith('delete from comments')) {
-                    const [id, studyUid] = values;
                     const before = state.comments.length;
-                    state.comments = state.comments.filter(
-                        (row) => !(row.id === Number(id) && row.study_uid === studyUid),
-                    );
+                    if (normalized.includes('where record_uuid = ? and study_uid = ?')) {
+                        const [recordUuid, studyUid] = values;
+                        state.comments = state.comments.filter(
+                            (row) => !(row.record_uuid === recordUuid && row.study_uid === studyUid),
+                        );
+                    } else {
+                        const [id, studyUid] = values;
+                        state.comments = state.comments.filter(
+                            (row) => !(row.id === Number(id) && row.study_uid === studyUid),
+                        );
+                    }
                     persistState(db, state);
                     return { rowsAffected: before - state.comments.length, lastInsertId: null };
                 }

--- a/tests/mock-tauri-sql-init.js
+++ b/tests/mock-tauri-sql-init.js
@@ -182,6 +182,7 @@
                         series_uid: seriesUid,
                         description,
                         updated_at: updatedAt,
+                        deleted_at: null,
                     });
                     persistState(db, state);
                     return { rowsAffected: 1, lastInsertId: null };
@@ -237,10 +238,42 @@
                 }
 
                 if (normalized.startsWith('update comments set')) {
+                    let existing;
+                    if (normalized.includes('set deleted_at = ?, updated_at = ?')) {
+                        let deletedAt;
+                        let updatedAt;
+
+                        if (normalized.includes('where record_uuid = ? and study_uid = ?')) {
+                            const recordUuid = values[2];
+                            const studyUid = values[3];
+                            [deletedAt, updatedAt] = values;
+                            existing = state.comments.find(
+                                (row) => row.record_uuid === recordUuid && row.study_uid === studyUid,
+                            );
+                        } else {
+                            const legacyId = values[3];
+                            const studyUid = values[4];
+                            const recordUuid = values[2];
+                            [deletedAt, updatedAt] = values;
+                            existing = state.comments.find(
+                                (row) => row.id === Number(legacyId) && row.study_uid === studyUid,
+                            );
+                            if (existing && !existing.record_uuid) {
+                                existing.record_uuid = recordUuid;
+                            }
+                        }
+                        if (!existing) {
+                            return { rowsAffected: 0, lastInsertId: null };
+                        }
+                        existing.deleted_at = deletedAt;
+                        existing.updated_at = updatedAt;
+                        persistState(db, state);
+                        return { rowsAffected: 1, lastInsertId: null };
+                    }
+
                     let text;
                     let time;
                     let updatedAt;
-                    let existing;
 
                     if (normalized.includes('where record_uuid = ? and study_uid = ?')) {
                         const recordUuid = values[3];
@@ -593,6 +626,28 @@
                             series_uid: row.series_uid,
                             description: row.description,
                         }));
+                }
+
+                if (
+                    normalized.startsWith(
+                        'select study_uid, series_uid, description, updated_at, deleted_at from series_notes where study_uid = ? and series_uid = ? limit 1',
+                    )
+                ) {
+                    const [studyUid, seriesUid] = values;
+                    const row = state.series_notes.find(
+                        (entry) => entry.study_uid === studyUid && entry.series_uid === seriesUid,
+                    );
+                    return row
+                        ? [
+                              {
+                                  study_uid: row.study_uid,
+                                  series_uid: row.series_uid,
+                                  description: row.description,
+                                  updated_at: row.updated_at,
+                                  deleted_at: row.deleted_at || null,
+                              },
+                          ]
+                        : [];
                 }
 
                 if (

--- a/tests/notes-ui-migration.spec.js
+++ b/tests/notes-ui-migration.spec.js
@@ -1,0 +1,142 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+
+const { test, expect } = require('@playwright/test');
+
+const HOME_URL = 'http://127.0.0.1:5001/?nolib';
+
+async function setupNotesUiPage(page) {
+    await page.goto(HOME_URL);
+    await page.waitForFunction(() => typeof window.DicomViewerApp?.notesUi?.migrateIfNeeded === 'function', null, {
+        timeout: 10000,
+    });
+}
+
+test.describe('Notes UI migration', () => {
+    test('failed legacy report uploads leave migration retryable and retry on the next pass', async ({ page }) => {
+        await setupNotesUiPage(page);
+
+        const result = await page.evaluate(async () => {
+            const studyUid = 'notes-ui-migration-study';
+            const reportId = 'legacy-report-retryable';
+            const legacyPayload = {
+                version: 2,
+                comments: {
+                    [studyUid]: {
+                        reports: [{ id: reportId, name: 'legacy-report.pdf', type: 'pdf', size: 16 }],
+                    },
+                },
+            };
+
+            localStorage.removeItem('dicom-viewer-migrated');
+            localStorage.setItem('dicom-viewer-comments', JSON.stringify(legacyPayload));
+
+            await new Promise((resolve, reject) => {
+                const deleteRequest = indexedDB.deleteDatabase('dicom-viewer-reports');
+                deleteRequest.onerror = () => reject(deleteRequest.error);
+                deleteRequest.onblocked = () => reject(new Error('legacy reports database delete blocked'));
+                deleteRequest.onsuccess = () => resolve();
+            });
+
+            const openRequest = indexedDB.open('dicom-viewer-reports', 1);
+            await new Promise((resolve, reject) => {
+                openRequest.onupgradeneeded = () => {
+                    openRequest.result.createObjectStore('reports', { keyPath: 'id' });
+                };
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => resolve();
+            });
+
+            const db = openRequest.result;
+            await new Promise((resolve, reject) => {
+                const tx = db.transaction('reports', 'readwrite');
+                tx.objectStore('reports').put({
+                    id: reportId,
+                    blob: new Blob([new TextEncoder().encode('%PDF-1.4\nretryable')], {
+                        type: 'application/pdf',
+                    }),
+                });
+                tx.oncomplete = () => resolve();
+                tx.onerror = () => reject(tx.error);
+                tx.onabort = () => reject(tx.error);
+            });
+            db.close();
+
+            const notesApi = window.NotesAPI;
+            const originalIsEnabled = notesApi.isEnabled;
+            const originalMigrate = notesApi.migrate;
+            const originalUploadReport = notesApi.uploadReport;
+            const originalNotesServer = window.CONFIG?.features?.notesServer;
+            const uploadAttempts = [];
+            let migrateCalls = 0;
+
+            if (!window.CONFIG) {
+                window.CONFIG = { features: { notesServer: true } };
+            } else if (!window.CONFIG.features) {
+                window.CONFIG.features = { notesServer: true };
+            } else {
+                window.CONFIG.features.notesServer = true;
+            }
+
+            notesApi.isEnabled = () => true;
+            notesApi.migrate = async () => {
+                migrateCalls += 1;
+                return true;
+            };
+            notesApi.uploadReport = async (incomingStudyUid, file, report) => {
+                uploadAttempts.push({
+                    studyUid: incomingStudyUid,
+                    fileName: file.name,
+                    reportId: report.id,
+                });
+                if (uploadAttempts.length === 1) {
+                    return null;
+                }
+                return {
+                    id: report.id,
+                    name: report.name,
+                    type: report.type,
+                    size: report.size,
+                };
+            };
+
+            try {
+                await window.DicomViewerApp.notesUi.migrateIfNeeded();
+                const flagAfterFirstRun = localStorage.getItem('dicom-viewer-migrated');
+
+                await window.DicomViewerApp.notesUi.migrateIfNeeded();
+                const flagAfterSecondRun = localStorage.getItem('dicom-viewer-migrated');
+
+                return {
+                    flagAfterFirstRun,
+                    flagAfterSecondRun,
+                    migrateCalls,
+                    uploadAttempts,
+                };
+            } finally {
+                notesApi.isEnabled = originalIsEnabled;
+                notesApi.migrate = originalMigrate;
+                notesApi.uploadReport = originalUploadReport;
+                if (window.CONFIG?.features) {
+                    window.CONFIG.features.notesServer = originalNotesServer;
+                }
+            }
+        });
+
+        expect(result.flagAfterFirstRun).toBeNull();
+        expect(result.flagAfterSecondRun).toBe('1');
+        expect(result.migrateCalls).toBe(2);
+        expect(result.uploadAttempts).toEqual([
+            {
+                studyUid: 'notes-ui-migration-study',
+                fileName: 'legacy-report.pdf',
+                reportId: 'legacy-report-retryable',
+            },
+            {
+                studyUid: 'notes-ui-migration-study',
+                fileName: 'legacy-report.pdf',
+                reportId: 'legacy-report-retryable',
+            },
+        ]);
+    });
+});

--- a/tests/sync-engine.spec.js
+++ b/tests/sync-engine.spec.js
@@ -26,6 +26,16 @@ async function setupSyncEnginePage(page) {
             return store.studies[studyUid];
         }
 
+        function ensureSeries(studyEntry, seriesUid) {
+            if (!studyEntry.series[seriesUid]) {
+                studyEntry.series[seriesUid] = {
+                    description: '',
+                    comments: [],
+                };
+            }
+            return studyEntry.series[seriesUid];
+        }
+
         window._NotesInternals = {
             loadStore() {
                 return structuredClone(window.__SYNC_TEST_STORE);
@@ -34,6 +44,7 @@ async function setupSyncEnginePage(page) {
                 window.__SYNC_TEST_STORE = structuredClone(store);
             },
             ensureStudy,
+            ensureSeries,
             normalizeReportId(id) {
                 return String(id || '').trim();
             },
@@ -398,5 +409,82 @@ test.describe('Sync Engine', () => {
         expect(comment.time).toBe(111);
         expect(comment.updated_at).toBe(222);
         expect(comment.sync_version).toBe(5);
+    });
+
+    test('remote series comments are inserted and moved into the correct series bucket', async ({ page }) => {
+        await setupSyncEnginePage(page);
+
+        const study = await page.evaluate(() => {
+            window.__SYNC_TEST_STORE = {
+                studies: {
+                    'study-series-remote': {
+                        description: '',
+                        comments: [
+                            {
+                                id: 'comment-move',
+                                record_uuid: 'comment-move',
+                                text: 'Study level',
+                                time: 1,
+                                created_at: 1,
+                                updated_at: 1,
+                                sync_version: 1,
+                            },
+                        ],
+                        reports: [],
+                        series: {
+                            'series-a': { description: '', comments: [] },
+                            'series-b': { description: '', comments: [] },
+                        },
+                    },
+                },
+            };
+
+            const engine = new window._SyncEngine.SyncEngine({
+                getAccessToken: async () => 'valid-access-token',
+                onAuthRequired: () => {},
+            });
+
+            engine._applyRemoteData(
+                'comments',
+                'comment-series-new',
+                {
+                    study_uid: 'study-series-remote',
+                    series_uid: 'series-a',
+                    text: 'Inserted into series A',
+                    created_at: 10,
+                    updated_at: 10,
+                },
+                5,
+            );
+
+            engine._applyRemoteData(
+                'comments',
+                'comment-move',
+                {
+                    study_uid: 'study-series-remote',
+                    series_uid: 'series-b',
+                    text: 'Moved into series B',
+                    created_at: 1,
+                    updated_at: 20,
+                },
+                6,
+            );
+
+            return window.__SYNC_TEST_STORE.studies['study-series-remote'];
+        });
+
+        expect(study.comments).toEqual([]);
+        expect(study.series['series-a'].comments[0]).toMatchObject({
+            id: 'comment-series-new',
+            record_uuid: 'comment-series-new',
+            text: 'Inserted into series A',
+            sync_version: 5,
+        });
+        expect(study.series['series-b'].comments[0]).toMatchObject({
+            id: 'comment-move',
+            record_uuid: 'comment-move',
+            text: 'Moved into series B',
+            sync_version: 6,
+        });
     });
 });

--- a/tests/sync-outbox.spec.js
+++ b/tests/sync-outbox.spec.js
@@ -60,7 +60,6 @@ async function setupOutboxPage(page) {
                         });
                     }
                     if (prop === 'isCloudPlatform') return () => true;
-                    if (typeof target[prop] === 'function') return target[prop].bind(target);
                     return target[prop];
                 },
             }),
@@ -558,5 +557,142 @@ test.describe('Outbox Collapsing Edge Cases', () => {
         // NEW: noop entries are kept in the array with _noop flag
         expect(matchingEntries.length).toBe(1);
         expect(matchingEntries[0]._noop).toBe(true);
+    });
+
+    test('readRecordState preserves series_uid for series comments from app state', async ({ page }) => {
+        await setupOutboxPage(page);
+        await clearOutbox(page);
+
+        const result = await page.evaluate(() => {
+            window.DicomViewerApp = {
+                state: {
+                    studies: {
+                        'study-series-sync': {
+                            description: '',
+                            comments: [],
+                            reports: [],
+                            series: {
+                                'series-1': {
+                                    description: '',
+                                    comments: [
+                                        {
+                                            id: 'series-comment-1',
+                                            record_uuid: 'series-comment-1',
+                                            text: 'Series-only comment',
+                                            time: 10,
+                                            created_at: 10,
+                                            updated_at: 10,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            return window._SyncOutbox.readRecordState('comments', 'series-comment-1');
+        });
+
+        expect(result).toMatchObject({
+            study_uid: 'study-series-sync',
+            series_uid: 'series-1',
+            text: 'Series-only comment',
+        });
+    });
+
+    test('dispatcher enqueues sync outbox entries for successful cloud mutations', async ({ page }) => {
+        await setupOutboxPage(page);
+        await clearOutbox(page);
+
+        const calls = await page.evaluate(async () => {
+            const studyUid = 'cloud-dispatcher-study';
+            const commentId = 'dispatcher-comment-1';
+            const enqueueCalls = [];
+
+            window.DicomViewerApp = {
+                state: {
+                    studies: {
+                        [studyUid]: {
+                            description: 'Before',
+                            sync_version: 2,
+                            comments: [
+                                {
+                                    id: commentId,
+                                    record_uuid: commentId,
+                                    text: 'Existing comment',
+                                    time: 1,
+                                    created_at: 1,
+                                    updated_at: 1,
+                                    sync_version: 3,
+                                },
+                            ],
+                            reports: [
+                                {
+                                    id: 'dispatcher-report-1',
+                                    name: 'Report',
+                                    type: 'pdf',
+                                    size: 128,
+                                    addedAt: 1,
+                                    updatedAt: 1,
+                                    sync_version: 4,
+                                },
+                            ],
+                            series: {},
+                        },
+                    },
+                },
+            };
+
+            window._SyncOutbox.enqueueChange = (tableName, recordKey, operation, baseSyncVersion) => {
+                enqueueCalls.push({ tableName, recordKey, operation, baseSyncVersion });
+                return {
+                    id: `entry-${enqueueCalls.length}`,
+                    operation_uuid: `op-${enqueueCalls.length}`,
+                    table_name: tableName,
+                    record_key: recordKey,
+                    operation,
+                    base_sync_version: baseSyncVersion,
+                };
+            };
+            window._NotesServer.ServerBackend.saveStudyDescription = async () => ({
+                studyUid,
+                description: 'After',
+            });
+            window._NotesServer.ServerBackend.updateComment = async () => ({
+                record_uuid: commentId,
+                text: 'Edited comment',
+            });
+            window._NotesServer.ServerBackend.deleteReport = async () => true;
+
+            await window.NotesAPI.saveStudyDescription(studyUid, 'After');
+            await window.NotesAPI.updateComment(studyUid, commentId, { text: 'Edited comment' });
+            await window.NotesAPI.deleteReport(studyUid, 'dispatcher-report-1');
+
+            return enqueueCalls;
+        });
+
+        expect(calls).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    tableName: 'study_notes',
+                    recordKey: 'cloud-dispatcher-study',
+                    operation: 'update',
+                    baseSyncVersion: 2,
+                }),
+                expect.objectContaining({
+                    tableName: 'comments',
+                    recordKey: 'dispatcher-comment-1',
+                    operation: 'update',
+                    baseSyncVersion: 3,
+                }),
+                expect.objectContaining({
+                    tableName: 'reports',
+                    recordKey: 'dispatcher-report-1',
+                    operation: 'delete',
+                    baseSyncVersion: 4,
+                }),
+            ]),
+        );
     });
 });

--- a/tests/sync-outbox.spec.js
+++ b/tests/sync-outbox.spec.js
@@ -607,6 +607,7 @@ test.describe('Outbox Collapsing Edge Cases', () => {
 
         const calls = await page.evaluate(async () => {
             const studyUid = 'cloud-dispatcher-study';
+            const seriesUid = 'cloud-dispatcher-series';
             const commentId = 'dispatcher-comment-1';
             const enqueueCalls = [];
 
@@ -638,7 +639,13 @@ test.describe('Outbox Collapsing Edge Cases', () => {
                                     sync_version: 4,
                                 },
                             ],
-                            series: {},
+                            series: {
+                                [seriesUid]: {
+                                    description: 'Series before',
+                                    sync_version: 5,
+                                    comments: [],
+                                },
+                            },
                         },
                     },
                 },
@@ -659,6 +666,11 @@ test.describe('Outbox Collapsing Edge Cases', () => {
                 studyUid,
                 description: 'After',
             });
+            window._NotesServer.ServerBackend.saveSeriesDescription = async () => ({
+                studyUid,
+                seriesUid,
+                description: 'Series after',
+            });
             window._NotesServer.ServerBackend.updateComment = async () => ({
                 record_uuid: commentId,
                 text: 'Edited comment',
@@ -666,6 +678,7 @@ test.describe('Outbox Collapsing Edge Cases', () => {
             window._NotesServer.ServerBackend.deleteReport = async () => true;
 
             await window.NotesAPI.saveStudyDescription(studyUid, 'After');
+            await window.NotesAPI.saveSeriesDescription(studyUid, seriesUid, 'Series after');
             await window.NotesAPI.updateComment(studyUid, commentId, { text: 'Edited comment' });
             await window.NotesAPI.deleteReport(studyUid, 'dispatcher-report-1');
 
@@ -679,6 +692,12 @@ test.describe('Outbox Collapsing Edge Cases', () => {
                     recordKey: 'cloud-dispatcher-study',
                     operation: 'update',
                     baseSyncVersion: 2,
+                }),
+                expect.objectContaining({
+                    tableName: 'series_notes',
+                    recordKey: JSON.stringify(['cloud-dispatcher-study', 'cloud-dispatcher-series']),
+                    operation: 'update',
+                    baseSyncVersion: 5,
                 }),
                 expect.objectContaining({
                     tableName: 'comments',

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -232,6 +232,56 @@ test.describe('Sync Push - Accepted Changes', () => {
         expect(deleteResult.accepted[0].operation_uuid).toBe(deleteChange.operation_uuid);
         expect(deleteResult.accepted[0].sync_version).toBeGreaterThan(insertedVersion);
     });
+
+    test('delete a study note emits a tombstone with deleted_at set', async ({ request }) => {
+        const { access_token, device_id } = await setupSyncUser(request);
+        const studyUid = uniqueStudyUid();
+
+        const insertChange = studyNoteUpdateChange(studyUid, {
+            description: 'Delete me',
+            baseSyncVersion: 0,
+        });
+        const insertResult = await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [insertChange]);
+        const insertedVersion = insertResult.accepted[0].sync_version;
+
+        const deleteChange = {
+            operation_uuid: uniqueOperationUuid(),
+            table: 'study_notes',
+            key: studyUid,
+            operation: 'delete',
+            base_sync_version: insertedVersion,
+            data: {},
+        };
+        const deleteResult = await syncAndExpectOk(
+            request,
+            BASE_URL,
+            access_token,
+            device_id,
+            insertResult.delta_cursor,
+            [deleteChange],
+        );
+
+        expect(deleteResult.accepted).toHaveLength(1);
+        expect(deleteResult.accepted[0].operation_uuid).toBe(deleteChange.operation_uuid);
+
+        const { device_id: device2 } = await registerDevice(request, BASE_URL, access_token);
+        const pullResult = await syncAndExpectOk(
+            request,
+            BASE_URL,
+            access_token,
+            device2,
+            insertResult.delta_cursor,
+            [],
+        );
+
+        const tombstone = pullResult.remote_changes.find(
+            (change) => change.table === 'study_notes' && change.key === studyUid,
+        );
+        expect(tombstone).toBeDefined();
+        expect(tombstone.operation).toBe('delete');
+        expect(typeof tombstone.data.deleted_at).toBe('number');
+        expect(tombstone.data.deleted_at).not.toBeNull();
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -193,6 +193,51 @@ test.describe('Sync Push - Accepted Changes', () => {
         expect(updateResult.accepted[0].sync_version).toBeGreaterThan(insertedVersion);
     });
 
+    test('update a series note, verify it appears in remote_changes', async ({ request }) => {
+        const { access_token, device_id: deviceA } = await setupSyncUser(request);
+        const { device_id: deviceB } = await registerDevice(request, BASE_URL, access_token);
+        const studyUid = uniqueStudyUid();
+        const seriesUid = `test-sync-series-${Date.now()}`;
+        const seriesKey = JSON.stringify([studyUid, seriesUid]);
+
+        const initialSync = await syncAndExpectOk(request, BASE_URL, access_token, deviceB, null, []);
+
+        const change = {
+            operation_uuid: uniqueOperationUuid(),
+            table: 'series_notes',
+            key: seriesKey,
+            operation: 'update',
+            base_sync_version: 0,
+            data: {
+                study_uid: studyUid,
+                series_uid: seriesUid,
+                description: 'Series sync description',
+                updated_at: Date.now(),
+            },
+        };
+        const pushResult = await syncAndExpectOk(request, BASE_URL, access_token, deviceA, null, [change]);
+
+        expect(pushResult.accepted).toHaveLength(1);
+        expect(pushResult.accepted[0].operation_uuid).toBe(change.operation_uuid);
+
+        const pullResult = await syncAndExpectOk(
+            request,
+            BASE_URL,
+            access_token,
+            deviceB,
+            initialSync.delta_cursor,
+            [],
+        );
+        const found = pullResult.remote_changes.find((rc) => rc.key === seriesKey && rc.table === 'series_notes');
+        expect(found).toBeDefined();
+        expect(found.operation).toBe('update');
+        expect(found.data).toMatchObject({
+            study_uid: studyUid,
+            series_uid: seriesUid,
+            description: 'Series sync description',
+        });
+    });
+
     test('delete (tombstone) a report, verify accepted', async ({ request }) => {
         const { access_token, device_id } = await setupSyncUser(request);
         const reportId = uniqueRecordUuid();
@@ -276,6 +321,59 @@ test.describe('Sync Push - Accepted Changes', () => {
 
         const tombstone = pullResult.remote_changes.find(
             (change) => change.table === 'study_notes' && change.key === studyUid,
+        );
+        expect(tombstone).toBeDefined();
+        expect(tombstone.operation).toBe('delete');
+        expect(typeof tombstone.data.deleted_at).toBe('number');
+        expect(tombstone.data.deleted_at).not.toBeNull();
+    });
+
+    test('delete of a never-inserted comment still creates a tombstone', async ({ request }) => {
+        const { access_token, device_id } = await setupSyncUser(request);
+        const commentKey = uniqueRecordUuid();
+
+        const deleteChange = {
+            operation_uuid: uniqueOperationUuid(),
+            table: 'comments',
+            key: commentKey,
+            operation: 'delete',
+            base_sync_version: 0,
+            data: {},
+        };
+        const deleteResult = await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [deleteChange]);
+
+        expect(deleteResult.accepted).toHaveLength(1);
+        expect(deleteResult.accepted[0].operation_uuid).toBe(deleteChange.operation_uuid);
+
+        const { device_id: device2 } = await registerDevice(request, BASE_URL, access_token);
+        const pullResult = await syncAndExpectOk(request, BASE_URL, access_token, device2, null, []);
+
+        const tombstone = pullResult.remote_changes.find(
+            (change) => change.table === 'comments' && change.key === commentKey,
+        );
+        expect(tombstone).toBeDefined();
+        expect(tombstone.operation).toBe('delete');
+        expect(typeof tombstone.data.deleted_at).toBe('number');
+        expect(tombstone.data.deleted_at).not.toBeNull();
+    });
+
+    test('delete of a never-inserted report still creates a tombstone', async ({ request }) => {
+        const { access_token, device_id } = await setupSyncUser(request);
+        const reportId = uniqueRecordUuid();
+
+        const deleteChange = reportDeleteChange(reportId, {
+            baseSyncVersion: 0,
+        });
+        const deleteResult = await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [deleteChange]);
+
+        expect(deleteResult.accepted).toHaveLength(1);
+        expect(deleteResult.accepted[0].operation_uuid).toBe(deleteChange.operation_uuid);
+
+        const { device_id: device2 } = await registerDevice(request, BASE_URL, access_token);
+        const pullResult = await syncAndExpectOk(request, BASE_URL, access_token, device2, null, []);
+
+        const tombstone = pullResult.remote_changes.find(
+            (change) => change.table === 'reports' && change.key === reportId,
         );
         expect(tombstone).toBeDefined();
         expect(tombstone.operation).toBe('delete');

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -773,14 +773,9 @@ test.describe('Sync Cursor Management', () => {
         const userA = await setupSyncUser(request);
         const userB = await setupSyncUser(request);
 
-        const aSync = await syncAndExpectOk(
-            request,
-            BASE_URL,
-            userA.access_token,
-            userA.device_id,
-            null,
-            [commentInsertChange({ text: 'User A private change' })],
-        );
+        const aSync = await syncAndExpectOk(request, BASE_URL, userA.access_token, userA.device_id, null, [
+            commentInsertChange({ text: 'User A private change' }),
+        ]);
 
         const response = await syncRequest(
             request,

--- a/tests/sync-protocol.spec.js
+++ b/tests/sync-protocol.spec.js
@@ -477,6 +477,85 @@ test.describe('Sync Push - Rejected Changes (Stale base_sync_version)', () => {
         expect(rej.current_data.description).toBe('Second');
     });
 
+    test('stale report updates return current_data instead of failing', async ({ request }) => {
+        const { access_token, device_id } = await setupSyncUser(request);
+        const reportId = uniqueRecordUuid();
+        const studyUid = uniqueStudyUid();
+        const addedAt = Date.now() - 5000;
+
+        const insertChange = {
+            operation_uuid: uniqueOperationUuid(),
+            table: 'reports',
+            key: reportId,
+            operation: 'insert',
+            base_sync_version: 0,
+            data: {
+                study_uid: studyUid,
+                name: 'Initial report name',
+                type: 'pdf',
+                size: 100,
+                content_hash: 'hash-initial',
+                added_at: addedAt,
+                updated_at: addedAt,
+            },
+        };
+        const inserted = await syncAndExpectOk(request, BASE_URL, access_token, device_id, null, [insertChange]);
+        const insertedVersion = inserted.accepted[0].sync_version;
+
+        const updateTime = Date.now();
+        const currentUpdate = {
+            operation_uuid: uniqueOperationUuid(),
+            table: 'reports',
+            key: reportId,
+            operation: 'update',
+            base_sync_version: insertedVersion,
+            data: {
+                name: 'Current report name',
+                size: 200,
+                content_hash: 'hash-current',
+                updated_at: updateTime,
+            },
+        };
+        const updated = await syncAndExpectOk(request, BASE_URL, access_token, device_id, inserted.delta_cursor, [
+            currentUpdate,
+        ]);
+        const currentVersion = updated.accepted[0].sync_version;
+
+        const staleUpdate = {
+            operation_uuid: uniqueOperationUuid(),
+            table: 'reports',
+            key: reportId,
+            operation: 'update',
+            base_sync_version: insertedVersion,
+            data: {
+                name: 'Stale report name',
+                size: 300,
+                content_hash: 'hash-stale',
+                updated_at: updateTime + 1000,
+            },
+        };
+        const staleResult = await syncAndExpectOk(request, BASE_URL, access_token, device_id, updated.delta_cursor, [
+            staleUpdate,
+        ]);
+
+        expect(staleResult.rejected).toHaveLength(1);
+        expect(staleResult.accepted).toEqual([]);
+        expect(staleResult.rejected[0]).toMatchObject({
+            operation_uuid: staleUpdate.operation_uuid,
+            key: reportId,
+            reason: 'stale',
+            current_sync_version: currentVersion,
+        });
+        expect(staleResult.rejected[0].current_data).toMatchObject({
+            study_uid: studyUid,
+            name: 'Current report name',
+            type: 'pdf',
+            size: 200,
+            content_hash: 'hash-current',
+            added_at: addedAt,
+        });
+    });
+
     test('unknown operation does not advance sync_version for the next valid write', async ({ request }) => {
         const { access_token, device_id } = await setupSyncUser(request);
         const studyUid = uniqueStudyUid();
@@ -688,6 +767,36 @@ test.describe('Sync Cursor Management', () => {
         const body = await response.json();
         expect(body.error).toBe('cursor_expired');
         expect(body.hint).toBe('full_resync');
+    });
+
+    test('cursor token from one user is rejected for another user', async ({ request }) => {
+        const userA = await setupSyncUser(request);
+        const userB = await setupSyncUser(request);
+
+        const aSync = await syncAndExpectOk(
+            request,
+            BASE_URL,
+            userA.access_token,
+            userA.device_id,
+            null,
+            [commentInsertChange({ text: 'User A private change' })],
+        );
+
+        const response = await syncRequest(
+            request,
+            BASE_URL,
+            userB.access_token,
+            userB.device_id,
+            aSync.delta_cursor,
+            [],
+        );
+        expect(response.status()).toBe(410);
+
+        const body = await response.json();
+        expect(body).toEqual({
+            error: 'cursor_expired',
+            hint: 'full_resync',
+        });
     });
 
     test('null cursor returns full enumeration', async ({ request }) => {


### PR DESCRIPTION
## Summary
- harden desktop scan path authorization so renderer input cannot expand native filesystem scope on its own
- fix sync integrity for normal UI mutations and series-level comments, and give desktop comments canonical UUID identities
- make report persistence atomic, enforce unique comment UUIDs, and stop trusting `X-Forwarded-For` unless trusted proxy mode is explicitly enabled
- surface or roll back failed comment, description, and report saves instead of showing silent success
- add regression coverage for auth throttling, sync outbox behavior, series comment sync, report durability, and comment identity

## Validation
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- `cargo clippy --locked --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml`
- `./scripts/run-ruff.sh check app.py server/`
- `npx biome lint docs/js/app/comments-ui.js docs/js/app/library.js docs/js/app/notes-ui.js docs/js/app/reports-ui.js docs/js/app/sync-engine.js docs/js/persistence/desktop.js docs/js/persistence/dispatcher.js docs/js/persistence/sync.js tests/auth-security.spec.js tests/comments.spec.js tests/desktop-report-persistence.spec.js tests/mock-tauri-sql-init.js tests/sync-engine.spec.js tests/sync-outbox.spec.js`
- `npx playwright test`
