### PR TITLE
Clarify myradone-stats provisioning comments

### DIFF
--- a/workers/stats/wrangler.toml
+++ b/workers/stats/wrangler.toml
@@ -18,15 +18,13 @@ ALLOWED_ORIGINS = "https://myradone.com,https://www.myradone.com"
 [[d1_databases]]
 binding = "DB"
 database_name = "myradone-stats"
-# Placeholder: the deployer must create the D1 database with
-#   npx wrangler d1 create myradone-stats
-# and paste the returned UUID here before running `wrangler deploy`.
+# Provisioned with `npx wrangler d1 create myradone-stats` in region ENAM.
 database_id = "5f9d6a5b-ef20-4a4d-8600-972ecebb690e"
 
 [[ratelimits]]
 name = "STATS_RATE_LIMIT"
-# Placeholder: create a new rate-limit namespace in the Cloudflare dashboard
-# (or let `wrangler deploy` provision it) and paste the numeric ID here.
+# Dedicated stats-worker rate-limit namespace, following the YYYYMMDDNN
+# convention used by the subscribe and dashboard worker configs.
 namespace_id = "2026050101"
 
   [ratelimits.simple]


### PR DESCRIPTION
## Summary
- replace stale placeholder comments in workers/stats/wrangler.toml with post-provisioning documentation
- note that the D1 database was provisioned in ENAM
- clarify that the stats rate-limit namespace follows the existing YYYYMMDDNN convention

## Verification
- git diff --check
- npx wrangler deploy --dry-run

No production deploy or merge performed.