### PR TITLE
Allow Tauri desktop origins for stats CORS

### DIFF
--- a/tests/stats-worker.test.mjs
+++ b/tests/stats-worker.test.mjs
@@ -264,7 +264,12 @@ test('handleStats: OPTIONS returns 204 for CORS preflight', async () => {
 
 test('handleStats: Tauri desktop origins are allowed for CORS preflight', async () => {
     const env = createEnv();
-    for (const origin of ['tauri://localhost', 'http://tauri.localhost', 'https://tauri.localhost']) {
+    for (const origin of [
+        'tauri://localhost',
+        'tauri://localhost:1430',
+        'http://tauri.localhost',
+        'https://tauri.localhost'
+    ]) {
         const request = createRequest(undefined, { method: 'OPTIONS', origin });
         const response = await handleStats(request, env);
         assert.equal(response.status, 204, `${origin} preflight should be allowed`);
@@ -320,7 +325,12 @@ test('handleStats: localhost origins are allowed', async () => {
 
 test('handleStats: Tauri desktop origins are allowed for POST', async () => {
     const env = createEnv();
-    for (const origin of ['tauri://localhost', 'http://tauri.localhost', 'https://tauri.localhost']) {
+    for (const origin of [
+        'tauri://localhost',
+        'tauri://localhost:1430',
+        'http://tauri.localhost',
+        'https://tauri.localhost'
+    ]) {
         const response = await handleStats(createRequest(validPayload(), { origin }), env);
         assert.equal(response.status, 200, `${origin} should be allowed`);
         assert.equal(response.headers.get('Access-Control-Allow-Origin'), origin);

--- a/tests/stats-worker.test.mjs
+++ b/tests/stats-worker.test.mjs
@@ -262,6 +262,16 @@ test('handleStats: OPTIONS returns 204 for CORS preflight', async () => {
     assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://myradone.com');
 });
 
+test('handleStats: Tauri desktop origins are allowed for CORS preflight', async () => {
+    const env = createEnv();
+    for (const origin of ['tauri://localhost', 'http://tauri.localhost', 'https://tauri.localhost']) {
+        const request = createRequest(undefined, { method: 'OPTIONS', origin });
+        const response = await handleStats(request, env);
+        assert.equal(response.status, 204, `${origin} preflight should be allowed`);
+        assert.equal(response.headers.get('Access-Control-Allow-Origin'), origin);
+    }
+});
+
 test('handleStats: unknown path returns 404', async () => {
     const env = createEnv();
     const response = await handleStats(createRequest(validPayload(), { path: '/api/other' }), env);
@@ -308,7 +318,16 @@ test('handleStats: localhost origins are allowed', async () => {
     }
 });
 
-test('handleStats: no Origin header is allowed (Tauri desktop case)', async () => {
+test('handleStats: Tauri desktop origins are allowed for POST', async () => {
+    const env = createEnv();
+    for (const origin of ['tauri://localhost', 'http://tauri.localhost', 'https://tauri.localhost']) {
+        const response = await handleStats(createRequest(validPayload(), { origin }), env);
+        assert.equal(response.status, 200, `${origin} should be allowed`);
+        assert.equal(response.headers.get('Access-Control-Allow-Origin'), origin);
+    }
+});
+
+test('handleStats: no Origin header is allowed', async () => {
     const env = createEnv();
     const response = await handleStats(createRequest(validPayload()), env);
     assert.equal(response.status, 200);

--- a/workers/stats/README.md
+++ b/workers/stats/README.md
@@ -95,8 +95,8 @@ CORS is a defense-in-depth check only -- the payload has no PHI, no
 credentials, and no authentication. The worker allows:
 
 - Requests with **no Origin** header (curl, same-origin, some Tauri builds)
-- Packaged Tauri desktop origins: `tauri://localhost`,
-  `http://tauri.localhost`, and `https://tauri.localhost`
+- Packaged Tauri desktop origins: `tauri://localhost`, optionally with a
+  port, plus `http://tauri.localhost` and `https://tauri.localhost`
 - `http://localhost:*` and `http://127.0.0.1:*` (pattern matched)
 - Origins in `ALLOWED_ORIGINS` (from `wrangler.toml [vars]`), currently
   `https://myradone.com` and `https://www.myradone.com`

--- a/workers/stats/README.md
+++ b/workers/stats/README.md
@@ -94,7 +94,9 @@ different value.
 CORS is a defense-in-depth check only -- the payload has no PHI, no
 credentials, and no authentication. The worker allows:
 
-- Requests with **no Origin** header (Tauri desktop, curl, same-origin)
+- Requests with **no Origin** header (curl, same-origin, some Tauri builds)
+- Packaged Tauri desktop origins: `tauri://localhost`,
+  `http://tauri.localhost`, and `https://tauri.localhost`
 - `http://localhost:*` and `http://127.0.0.1:*` (pattern matched)
 - Origins in `ALLOWED_ORIGINS` (from `wrangler.toml [vars]`), currently
   `https://myradone.com` and `https://www.myradone.com`

--- a/workers/stats/src/index.mjs
+++ b/workers/stats/src/index.mjs
@@ -41,7 +41,7 @@ const ALLOWED_PAYLOAD_FIELDS = new Set([
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 const LOCALHOST_ORIGIN_PATTERN = /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/;
-const TAURI_ORIGIN_PATTERN = /^(?:tauri:\/\/localhost|https?:\/\/tauri\.localhost(?::\d+)?)$/;
+const TAURI_ORIGIN_PATTERN = /^(?:tauri:\/\/localhost(?::\d+)?|https?:\/\/tauri\.localhost(?::\d+)?)$/;
 
 // =====================================================================
 // CORS / HEADERS

--- a/workers/stats/src/index.mjs
+++ b/workers/stats/src/index.mjs
@@ -15,9 +15,9 @@
 export const STATS_PATH = '/api/stats';
 export const SCHEMA_VERSION = 1;
 
-// Origins configured in wrangler.toml [vars]. Tauri desktop sends no Origin
-// header and is allowed implicitly. Localhost origins are matched by pattern
-// at request time (see isOriginAllowed).
+// Origins configured in wrangler.toml [vars]. Some Tauri desktop requests send
+// no Origin and are allowed implicitly; packaged WKWebView builds can also send
+// Tauri-specific origins, which are matched by pattern at request time.
 const DEFAULT_ALLOWED_ORIGINS = [
     'https://myradone.com',
     'https://www.myradone.com'
@@ -41,6 +41,7 @@ const ALLOWED_PAYLOAD_FIELDS = new Set([
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 const LOCALHOST_ORIGIN_PATTERN = /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/;
+const TAURI_ORIGIN_PATTERN = /^(?:tauri:\/\/localhost|https?:\/\/tauri\.localhost(?::\d+)?)$/;
 
 // =====================================================================
 // CORS / HEADERS
@@ -61,6 +62,7 @@ function isOriginAllowed(origin, env) {
     // defense-in-depth check rather than a security boundary.
     if (!origin) return true;
     if (LOCALHOST_ORIGIN_PATTERN.test(origin)) return true;
+    if (TAURI_ORIGIN_PATTERN.test(origin)) return true;
     return parseAllowedOrigins(env.ALLOWED_ORIGINS).has(origin);
 }
 


### PR DESCRIPTION
## Summary
- diagnose deployed stats worker CORS behavior for likely packaged Tauri origins
- allow Tauri desktop origins (`tauri://localhost`, optional `tauri://localhost:<port>`, `http://tauri.localhost`, `https://tauri.localhost`) in stats worker CORS checks
- add preflight and POST unit coverage for those origins, including the ported custom-protocol form
- update the stats worker README CORS notes

## Diagnosis
Live worker preflight simulation showed `OPTIONS /api/stats` for Tauri-style origins returned `204` without `Access-Control-Allow-Origin`, while localhost and `https://myradone.com` returned the header. Direct POSTs with Tauri-style `Origin` values returned `403 {"error":"Origin not allowed"}`. This matches the desktop phone-home symptom: the browser preflight blocks the POST before D1 sees data.

The installed `/Applications/myradone.app` is hardened but not sandboxed: `codesign -d --entitlements :-` shows only `com.apple.security.cs.allow-jit`, and `codesign -dvv` shows `flags=0x10000(runtime)`. So `com.apple.security.network.client` is not the current fix.

## Verification
- `node --test tests/stats-worker.test.mjs` (25/25 passing)
- `npx wrangler deploy --dry-run` from `workers/stats`
- `git diff --check`
- deleted synthetic install id `99999999-aaaa-4bbb-8ccc-dddddddddddd` from remote D1 and verified `COUNT(*) = 0`

## Notes
- No deployment performed from this PR.
