### PR TITLE
[codex] Apply ADR 013 routes across remaining workers

### DIFF
--- a/docs/decisions/013-worker-routing-as-code.md
+++ b/docs/decisions/013-worker-routing-as-code.md
@@ -73,4 +73,4 @@ Tradeoffs:
 - `workers/download/wrangler.toml` declares `myradone.com/download` using the ADR 013 `[[routes]]` table-array form.
 - `workers/subscribe/wrangler.toml` declares `api.myradone.com/subscribe`.
 - `workers/stats/wrangler.toml` declares `api.myradone.com/api/stats`.
-- Follow-up completion is tracked in the PR that applies those route declarations and README updates.
+- Follow-up completion is tracked in PR #93, which applies those route declarations and README updates.

--- a/docs/decisions/013-worker-routing-as-code.md
+++ b/docs/decisions/013-worker-routing-as-code.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Implemented
 
 ## Context
 
@@ -73,4 +73,4 @@ Tradeoffs:
 - `workers/download/wrangler.toml` declares `myradone.com/download` using the ADR 013 `[[routes]]` table-array form.
 - `workers/subscribe/wrangler.toml` declares `api.myradone.com/subscribe`.
 - `workers/stats/wrangler.toml` declares `api.myradone.com/api/stats`.
-- Follow-up completion is tracked in PR #93, which applies those route declarations and README updates.
+- All four workers now declare their routes in `wrangler.toml`. Migration complete.

--- a/docs/decisions/013-worker-routing-as-code.md
+++ b/docs/decisions/013-worker-routing-as-code.md
@@ -70,5 +70,7 @@ Tradeoffs:
 ## Migration
 
 - `workers/dashboard/wrangler.toml` declares `dashboard.myradone.com/*` (PR #90).
-- `workers/download/wrangler.toml` already declares `myradone.com/download`.
-- `workers/subscribe/wrangler.toml` and `workers/stats/wrangler.toml` will be updated in a follow-up to declare their `api.myradone.com` routes. This is tracked as a follow-up task, not a blocker for this ADR.
+- `workers/download/wrangler.toml` declares `myradone.com/download` using the ADR 013 `[[routes]]` table-array form.
+- `workers/subscribe/wrangler.toml` declares `api.myradone.com/subscribe`.
+- `workers/stats/wrangler.toml` declares `api.myradone.com/api/stats`.
+- Follow-up completion is tracked in the PR that applies those route declarations and README updates.

--- a/workers/download/wrangler.toml
+++ b/workers/download/wrangler.toml
@@ -2,6 +2,6 @@ name = "myradone-download"
 main = "worker.js"
 compatibility_date = "2024-01-01"
 
-routes = [
-  { pattern = "myradone.com/download", zone_name = "myradone.com" }
-]
+[[routes]]
+pattern = "myradone.com/download"
+zone_name = "myradone.com"

--- a/workers/stats/README.md
+++ b/workers/stats/README.md
@@ -141,15 +141,11 @@ trivial abuse.
    npx wrangler deploy
    ```
 
-7. Add a custom-domain route in Cloudflare so the worker is reachable at
-   `api.myradone.com/api/stats`:
-
-   - Worker: `myradone-stats`
-   - Domain: `api.myradone.com`
-   - Path: `/api/stats`
-
-   The existing subscribe worker (`workers/subscribe`) follows the same
-   pattern at `api.myradone.com/subscribe` -- mirror that configuration.
+7. The route is config-managed per
+   [`docs/decisions/013-worker-routing-as-code.md`](../../docs/decisions/013-worker-routing-as-code.md)
+   and is applied on `wrangler deploy`. Do not add or edit the
+   `api.myradone.com/api/stats` route manually in the Cloudflare dashboard
+   unless you are making an emergency override that will be reconciled in a PR.
 
 ## Verification
 

--- a/workers/stats/wrangler.toml
+++ b/workers/stats/wrangler.toml
@@ -4,6 +4,10 @@ compatibility_date = "2026-04-07"
 workers_dev = false
 preview_urls = false
 
+[[routes]]
+pattern = "api.myradone.com/api/stats"
+zone_name = "myradone.com"
+
 # Allowed CORS origins. Tauri desktop sends no Origin header, so it is allowed
 # implicitly by the worker. Demo mode (github.io) has instrumentation disabled
 # and intentionally is not listed here. Localhost origins are matched by

--- a/workers/subscribe/README.md
+++ b/workers/subscribe/README.md
@@ -36,11 +36,11 @@ Cloudflare Worker + D1 for newsletter signup collection.
    npx wrangler deploy --config workers/subscribe/wrangler.toml
    ```
 
-6. Add a custom domain in Cloudflare:
-
-   - Worker: `myradone-subscribe`
-   - Domain: `api.myradone.com`
-   - Path: `/subscribe`
+6. The route is config-managed per
+   [`docs/decisions/013-worker-routing-as-code.md`](../../docs/decisions/013-worker-routing-as-code.md)
+   and is applied on `wrangler deploy`. Do not add or edit the
+   `api.myradone.com/subscribe` route manually in the Cloudflare dashboard
+   unless you are making an emergency override that will be reconciled in a PR.
 
 7. Replace the test Turnstile site key in `design/brand/landing.html` with the production site key before launch.
 

--- a/workers/subscribe/wrangler.toml
+++ b/workers/subscribe/wrangler.toml
@@ -4,6 +4,10 @@ compatibility_date = "2026-04-07"
 workers_dev = false
 preview_urls = false
 
+[[routes]]
+pattern = "api.myradone.com/subscribe"
+zone_name = "myradone.com"
+
 [vars]
 ALLOWED_ORIGINS = "https://myradone.com,https://www.myradone.com,https://divergent.health,https://www.divergent.health"
 


### PR DESCRIPTION
## Summary
- add repo-managed `[[routes]]` entries for `subscribe` and `stats`
- normalize `download` from inline `routes = [...]` to ADR 013's `[[routes]]` form
- update the `subscribe` and `stats` READMEs plus ADR 013 migration notes to reflect repo-managed routing

## Why
ADR 013 set the policy that Worker routes live in `wrangler.toml` using the `[[routes]]` table-array form. PR #90 applied that to `dashboard`, but `subscribe` and `stats` were still dashboard-managed in tracked config and `download` was still using the older inline syntax.

This PR brings the remaining worker configs/docs into the ADR 013 shape so the repo is consistent.

## Notes
- `stats` is still not deploy-ready from tracked config because its D1 and rate-limit IDs remain placeholders; this PR only adds the route declaration and doc cleanup.
- The `subscribe` route pattern here is based on the existing tracked docs (`api.myradone.com/subscribe`). Please verify the live Cloudflare route matches before deploy/merge so the config reconciles exactly.

## Validation
- `npx wrangler deploy --dry-run --config workers/subscribe/wrangler.toml`
- `npx wrangler deploy --dry-run --config workers/download/wrangler.toml`
- `npx wrangler deploy --dry-run --config workers/stats/wrangler.toml`

Closes #91.
