### PR TITLE
[codex] Fail loud on dashboard auth misconfig

### DIFF
--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 
 import {
     DASHBOARD_PATH,
+    CONFIG_PATH,
     SESSION_PATH,
     SUMMARY_PATH,
     SUBSCRIBERS_PATH,
@@ -19,6 +20,7 @@ import {
 } from '../workers/dashboard/src/lib.mjs';
 
 const DASHBOARD_HTML = '<!doctype html><html><body data-dashboard-shell="true">dashboard</body></html>';
+const VALID_TEST_TOKEN = 'valid-dashboard-token-0123456789abcdef';
 const REAL_DASHBOARD_HTML = fs.readFileSync(
     new URL('../workers/dashboard/src/dashboard.html', import.meta.url),
     'utf8'
@@ -34,7 +36,14 @@ function sha256Base64(value) {
     return crypto.createHash('sha256').update(value).digest('base64');
 }
 
-function createEnv({ subscribers = [], token = 'secret-token', rateLimitSuccess = true } = {}) {
+function sha256Hex(value) {
+    return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function createEnv(options = {}) {
+    const { subscribers = [], rateLimitSuccess = true } = options;
+    const token = Object.prototype.hasOwnProperty.call(options, 'token') ? options.token : VALID_TEST_TOKEN;
+
     return {
         DASHBOARD_TOKEN: token,
         DASHBOARD_RATE_LIMIT: {
@@ -208,40 +217,40 @@ test('authenticate rejects missing and wrong tokens, accepts matching token', as
 
     assert.equal(await authenticate(createRequest(DASHBOARD_PATH), env), false);
     assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { token: 'wrong' }), env), false);
-    assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { token: 'secret-token' }), env), true);
+    assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { token: VALID_TEST_TOKEN }), env), true);
 
     const sessionLogin = await dispatchRequest(
-        createRequest(SESSION_PATH, { method: 'POST', token: 'secret-token' }),
+        createRequest(SESSION_PATH, { method: 'POST', token: VALID_TEST_TOKEN }),
         env,
         DASHBOARD_HTML
     );
     const cookieValue = extractCookieValue(sessionLogin.headers.get('Set-Cookie'));
     assert.match(cookieValue, /^v1\.\d+\.[0-9a-f]{64}$/);
