### PR TITLE
[codex] Preserve spaces in library allowed roots

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -33,9 +33,10 @@ DICOM_TEST_DATA="/path/to/dicom/folder" python app.py
 |----------|-------|
 | Purpose | Restrict folders accepted by `/api/library/config` |
 | Default | Unrestricted on loopback, required when `FLASK_HOST=0.0.0.0` |
-| Format | `:`-separated directories on macOS/Linux, `;`-separated on Windows |
+| Format | Platform path separator (`:` on macOS/Linux, `;` on Windows), semicolon, comma, or newline-separated directories |
 
 When the Flask app is exposed on all interfaces with `FLASK_HOST=0.0.0.0`, runtime library-folder changes are rejected unless the requested folder is inside one of these allowed roots.
+Spaces inside directory names are preserved.
 
 **Usage:**
 ```bash

--- a/server/routes/library.py
+++ b/server/routes/library.py
@@ -418,10 +418,9 @@ def _parse_library_allowed_roots(raw_value):
     if not raw_value:
         return []
 
-    # Accept any common separator regardless of platform: colon, semicolon,
-    # comma, newline, or whitespace. A user copying config between macOS and
-    # Windows shouldn't silently get an empty allow-list.
-    return [item.strip() for item in re.split(r'[:;,\s]+', raw_value) if item.strip()]
+    separators = tuple(dict.fromkeys((os.pathsep, ';', ',', '\n')))
+    pattern = '|'.join(re.escape(separator) for separator in separators)
+    return [item.strip() for item in re.split(pattern, raw_value) if item.strip()]
 
 
 def _get_library_allowed_roots():

--- a/tests/hardening-pass.spec.js
+++ b/tests/hardening-pass.spec.js
@@ -107,8 +107,12 @@ def validate(path):
     return {'allowed': allowed, 'error': error, 'status': status}
 
 try:
-    allowed_root = tempfile.mkdtemp(prefix='dicom-allowed-root-')
+    allowed_root = tempfile.mkdtemp(prefix='dicom allowed root ')
     allowed_child = os.path.join(allowed_root, 'incoming')
+    second_allowed_root = tempfile.mkdtemp(prefix='dicom second allowed root ')
+    second_allowed_child = os.path.join(second_allowed_root, 'incoming')
+    semicolon_allowed_root = tempfile.mkdtemp(prefix='dicom semicolon allowed root ')
+    semicolon_allowed_child = os.path.join(semicolon_allowed_root, 'incoming')
     outside_root = tempfile.mkdtemp(prefix='dicom-outside-root-')
 
     os.environ['FLASK_HOST'] = '127.0.0.1'
@@ -119,8 +123,12 @@ try:
     os.environ.pop(library_module.LIBRARY_ALLOWED_ROOTS_ENV, None)
     exposed_without_roots = validate(allowed_child)
 
-    os.environ[library_module.LIBRARY_ALLOWED_ROOTS_ENV] = allowed_root
+    os.environ[library_module.LIBRARY_ALLOWED_ROOTS_ENV] = (
+        f'{allowed_root}{os.pathsep}{second_allowed_root};{semicolon_allowed_root}'
+    )
     exposed_allowed = validate(allowed_child)
+    exposed_second_allowed = validate(second_allowed_child)
+    exposed_semicolon_allowed = validate(semicolon_allowed_child)
     exposed_outside = validate(outside_root)
 finally:
     restore_env()
@@ -129,6 +137,8 @@ print(json.dumps({
     'loopback': loopback,
     'exposed_without_roots': exposed_without_roots,
     'exposed_allowed': exposed_allowed,
+    'exposed_second_allowed': exposed_second_allowed,
+    'exposed_semicolon_allowed': exposed_semicolon_allowed,
     'exposed_outside': exposed_outside,
 }))
         `);
@@ -140,6 +150,8 @@ print(json.dumps({
         });
         expect(result.exposed_without_roots.error).toContain('DICOM_LIBRARY_ALLOWED_ROOTS');
         expect(result.exposed_allowed).toEqual({ allowed: true, error: null, status: null });
+        expect(result.exposed_second_allowed).toEqual({ allowed: true, error: null, status: null });
+        expect(result.exposed_semicolon_allowed).toEqual({ allowed: true, error: null, status: null });
         expect(result.exposed_outside).toMatchObject({
             allowed: false,
             status: 403,


### PR DESCRIPTION
## Summary
- Preserve spaces inside `DICOM_LIBRARY_ALLOWED_ROOTS` path entries
- Keep splitting allowed roots on the platform path separator, comma, or newline
- Add a regression case with a space-containing allowed root and update config docs

## Root Cause
The previous parser treated all whitespace as a separator. That broke valid filesystem paths containing spaces, so an allowed root like `/Users/gabriel/claude 0/...` was split into invalid fragments and rejected as outside the allowlist.

## Validation
- Focused Playwright regression: `network-exposed library config requires an allowed root`
- `python -m py_compile server/routes/library.py`
- `./scripts/run-ruff.sh format --check server/routes/library.py`
- `./scripts/run-ruff.sh check server/routes/library.py`
- `node --check tests/hardening-pass.spec.js`
- `git diff --check`