### PR TITLE
Track dashboard.myradone.com route in wrangler.toml

### DIFF
--- a/docs/decisions/013-worker-routing-as-code.md
+++ b/docs/decisions/013-worker-routing-as-code.md
@@ -1,0 +1,74 @@
+# ADR 013: Cloudflare Worker Routes As Code
+
+## Status
+
+Accepted
+
+## Context
+
+Divergent Health runs four Cloudflare Workers in production: `myradone-subscribe` (email signups), `myradone-stats` (local-first telemetry receiver), `myradone-download` (DMG redirect), and `myradone-dashboard` (internal subscriber admin). Each Worker is reached at a custom domain on `myradone.com` or `api.myradone.com`.
+
+Cloudflare supports two ways to manage the route → Worker binding:
+
+1. **Dashboard-managed** -- the route is added through the Cloudflare UI and `wrangler.toml` omits any `routes` declaration. `wrangler deploy` touches the Worker code but leaves routes alone.
+2. **Repo-managed** -- the route is declared in `wrangler.toml` (`[[routes]]` table-array). `wrangler deploy` reconciles the declared routes against production.
+
+Until this decision the four Workers drifted between modes: `workers/download/wrangler.toml` declared its route; `workers/subscribe/`, `workers/stats/`, and `workers/dashboard/` did not. The dashboard worker's `dashboard.myradone.com/*` route was in particular added via the Cloudflare UI during its initial deploy and was never captured in the tracked config. That drift was invisible to code review and would not be rebuildable from a fresh checkout.
+
+## Decision
+
+All Cloudflare Worker routes for this project are declared in the Worker's `wrangler.toml` using the `[[routes]]` table-array form.
+
+```toml
+[[routes]]
+pattern = "dashboard.myradone.com/*"
+zone_name = "myradone.com"
+```
+
+The Cloudflare dashboard is not the source of truth for routing. Route changes flow through `wrangler.toml` edits and PR review, then take effect on the next `wrangler deploy`.
+
+## Alternatives Considered
+
+### Dashboard-managed routes, `wrangler.toml` route-agnostic
+
+Rejected. Works in isolation, but:
+
+- A fresh environment (staging, disaster recovery, new region) cannot be stood up from the repo without someone clicking through the dashboard.
+- Route changes leave no authored, reviewed, revertable record. `git revert` is not available.
+- The two-mode repo we had was confusing -- `download` looked like one thing, `subscribe`/`stats`/`dashboard` looked like another, and neither pattern was documented.
+- SOC 2 / HIPAA compliance work planned under [ADR 006](006-cloud-sync-storage-architecture.md) and [ADR 010](010-patient-provider-image-sharing.md) will require auditable change history for production infrastructure. Starting with infra-as-code is cheaper than retrofitting it.
+
+### Inline-table form (`routes = [{ ... }]`)
+
+Rejected. Cloudflare's official Wrangler configuration docs use the `[[routes]]` table-array form. The inline form parses correctly today, but standardizing on the documented style keeps the config readable and avoids a future rewrite when the form changes or a linter enforces one style.
+
+### Terraform or Pulumi for Cloudflare infra
+
+Deferred, not rejected. Terraform is the natural next step when managing zones, DNS records, rate-limit namespaces, and Workers together becomes enough work to justify a dedicated stack. For four Workers on a single zone, `wrangler.toml` is sufficient. Revisit if we grow to ~10 Workers or add multi-account deploys.
+
+## Design Details
+
+- Each Worker's `wrangler.toml` declares its own routes. No shared config file.
+- Custom domains and zone configuration (DNS records, SSL modes, WAF rules) remain in the Cloudflare dashboard. This ADR covers Worker → route bindings only, not the broader zone.
+- Rate-limit namespaces (`[[ratelimits]]`) and D1 database IDs remain in `wrangler.toml` alongside routes -- same policy, same file, same review path.
+- Secrets (`wrangler secret put`) stay out of `wrangler.toml`. That is an orthogonal policy and does not change here.
+
+## Consequences
+
+Positive:
+
+- Single source of truth for route configuration per Worker.
+- Route changes are reviewable, revertable, and auditable.
+- A fresh clone + `wrangler deploy` reproduces production routing.
+- Consistency across the four Workers eliminates the previous two-mode repo confusion.
+
+Tradeoffs:
+
+- Route changes now require a PR rather than a dashboard click. For emergency routing changes (e.g., cutting a compromised Worker off its domain), the dashboard remains available as an override; the expectation is that a reconciling PR follows immediately.
+- Any Cloudflare user with dashboard access can still change routes directly. We rely on convention, not enforcement, to keep the repo authoritative. If that becomes a problem, Cloudflare Terraform provider adds locking; see the deferred alternative above.
+
+## Migration
+
+- `workers/dashboard/wrangler.toml` declares `dashboard.myradone.com/*` (PR #90).
+- `workers/download/wrangler.toml` already declares `myradone.com/download`.
+- `workers/subscribe/wrangler.toml` and `workers/stats/wrangler.toml` will be updated in a follow-up to declare their `api.myradone.com` routes. This is tracked as a follow-up task, not a blocker for this ADR.

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -86,10 +86,12 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
    npx wrangler deploy --config workers/dashboard/wrangler.toml
    ```
 
-4. Add a custom domain route in Cloudflare:
-
-   - Worker: `myradone-dashboard`
-   - Domain: `dashboard.myradone.com`
+4. Route configuration is managed in `wrangler.toml` (`[[routes]]` block)
+   per [ADR 013](../../docs/decisions/013-worker-routing-as-code.md). The
+   `wrangler deploy` step above reconciles the `dashboard.myradone.com/*`
+   route automatically; no Cloudflare UI change is required. Do not add or
+   edit the route through the Cloudflare dashboard -- it will drift from the
+   repo and the next deploy may reconcile it away.
 
 5. Verify the deployed dashboard token configuration:
 

--- a/workers/dashboard/wrangler.toml
+++ b/workers/dashboard/wrangler.toml
@@ -4,6 +4,10 @@ compatibility_date = "2026-04-07"
 workers_dev = false
 preview_urls = false
 
+[[routes]]
+pattern = "dashboard.myradone.com/*"
+zone_name = "myradone.com"
+
 [[rules]]
 type = "Text"
 globs = ["**/*.html"]


### PR DESCRIPTION
## Summary

The dashboard worker's production route (`dashboard.myradone.com/*`) was added in the Cloudflare UI during deploy but never captured in the tracked `wrangler.toml`. This PR closes that config drift by declaring the route using the documented `[[routes]]` table-array form.

Rationale: infrastructure-as-code convention. Matches how `workers/download/wrangler.toml` already tracks its route. Follow-up: bring `workers/subscribe/` and `workers/stats/` under the same policy.

## Test plan

- [ ] CI passes
- [ ] Next `wrangler deploy` reconciles the route (no-op since route already exists in CF)