-    assert.equal(await verifySignedSessionValue(cookieValue, 'secret-token'), true);
+    assert.equal(await verifySignedSessionValue(cookieValue, VALID_TEST_TOKEN), true);
     assert.equal(await authenticate(createRequest(DASHBOARD_PATH, { cookieToken: cookieValue }), env), true);
 });
 
 test('signed session values expire server-side', async () => {
     const nowMs = Date.UTC(2026, 3, 12, 12, 0, 0);
-    const value = await createSignedSessionValue('secret-token', nowMs);
+    const value = await createSignedSessionValue(VALID_TEST_TOKEN, nowMs);
 
-    assert.equal(await verifySignedSessionValue(value, 'secret-token', nowMs + 1_000), true);
+    assert.equal(await verifySignedSessionValue(value, VALID_TEST_TOKEN, nowMs + 1_000), true);
     assert.equal(
-        await verifySignedSessionValue(value, 'secret-token', nowMs + 12 * 60 * 60 * 1000 + 1),
+        await verifySignedSessionValue(value, VALID_TEST_TOKEN, nowMs + 12 * 60 * 60 * 1000 + 1),
         false
     );
 });
 
 test('tampered session values are rejected', async () => {
-    const value = await createSignedSessionValue('secret-token', Date.UTC(2026, 3, 12, 12, 0, 0));
+    const value = await createSignedSessionValue(VALID_TEST_TOKEN, Date.UTC(2026, 3, 12, 12, 0, 0));
     const tampered = value.replace(/\.[0-9a-f]{64}$/, '.'.concat('0'.repeat(64)));
 
-    assert.equal(await verifySignedSessionValue(tampered, 'secret-token'), false);
+    assert.equal(await verifySignedSessionValue(tampered, VALID_TEST_TOKEN), false);
 });
 
 test('malformed session values are rejected', async () => {
-    assert.equal(await verifySignedSessionValue('v1.123abc.'.concat('0'.repeat(64)), 'secret-token'), false);
-    assert.equal(await verifySignedSessionValue('v1.123456.short', 'secret-token'), false);
+    assert.equal(await verifySignedSessionValue('v1.123abc.'.concat('0'.repeat(64)), VALID_TEST_TOKEN), false);
+    assert.equal(await verifySignedSessionValue('v1.123456.short', VALID_TEST_TOKEN), false);
 });
 
 test('handleDashboard returns login page without auth and shell with auth', async () => {
@@ -254,7 +263,7 @@ test('handleDashboard returns login page without auth and shell with auth', asyn
     assert.match(loginResponse.headers.get('Set-Cookie'), /Max-Age=0/);
 
     const sessionLogin = await dispatchRequest(
-        createRequest(SESSION_PATH, { method: 'POST', token: 'secret-token' }),
+        createRequest(SESSION_PATH, { method: 'POST', token: VALID_TEST_TOKEN }),
         env,
         REAL_DASHBOARD_HTML
     );
@@ -319,7 +328,7 @@ test('handleSubscribers enforces per_page <= 100', async () => {
 test('handleSubscribers invalid integer errors do not reflect raw input', async () => {
     const env = createEnv();
     const request = createRequest(`${SUBSCRIBERS_PATH}?page=%3Cscript%3Ealert(1)%3C/script%3E`, {
-        cookieToken: 'secret-token'
+        cookieToken: VALID_TEST_TOKEN
     });
 
     let response = null;
@@ -370,7 +379,7 @@ test('dispatchRequest creates and clears dashboard sessions', async () => {
     const env = createEnv();
 
     const loginResponse = await dispatchRequest(
-        createRequest(SESSION_PATH, { method: 'POST', token: 'secret-token' }),
+        createRequest(SESSION_PATH, { method: 'POST', token: VALID_TEST_TOKEN }),
         env,
         DASHBOARD_HTML
     );
@@ -397,11 +406,102 @@ test('dispatchRequest creates and clears dashboard sessions', async () => {
     assert.match(logoutResponse.headers.get('Set-Cookie'), /Max-Age=0/);
 });
 
+test('POST /api/session returns 503, not 401, when DASHBOARD_TOKEN is empty', async () => {
+    const response = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'POST', token: VALID_TEST_TOKEN }),
+        createEnv({ token: '' }),
+        DASHBOARD_HTML
+    );
+
+    assert.equal(response.status, 503);
+    assert.match(response.headers.get('Set-Cookie'), /Max-Age=0/);
+    assert.deepEqual(await response.json(), {
+        error: 'Dashboard misconfigured',
+        reason: 'DASHBOARD_TOKEN is empty'
+    });
+});
+
+test('POST /api/session returns 503 when DASHBOARD_TOKEN is unset', async () => {
+    const response = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'POST', token: VALID_TEST_TOKEN }),
+        createEnv({ token: undefined }),
+        DASHBOARD_HTML
+    );
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), {
+        error: 'Dashboard misconfigured',
+        reason: 'DASHBOARD_TOKEN is unset'
+    });
+});
+
+test('POST /api/session returns 503 when DASHBOARD_TOKEN is too short', async () => {
+    const response = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'POST', token: VALID_TEST_TOKEN }),
+        createEnv({ token: 'too-short-dashboard' }),
+        DASHBOARD_HTML
+    );
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), {
+        error: 'Dashboard misconfigured',
+        reason: 'DASHBOARD_TOKEN is too short (length < 32)'
+    });
+});
+
 test('logout is not blocked by the dashboard rate limiter', async () => {
     const env = createEnv({ rateLimitSuccess: false });
     const response = await dispatchRequest(createRequest(SESSION_PATH, { method: 'DELETE' }), env, DASHBOARD_HTML);
 
     assert.equal(response.status, 204);
+});
+
+test('logout still clears cookies while the dashboard is misconfigured', async () => {
+    const response = await dispatchRequest(
+        createRequest(SESSION_PATH, { method: 'DELETE' }),
+        createEnv({ token: '' }),
+        DASHBOARD_HTML
+    );
+
+    assert.equal(response.status, 204);
+    assert.match(response.headers.get('Set-Cookie'), /Max-Age=0/);
+});
+
+test('dispatchRequest returns a dedicated misconfig page for GET /', async () => {
+    const response = await dispatchRequest(createRequest(DASHBOARD_PATH), createEnv({ token: '' }), DASHBOARD_HTML);
+    const html = await response.text();
+
+    assert.equal(response.status, 503);
+    assert.match(response.headers.get('Set-Cookie'), /Max-Age=0/);
+    assert.match(html, /Dashboard unavailable/);
+    assert.match(html, /DASHBOARD_TOKEN is empty/);
+    assert.doesNotMatch(html, /id="tokenInput"/);
+});
+
+test('GET /api/config returns trimmed token metadata with a SHA-256 fingerprint prefix', async () => {
+    const tokenWithWhitespace = `  ${VALID_TEST_TOKEN}  `;
+    const response = await dispatchRequest(createRequest(CONFIG_PATH), createEnv({ token: tokenWithWhitespace }), DASHBOARD_HTML);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+        status: 'ok',
+        token_configured: true,
+        token_length: VALID_TEST_TOKEN.length,
+        token_fingerprint_sha256_prefix: sha256Hex(VALID_TEST_TOKEN).slice(0, 12)
+    });
+    assert.match(payload.token_fingerprint_sha256_prefix, /^[0-9a-f]{12}$/);
+});
+
+test('GET /api/config bypasses the dashboard rate limiter', async () => {
+    const response = await dispatchRequest(
+        createRequest(CONFIG_PATH),
+        createEnv({ rateLimitSuccess: false }),
+        DASHBOARD_HTML
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal((await response.json()).status, 'ok');
 });
 
 test('tampered dashboard cookies fall back to login and get cleared', async () => {

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -493,6 +493,17 @@ test('GET /api/config returns trimmed token metadata with a SHA-256 fingerprint 
     assert.match(payload.token_fingerprint_sha256_prefix, /^[0-9a-f]{12}$/);
 });
 
+test('GET /api/config returns the standard 503 misconfig payload without clearing cookies', async () => {
+    const response = await dispatchRequest(createRequest(CONFIG_PATH), createEnv({ token: '' }), DASHBOARD_HTML);
+
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('Set-Cookie'), null);
+    assert.deepEqual(await response.json(), {
+        error: 'Dashboard misconfigured',
+        reason: 'DASHBOARD_TOKEN is empty'
+    });
+});
+
 test('GET /api/config bypasses the dashboard rate limiter', async () => {
     const response = await dispatchRequest(
         createRequest(CONFIG_PATH),

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -15,6 +15,9 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 
 - `GET /` - Protected dashboard shell. Without a valid dashboard session cookie
   or bearer token, returns a minimal login page.
+- `GET /api/config` - Unauthenticated dashboard auth-config diagnostic endpoint.
+  Returns the trimmed token length plus a SHA-256 fingerprint prefix when valid,
+  or a 503 with the config failure reason when invalid.
 - `POST /api/session` - Validates a bearer token and mints the browser session
   cookie used by the dashboard shell.
 - `DELETE /api/session` - Clears the dashboard session cookie.
@@ -35,12 +38,15 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 ## Security Notes
 
 - The dashboard uses a single shared bearer token from `DASHBOARD_TOKEN`.
+- `DASHBOARD_TOKEN` must be at least 32 characters after trimming whitespace.
 - Browser login exchanges that token for a same-site `HttpOnly` session cookie
   via `POST /api/session`, so the full dashboard flow does not depend on
   `sessionStorage` or `document.write`.
 - The session cookie stores a signed, time-bound verifier rather than the raw
   shared secret, and the worker enforces the 12-hour expiry server-side.
-- Rate limiting runs before auth and applies to the entire worker.
+- Rate limiting runs before auth for the main dashboard routes, but
+  `/api/config` and `DELETE /api/session` intentionally bypass it so operators
+  can diagnose misconfiguration and clear stale cookies.
 - Every response is `Cache-Control: no-store`.
 - The worker sets CSP, frame, referrer, and content-type hardening headers.
   HTML responses derive script hashes from the inline scripts they actually
@@ -50,6 +56,16 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 - D1 access is read-only by convention, not by enforced binding mode. This
   worker only issues `SELECT` queries.
 
+## Token Contract
+
+- `DASHBOARD_TOKEN` must trim to at least 32 characters.
+- `/api/config` computes `token_length` and
+  `token_fingerprint_sha256_prefix` from the trimmed token, matching what auth
+  compares.
+- The config endpoint exposes a 12-character SHA-256 hex prefix, not literal
+  token characters, so operators can verify deployment state without leaking
+  any portion of the shared secret.
+
 ## Production Setup
 
 1. Set the dashboard token secret:
@@ -58,19 +74,32 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
    npx wrangler secret put DASHBOARD_TOKEN --config workers/dashboard/wrangler.toml
    ```
 
-2. Apply the subscriber index migration remotely:
+2. Verify the deployed dashboard token configuration:
+
+   ```bash
+   echo -n 'YOUR_TOKEN' | shasum -a 256 | head -c 12
+   curl https://dashboard.myradone.com/api/config
+   ```
+
+   Confirm the response includes:
+
+   - `"status":"ok"`
+   - `"token_length":<trimmed token length>`
+   - `"token_fingerprint_sha256_prefix":"<same 12-char SHA-256 prefix>"`
+
+3. Apply the subscriber index migration remotely:
 
    ```bash
    npx wrangler d1 migrations apply myradone-subscribers --remote --config workers/dashboard/wrangler.toml
    ```
 
-3. Deploy the worker:
+4. Deploy the worker:
 
    ```bash
    npx wrangler deploy --config workers/dashboard/wrangler.toml
    ```
 
-4. Add a custom domain route in Cloudflare:
+5. Add a custom domain route in Cloudflare:
 
    - Worker: `myradone-dashboard`
    - Domain: `dashboard.myradone.com`
@@ -83,7 +112,7 @@ you want meaningful dashboard output.
 1. Create `workers/dashboard/.dev.vars`:
 
    ```dotenv
-   DASHBOARD_TOKEN=localtest123
+   DASHBOARD_TOKEN=localtest-localtest-localtest-1234
    ```
 
 2. Apply the existing subscriber schema locally:
@@ -112,7 +141,7 @@ you want meaningful dashboard output.
    ```
 
 6. Visit [http://localhost:8787/](http://localhost:8787/) and enter
-   `localtest123`.
+   `localtest-localtest-localtest-1234`.
 
 ## Verification
 
@@ -125,15 +154,37 @@ node --test tests/dashboard-worker.test.mjs
 Manual:
 
 1. Start `wrangler dev` with seeded local data.
-2. Load `http://localhost:8787/` without a token and confirm the login page is
+2. Confirm the config endpoint reports the trimmed token length and fingerprint:
+
+   ```bash
+   curl http://localhost:8787/api/config
+   ```
+
+3. Load `http://localhost:8787/` without a token and confirm the login page is
    shown.
-3. Enter the token and confirm the summary cards, recent signups, and full table
+4. Enter the token and confirm the summary cards, recent signups, and full table
    render.
-4. Exercise filters, sorting, and pagination.
-5. Confirm invalid login attempts stay on the login page and valid logout returns
-   you there.
-6. Inspect headers with:
+5. Exercise filters, sorting, and pagination.
+6. Confirm invalid login attempts stay on the login page and misconfigured
+   workers show a dedicated 503 page.
+7. Confirm invalid `DASHBOARD_TOKEN` values fail loud:
+
+   ```bash
+   curl -i -X POST http://localhost:8787/api/session -H "Authorization: Bearer wrong"
+   ```
+
+   With an empty or too-short secret, this should return `503` and a
+   `Dashboard misconfigured` JSON payload instead of `401`.
+8. Confirm valid logout returns you there.
+9. Inspect headers with:
 
    ```bash
    curl -I http://localhost:8787/
+   ```
+
+   And confirm the misconfig diagnostic endpoint clears stale cookies when the
+   worker is invalid:
+
+   ```bash
+   curl -i http://localhost:8787/api/config
    ```

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -74,7 +74,24 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
    npx wrangler secret put DASHBOARD_TOKEN --config workers/dashboard/wrangler.toml
    ```
 
-2. Verify the deployed dashboard token configuration:
+2. Apply the subscriber index migration remotely:
+
+   ```bash
+   npx wrangler d1 migrations apply myradone-subscribers --remote --config workers/dashboard/wrangler.toml
+   ```
+
+3. Deploy the worker:
+
+   ```bash
+   npx wrangler deploy --config workers/dashboard/wrangler.toml
+   ```
+
+4. Add a custom domain route in Cloudflare:
+
+   - Worker: `myradone-dashboard`
+   - Domain: `dashboard.myradone.com`
+
+5. Verify the deployed dashboard token configuration:
 
    ```bash
    echo -n 'YOUR_TOKEN' | shasum -a 256 | head -c 12
@@ -86,23 +103,6 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
    - `"status":"ok"`
    - `"token_length":<trimmed token length>`
    - `"token_fingerprint_sha256_prefix":"<same 12-char SHA-256 prefix>"`
-
-3. Apply the subscriber index migration remotely:
-
-   ```bash
-   npx wrangler d1 migrations apply myradone-subscribers --remote --config workers/dashboard/wrangler.toml
-   ```
-
-4. Deploy the worker:
-
-   ```bash
-   npx wrangler deploy --config workers/dashboard/wrangler.toml
-   ```
-
-5. Add a custom domain route in Cloudflare:
-
-   - Worker: `myradone-dashboard`
-   - Domain: `dashboard.myradone.com`
 
 ## Local Development
 

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -27,6 +27,7 @@ const inlineScriptCspCache = new Map();
 const JSON_RESPONSE_CSP = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
 const STATIC_HTML_CSP =
     "default-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'; img-src 'self' data:; object-src 'none'; style-src 'unsafe-inline'";
+// Cloudflare Workers isolates reset this naturally on cold start.
 let misconfigWarningLogged = false;
 const LOGIN_PAGE_SCRIPT = `(function () {
   const form = document.getElementById('loginForm');
@@ -856,11 +857,7 @@ async function handleConfig(request, env) {
     const config = validateConfig(env);
     if (!config.ok) {
         logMisconfigOnce(config.reason);
-        return misconfigJsonResponse(request, config.reason, {
-            status: 'error',
-            reason: config.reason,
-            token_configured: false
-        });
+        return jsonResponse({ error: DASHBOARD_MISCONFIG_ERROR, reason: config.reason }, 503);
     }
 
     return jsonResponse({

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -1,9 +1,12 @@
 export const DASHBOARD_PATH = '/';
+export const CONFIG_PATH = '/api/config';
 export const SESSION_PATH = '/api/session';
 export const SUMMARY_PATH = '/api/summary';
 export const SUBSCRIBERS_PATH = '/api/subscribers';
 
 const DASHBOARD_SESSION_COOKIE = 'myradone_dashboard_token';
+const DASHBOARD_MISCONFIG_ERROR = 'Dashboard misconfigured';
+const DASHBOARD_TOKEN_MIN_LENGTH = 32;
 const VALID_STATUSES = new Set(['active', 'unsubscribed']);
 const VALID_SOURCES = new Set(['landing', 'demo', 'app']);
 const VALID_ORDERS = new Set(['asc', 'desc']);
@@ -22,6 +25,9 @@ const textEncoder = new TextEncoder();
 const signingKeyCache = new Map();
 const inlineScriptCspCache = new Map();
 const JSON_RESPONSE_CSP = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
+const STATIC_HTML_CSP =
+    "default-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'; img-src 'self' data:; object-src 'none'; style-src 'unsafe-inline'";
+let misconfigWarningLogged = false;
 const LOGIN_PAGE_SCRIPT = `(function () {
   const form = document.getElementById('loginForm');
   const tokenInput = document.getElementById('tokenInput');
@@ -52,6 +58,13 @@ const LOGIN_PAGE_SCRIPT = `(function () {
 
       if (response.status === 429) {
         throw new Error('Too many requests. Please try again shortly.');
+      }
+
+      if (response.status === 503) {
+        const body = await response.json().catch(function () {
+          return {};
+        });
+        throw new Error(body.reason ? 'Server misconfigured: ' + body.reason : 'Server misconfigured.');
       }
 
       if (!response.ok) {
@@ -156,6 +169,11 @@ function getBearerToken(request) {
 
 function bytesToHex(bytes) {
     return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function tokenFingerprint(token) {
+    const digest = await crypto.subtle.digest('SHA-256', textEncoder.encode(token));
+    return bytesToHex(new Uint8Array(digest)).slice(0, 12);
 }
 
 function bytesToBase64(bytes) {
@@ -295,24 +313,46 @@ function buildClearSessionCookie(request) {
     return `${DASHBOARD_SESSION_COOKIE}=; ${attributes.join('; ')}`;
 }
 
-export async function authenticate(request, env) {
-    const bearerToken = getBearerToken(request);
-    const cookieToken = getCookieToken(request);
-    const expectedToken = typeof env.DASHBOARD_TOKEN === 'string' ? env.DASHBOARD_TOKEN.trim() : '';
-
-    if (!expectedToken) {
-        return false;
+export function validateConfig(env) {
+    const rawToken = env?.DASHBOARD_TOKEN;
+    if (typeof rawToken !== 'string') {
+        return { ok: false, reason: 'DASHBOARD_TOKEN is unset' };
     }
 
+    const token = rawToken.trim();
+    if (!token) {
+        return { ok: false, reason: 'DASHBOARD_TOKEN is empty' };
+    }
+
+    if (token.length < DASHBOARD_TOKEN_MIN_LENGTH) {
+        return { ok: false, reason: `DASHBOARD_TOKEN is too short (length < ${DASHBOARD_TOKEN_MIN_LENGTH})` };
+    }
+
+    return { ok: true, token };
+}
+
+async function authenticateToken(request, token) {
+    const bearerToken = getBearerToken(request);
+    const cookieToken = getCookieToken(request);
+
     if (bearerToken) {
-        return timingSafeEqual(bearerToken, expectedToken);
+        return timingSafeEqual(bearerToken, token);
     }
 
     if (!cookieToken) {
         return false;
     }
 
-    return verifySignedSessionValue(cookieToken, expectedToken);
+    return verifySignedSessionValue(cookieToken, token);
+}
+
+export async function authenticate(request, env) {
+    const config = validateConfig(env);
+    if (!config.ok) {
+        return false;
+    }
+
+    return authenticateToken(request, config.token);
 }
 
 async function isRateLimited(request, env) {
@@ -328,16 +368,8 @@ async function isRateLimited(request, env) {
     return !success;
 }
 
-function createLoginHtml(errorMessage = '') {
-    const safeError = escapeHtml(errorMessage);
-
-    return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>myRadOne Subscriber Dashboard Login</title>
-  <style>
+function createAuthPageStyles() {
+    return `<style>
     :root {
       --bg: #fff8f3;
       --text: #3d3a36;
@@ -428,7 +460,33 @@ function createLoginHtml(errorMessage = '') {
       font-size: 0.92rem;
       font-weight: 600;
     }
-  </style>
+    .notice {
+      margin-top: 24px;
+      padding: 16px 18px;
+      border: 1px solid rgba(182, 69, 25, 0.2);
+      border-radius: 14px;
+      background: rgba(182, 69, 25, 0.06);
+    }
+    .notice p {
+      margin: 0;
+      color: #7a3a20;
+    }
+    .notice p + p {
+      margin-top: 12px;
+    }
+  </style>`;
+}
+
+function createLoginHtml(errorMessage = '') {
+    const safeError = escapeHtml(errorMessage);
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>myRadOne Subscriber Dashboard Login</title>
+  ${createAuthPageStyles()}
 </head>
 <body>
   <main class="card">
@@ -445,6 +503,31 @@ function createLoginHtml(errorMessage = '') {
     <div id="errorMessage" class="error" role="alert">${safeError}</div>
   </main>
   <script>${LOGIN_PAGE_SCRIPT}</script>
+</body>
+</html>`;
+}
+
+function createMisconfigHtml(reason) {
+    const safeReason = escapeHtml(reason);
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>myRadOne Subscriber Dashboard Misconfigured</title>
+  ${createAuthPageStyles()}
+</head>
+<body>
+  <main class="card">
+    <p class="eyebrow">Configuration Error</p>
+    <h1>Dashboard unavailable</h1>
+    <p>The dashboard worker is misconfigured and cannot authenticate requests.</p>
+    <div class="notice" role="alert">
+      <p>${safeReason}</p>
+      <p>Use <code>${CONFIG_PATH}</code> to verify the deployed token configuration after updating the secret.</p>
+    </div>
+  </main>
 </body>
 </html>`;
 }
@@ -672,9 +755,14 @@ export async function handleSubscribers(request, env) {
 
 export async function handleDashboard(request, env, dashboardHtml) {
     requireGet(request);
-    const loginHtml = createLoginHtml();
+    const config = validateConfig(env);
+    if (!config.ok) {
+        logMisconfigOnce(config.reason);
+        return misconfigHtmlResponse(request, config.reason);
+    }
 
-    if (!(await authenticate(request, env))) {
+    if (!(await authenticateToken(request, config.token))) {
+        const loginHtml = createLoginHtml();
         return htmlResponse(
             loginHtml,
             200,
@@ -697,7 +785,13 @@ export async function handleSession(request, env) {
         methodNotAllowed();
     }
 
-    if (!(await authenticate(request, env))) {
+    const config = validateConfig(env);
+    if (!config.ok) {
+        logMisconfigOnce(config.reason);
+        return misconfigJsonResponse(request, config.reason);
+    }
+
+    if (!(await authenticateToken(request, config.token))) {
         return jsonResponse(
             { error: 'Unauthorized' },
             401,
@@ -709,7 +803,28 @@ export async function handleSession(request, env) {
     }
 
     return emptyResponse(204, {
-        'Set-Cookie': await buildSessionCookie(request, env.DASHBOARD_TOKEN.trim())
+        'Set-Cookie': await buildSessionCookie(request, config.token)
+    });
+}
+
+function logMisconfigOnce(reason) {
+    if (misconfigWarningLogged) {
+        return;
+    }
+
+    misconfigWarningLogged = true;
+    console.error('dashboard worker misconfigured:', reason);
+}
+
+function misconfigJsonResponse(request, reason, payload = null) {
+    return jsonResponse(payload || { error: DASHBOARD_MISCONFIG_ERROR, reason }, 503, {
+        'Set-Cookie': buildClearSessionCookie(request)
+    });
+}
+
+function misconfigHtmlResponse(request, reason) {
+    return htmlResponse(createMisconfigHtml(reason), 503, STATIC_HTML_CSP, {
+        'Set-Cookie': buildClearSessionCookie(request)
     });
 }
 
@@ -736,8 +851,32 @@ async function createRateLimitResponse(pathname) {
     return jsonResponse({ error: 'Too many requests. Please try again later.' }, 429);
 }
 
+async function handleConfig(request, env) {
+    requireGet(request);
+    const config = validateConfig(env);
+    if (!config.ok) {
+        logMisconfigOnce(config.reason);
+        return misconfigJsonResponse(request, config.reason, {
+            status: 'error',
+            reason: config.reason,
+            token_configured: false
+        });
+    }
+
+    return jsonResponse({
+        status: 'ok',
+        token_configured: true,
+        token_length: config.token.length,
+        token_fingerprint_sha256_prefix: await tokenFingerprint(config.token)
+    });
+}
+
 export async function dispatchRequest(request, env, dashboardHtml) {
     const { pathname } = new URL(request.url);
+
+    if (pathname === CONFIG_PATH) {
+        return handleConfig(request, env);
+    }
 
     if (pathname === SESSION_PATH && request.method === 'DELETE') {
         return handleSession(request, env);
@@ -745,6 +884,14 @@ export async function dispatchRequest(request, env, dashboardHtml) {
 
     if (await isRateLimited(request, env)) {
         return await createRateLimitResponse(pathname);
+    }
+
+    const config = validateConfig(env);
+    if (!config.ok) {
+        logMisconfigOnce(config.reason);
+        return pathname === DASHBOARD_PATH
+            ? misconfigHtmlResponse(request, config.reason)
+            : misconfigJsonResponse(request, config.reason);
     }
 
     if (pathname === SESSION_PATH) {


### PR DESCRIPTION
## Summary
- fail loud when `DASHBOARD_TOKEN` is unset, empty, or shorter than 32 characters instead of returning the same 401 as a bad credential
- add unauthenticated `GET /api/config` diagnostics plus a dedicated misconfiguration page for `GET /`
- update worker tests and README to cover the new token contract, fingerprint verification flow, and regression cases

## Why
The dashboard worker currently treats a misconfigured shared secret the same way it treats an invalid bearer token. That makes production misconfiguration look like a bad password and wastes operator time during deploy/debug loops.

## Impact
Operators can now distinguish worker misconfiguration from invalid credentials immediately, clear stale cookies even while misconfigured, and verify deployed token state without leaking any literal secret characters.

## Root Cause
`authenticate()` previously read `env.DASHBOARD_TOKEN` directly and returned `false` for both missing config and wrong credentials, which caused `POST /api/session` to return a generic 401 either way.

## Validation
- `node --test tests/dashboard-worker.test.mjs`
