### PR TITLE
Clarify allowed roots separator behavior

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,6 +37,7 @@ DICOM_TEST_DATA="/path/to/dicom/folder" python app.py
 
 When the Flask app is exposed on all interfaces with `FLASK_HOST=0.0.0.0`, runtime library-folder changes are rejected unless the requested folder is inside one of these allowed roots.
 Spaces inside directory names are preserved.
+On Windows, use semicolon, comma, or newline between roots; colon is not treated as a separator because it appears in drive-letter paths.
 
 **Usage:**
 ```bash

--- a/server/routes/library.py
+++ b/server/routes/library.py
@@ -418,7 +418,7 @@ def _parse_library_allowed_roots(raw_value):
     if not raw_value:
         return []
 
-    separators = tuple(dict.fromkeys((os.pathsep, ';', ',', '\n')))
+    separators = (os.pathsep, ';', ',', '\n')
     pattern = '|'.join(re.escape(separator) for separator in separators)
     return [item.strip() for item in re.split(pattern, raw_value) if item.strip()]
 

--- a/tests/hardening-pass.spec.js
+++ b/tests/hardening-pass.spec.js
@@ -113,6 +113,7 @@ try:
     second_allowed_child = os.path.join(second_allowed_root, 'incoming')
     semicolon_allowed_root = tempfile.mkdtemp(prefix='dicom semicolon allowed root ')
     semicolon_allowed_child = os.path.join(semicolon_allowed_root, 'incoming')
+    flanked_allowed_root = tempfile.mkdtemp(prefix='dicom flanked allowed root ')
     outside_root = tempfile.mkdtemp(prefix='dicom-outside-root-')
 
     os.environ['FLASK_HOST'] = '127.0.0.1'
@@ -130,6 +131,9 @@ try:
     exposed_second_allowed = validate(second_allowed_child)
     exposed_semicolon_allowed = validate(semicolon_allowed_child)
     exposed_outside = validate(outside_root)
+    parsed_flanked_roots = library_module._parse_library_allowed_roots(
+        f'{outside_root},{flanked_allowed_root},{semicolon_allowed_root}'
+    )
 finally:
     restore_env()
 
@@ -140,6 +144,8 @@ print(json.dumps({
     'exposed_second_allowed': exposed_second_allowed,
     'exposed_semicolon_allowed': exposed_semicolon_allowed,
     'exposed_outside': exposed_outside,
+    'parsed_flanked_roots': parsed_flanked_roots,
+    'flanked_allowed_root': flanked_allowed_root,
 }))
         `);
 
@@ -152,6 +158,8 @@ print(json.dumps({
         expect(result.exposed_allowed).toEqual({ allowed: true, error: null, status: null });
         expect(result.exposed_second_allowed).toEqual({ allowed: true, error: null, status: null });
         expect(result.exposed_semicolon_allowed).toEqual({ allowed: true, error: null, status: null });
+        expect(result.parsed_flanked_roots).toHaveLength(3);
+        expect(result.parsed_flanked_roots[1]).toBe(result.flanked_allowed_root);
         expect(result.exposed_outside).toMatchObject({
             allowed: false,
             status: 403,


### PR DESCRIPTION
## Summary
- document that Windows allowed-root lists should use semicolon, comma, or newline, not colon
- add an explicit regression assertion that a space-containing root parses correctly when flanked by separators
- simplify the allowed-root separator tuple; duplicate semicolon alternatives on Windows are harmless

## Verification
- python3 -m py_compile server/routes/library.py
- node --check tests/hardening-pass.spec.js
- ./scripts/run-ruff.sh check server/routes/library.py
- ./scripts/run-ruff.sh format --check server/routes/library.py
- direct parser regression with a flanked space-containing root

No merge performed.