### PR TITLE
Add dashboard stats tab

### DIFF
--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -9,13 +9,18 @@ import {
     SESSION_PATH,
     SUMMARY_PATH,
     SUBSCRIBERS_PATH,
+    STATS_INSTALLS_PATH,
+    STATS_SUMMARY_PATH,
     authenticate,
     createSignedSessionValue,
     createErrorResponse,
     dispatchRequest,
     handleDashboard,
+    handleStatsInstalls,
+    handleStatsSummary,
     handleSubscribers,
     handleSummary,
+    readonlySelect,
     verifySignedSessionValue
 } from '../workers/dashboard/src/lib.mjs';
 
@@ -41,18 +46,87 @@ function sha256Hex(value) {
 }
 
 function createEnv(options = {}) {
-    const { subscribers = [], rateLimitSuccess = true } = options;
+    const { subscribers = [], installs = [], rateLimitSuccess = true } = options;
     const token = Object.prototype.hasOwnProperty.call(options, 'token') ? options.token : VALID_TEST_TOKEN;
 
     return {
         DASHBOARD_TOKEN: token,
+        NOW: options.now,
         DASHBOARD_RATE_LIMIT: {
             async limit() {
                 return { success: rateLimitSuccess };
             }
         },
-        SUBSCRIBERS_DB: createDb(subscribers)
+        SUBSCRIBERS_DB: createDb(subscribers),
+        STATS_DB: createStatsDb(installs)
     };
+}
+
+function createStatsDb(initialInstalls) {
+    const installs = initialInstalls.map((install, index) => {
+        const statsJson = Object.prototype.hasOwnProperty.call(install, 'statsJson')
+            ? install.statsJson
+            : JSON.stringify({
+                sessions: install.sessions ?? 0,
+                studiesImported: install.studiesImported ?? 0
+            });
+
+        return {
+            install_id: install.installationId,
+            revision: install.revision ?? index,
+            first_seen: install.firstSeen ?? '2026-04-12T00:00:00.000Z',
+            last_seen: install.lastSeen ?? '2026-04-12T00:00:00.000Z',
+            created_at: install.createdAt ?? '2026-04-12T00:00:00.000Z',
+            stats_json: statsJson,
+            version: install.version ?? 1
+        };
+    });
+
+    const db = {
+        recordedQueries: [],
+        directPrepareCalls: [],
+        prepare(query) {
+            if (!this.__readonlySelectActive) {
+                this.directPrepareCalls.push(query);
+            }
+            this.recordedQueries.push(query);
+            return {
+                args: [],
+                bind(...args) {
+                    this.args = args;
+                    return this;
+                },
+                async first() {
+                    if (query.includes('COUNT(*) AS installs_total')) {
+                        return buildStatsTotals(installs, this.args);
+                    }
+
+                    if (query.startsWith('SELECT COUNT(*) AS total FROM installs')) {
+                        return { total: installs.length };
+                    }
+
+                    throw new Error(`Unhandled stats first() query: ${query}`);
+                },
+                async all() {
+                    if (query.startsWith('WITH RECURSIVE days(day) AS')) {
+                        return { results: buildInstallDailyRows(installs, this.args) };
+                    }
+
+                    if (query.includes('SELECT') && query.includes('install_id') && query.includes('FROM installs')) {
+                        const [limit, offset] = this.args;
+                        const { column, direction } = extractInstallSort(query);
+                        const rows = installs.map(normalizeStatsRecord);
+                        rows.sort((left, right) => compareInstallRows(left, right, column, direction));
+                        return { results: rows.slice(offset, offset + limit) };
+                    }
+
+                    throw new Error(`Unhandled stats all() query: ${query}`);
+                }
+            };
+        }
+    };
+
+    return db;
 }
 
 function createDb(initialSubscribers) {
@@ -170,6 +244,93 @@ function compareRows(left, right, column, direction) {
     if (leftValue > rightValue) return 1 * factor;
 
     return (left.id - right.id) * factor;
+}
+
+function parseStatsJson(statsJson) {
+    try {
+        const parsed = JSON.parse(statsJson);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function nonNegativeInteger(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 0;
+}
+
+function normalizeStatsRecord(row) {
+    const stats = parseStatsJson(row.stats_json);
+    return {
+        install_id: row.install_id,
+        first_seen: row.first_seen,
+        last_seen: row.last_seen,
+        revision: row.revision,
+        sessions: nonNegativeInteger(stats.sessions),
+        studies_imported: nonNegativeInteger(stats.studiesImported),
+        version: row.version
+    };
+}
+
+function buildStatsTotals(installs, args) {
+    const [active24hSince, active7dSince, active30dSince] = args;
+    return installs.reduce(
+        (totals, row) => {
+            const stats = parseStatsJson(row.stats_json);
+            totals.installs_total += 1;
+            totals.active_24h += Date.parse(row.last_seen) >= Date.parse(active24hSince) ? 1 : 0;
+            totals.active_7d += Date.parse(row.last_seen) >= Date.parse(active7dSince) ? 1 : 0;
+            totals.active_30d += Date.parse(row.last_seen) >= Date.parse(active30dSince) ? 1 : 0;
+            totals.sessions_total += nonNegativeInteger(stats.sessions);
+            totals.studies_total += nonNegativeInteger(stats.studiesImported);
+            return totals;
+        },
+        {
+            installs_total: 0,
+            active_24h: 0,
+            active_7d: 0,
+            active_30d: 0,
+            sessions_total: 0,
+            studies_total: 0
+        }
+    );
+}
+
+function buildInstallDailyRows(installs, args) {
+    const [startDay, todayDay] = args;
+    const counts = new Map();
+    for (const install of installs) {
+        const day = new Date(install.created_at).toISOString().slice(0, 10);
+        counts.set(day, (counts.get(day) || 0) + 1);
+    }
+
+    const today = new Date(`${todayDay}T00:00:00.000Z`);
+    const start = new Date(`${startDay}T00:00:00.000Z`);
+    const rows = [];
+    for (const date = new Date(start); date <= today; date.setUTCDate(date.getUTCDate() + 1)) {
+        const day = date.toISOString().slice(0, 10);
+        rows.push({ day, count: counts.get(day) || 0 });
+    }
+    return rows;
+}
+
+function extractInstallSort(query) {
+    const match = query.match(/ORDER BY ([a-z_]+) (ASC|DESC), install_id (ASC|DESC)/i);
+    return {
+        column: match ? match[1] : 'last_seen',
+        direction: match ? match[2].toLowerCase() : 'desc'
+    };
+}
+
+function compareInstallRows(left, right, column, direction) {
+    const factor = direction === 'asc' ? 1 : -1;
+    const leftValue = left[column];
+    const rightValue = right[column];
+
+    if (leftValue < rightValue) return -1 * factor;
+    if (leftValue > rightValue) return 1 * factor;
+    return left.install_id.localeCompare(right.install_id) * factor;
 }
 
 function buildDailyRows(subscribers) {
@@ -295,6 +456,97 @@ test('handleSummary returns empty shapes on an empty database', async () => {
     assert.equal(payload.daily.length, 30);
 });
 
+test('handleStatsSummary returns zero shape and 30 UTC days on an empty database', async () => {
+    const env = createEnv({ installs: [] });
+    const payload = await handleStatsSummary(env, { now: '2026-05-02T15:45:00.000Z' });
+
+    assert.deepEqual(payload.installs, {
+        total: 0,
+        active_24h: 0,
+        active_7d: 0,
+        active_30d: 0
+    });
+    assert.deepEqual(payload.sessions, { total: 0 });
+    assert.deepEqual(payload.studies, { total: 0 });
+    assert.equal(payload.new_installs_daily.length, 30);
+    assert.equal(payload.new_installs_daily.at(0).day, '2026-04-03');
+    assert.equal(payload.new_installs_daily.at(-1).day, '2026-05-02');
+    assert.deepEqual(payload.new_installs_daily.map((row) => row.count), Array(30).fill(0));
+    assert.deepEqual(
+        [...payload.new_installs_daily].sort((left, right) => left.day.localeCompare(right.day)),
+        payload.new_installs_daily
+    );
+});
+
+test('handleStatsSummary aggregates seeded installs defensively', async () => {
+    const env = createEnv({
+        installs: [
+            {
+                installationId: '11111111-1111-4111-8111-111111111111',
+                revision: 3,
+                firstSeen: '2026-04-01T00:00:00.000Z',
+                lastSeen: '2026-05-02T10:00:00.000Z',
+                createdAt: '2026-04-01T00:00:00.000Z',
+                sessions: 4,
+                studiesImported: 10,
+                version: 1
+            },
+            {
+                installationId: '22222222-2222-4222-8222-222222222222',
+                revision: 5,
+                firstSeen: '2026-03-01T00:00:00.000Z',
+                lastSeen: '2026-04-29T10:00:00.000Z',
+                createdAt: '2026-05-01T04:00:00.000Z',
+                sessions: 7,
+                studiesImported: 2,
+                version: 1
+            },
+            {
+                installationId: '33333333-3333-4333-8333-333333333333',
+                revision: 9,
+                firstSeen: '2026-05-02T00:00:00.000Z',
+                lastSeen: '2026-03-01T00:00:00.000Z',
+                createdAt: '2026-05-02T03:00:00.000Z',
+                statsJson: '{malformed-json',
+                version: 2
+            }
+        ]
+    });
+
+    const payload = await handleStatsSummary(env, { now: '2026-05-02T12:00:00.000Z' });
+
+    assert.deepEqual(payload.installs, {
+        total: 3,
+        active_24h: 1,
+        active_7d: 2,
+        active_30d: 2
+    });
+    assert.deepEqual(payload.sessions, { total: 11 });
+    assert.deepEqual(payload.studies, { total: 12 });
+    assert.equal(payload.new_installs_daily.find((row) => row.day === '2026-05-01').count, 1);
+    assert.equal(payload.new_installs_daily.find((row) => row.day === '2026-05-02').count, 1);
+});
+
+test('new installs daily uses created_at rather than first_seen', async () => {
+    const env = createEnv({
+        installs: [
+            {
+                installationId: '44444444-4444-4444-8444-444444444444',
+                firstSeen: '2026-05-02T11:00:00.000Z',
+                lastSeen: '2026-05-02T11:00:00.000Z',
+                createdAt: '2026-04-20T03:00:00.000Z',
+                sessions: 1,
+                studiesImported: 1
+            }
+        ]
+    });
+
+    const payload = await handleStatsSummary(env, { now: '2026-05-02T12:00:00.000Z' });
+
+    assert.equal(payload.new_installs_daily.find((row) => row.day === '2026-04-20').count, 1);
+    assert.equal(payload.new_installs_daily.find((row) => row.day === '2026-05-02').count, 0);
+});
+
 test('handleSubscribers rejects invalid filters and sort params', async () => {
     const env = createEnv();
 
@@ -362,6 +614,86 @@ test('handleSubscribers paginates and sorts seeded subscribers', async () => {
     assert.equal(payload.pagination.total_pages, 2);
 });
 
+test('handleStatsInstalls paginates, sorts, and redacts install identifiers', async () => {
+    const fullId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const env = createEnv({
+        installs: [
+            {
+                installationId: fullId,
+                revision: 1,
+                firstSeen: '2026-04-01T01:00:00.000Z',
+                lastSeen: '2026-05-01T01:00:00.000Z',
+                sessions: 9,
+                studiesImported: 3,
+                version: 1
+            },
+            {
+                installationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+                revision: 2,
+                firstSeen: '2026-04-02T01:00:00.000Z',
+                lastSeen: '2026-05-02T01:00:00.000Z',
+                sessions: 2,
+                studiesImported: 4,
+                version: 2
+            },
+            {
+                installationId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+                revision: 3,
+                firstSeen: '2026-04-03T01:00:00.000Z',
+                lastSeen: '2026-04-30T01:00:00.000Z',
+                sessions: 5,
+                studiesImported: 6,
+                version: 1
+            }
+        ]
+    });
+
+    const payload = await handleStatsInstalls(
+        createRequest(`${STATS_INSTALLS_PATH}?sort=sessions&order=desc&per_page=2&page=1`),
+        env
+    );
+    const serialized = JSON.stringify(payload);
+
+    assert.equal(payload.installs.length, 2);
+    assert.equal(payload.installs[0].install_id_prefix, 'aaaaaaaa');
+    assert.equal(payload.installs[0].install_id_prefix.length, 8);
+    assert.equal(payload.installs[0].sessions, 9);
+    assert.equal(payload.installs[0].version, 1);
+    assert.deepEqual(payload.pagination, {
+        page: 1,
+        per_page: 2,
+        total: 3,
+        total_pages: 2
+    });
+    assert.doesNotMatch(serialized, new RegExp(fullId));
+    assert.doesNotMatch(serialized, /installationId/);
+    assert.doesNotMatch(serialized, /install_id"/);
+});
+
+test('handleStatsInstalls returns field-specific 400 payloads for invalid params', async () => {
+    const env = createEnv();
+    const cases = [
+        [`${STATS_INSTALLS_PATH}?page=0`, 'page'],
+        [`${STATS_INSTALLS_PATH}?per_page=200`, 'per_page'],
+        [`${STATS_INSTALLS_PATH}?sort=unknown`, 'sort'],
+        [`${STATS_INSTALLS_PATH}?order=sideways`, 'order']
+    ];
+
+    for (const [path, field] of cases) {
+        let response = null;
+        const request = createRequest(path, { token: VALID_TEST_TOKEN });
+        try {
+            await handleStatsInstalls(request, env);
+        } catch (error) {
+            response = await createErrorResponse(request, error);
+        }
+
+        assert.ok(response);
+        assert.equal(response.status, 400);
+        assert.equal((await response.json()).field, field);
+    }
+});
+
 test('dispatchRequest returns 401 for unauthenticated API requests and 429 when rate-limited', async () => {
     const env = createEnv();
 
@@ -373,6 +705,16 @@ test('dispatchRequest returns 401 for unauthenticated API requests and 429 when 
     const rateLimitedEnv = createEnv({ rateLimitSuccess: false });
     const rateLimited = await dispatchRequest(createRequest(SUMMARY_PATH), rateLimitedEnv, DASHBOARD_HTML);
     assert.equal(rateLimited.status, 429);
+});
+
+test('dispatchRequest returns 401 for unauthenticated stats endpoints', async () => {
+    const env = createEnv();
+
+    for (const path of [STATS_SUMMARY_PATH, STATS_INSTALLS_PATH]) {
+        const response = await dispatchRequest(createRequest(path), env, DASHBOARD_HTML);
+        assert.equal(response.status, 401);
+        assert.deepEqual(await response.json(), { error: 'Unauthorized' });
+    }
 });
 
 test('dispatchRequest creates and clears dashboard sessions', async () => {
@@ -513,6 +855,100 @@ test('GET /api/config bypasses the dashboard rate limiter', async () => {
 
     assert.equal(response.status, 200);
     assert.equal((await response.json()).status, 'ok');
+});
+
+test('readonlySelect accepts read-only SELECT and WITH forms', async () => {
+    const db = createStatsDb([]);
+    const accepted = [
+        'SELECT 1',
+        'select 1',
+        'SeLeCt 1',
+        'WITH rows AS (SELECT 1) SELECT * FROM rows',
+        '   SELECT 1',
+        '-- leading comment\nSELECT 1',
+        '/* leading block */ SELECT 1'
+    ];
+
+    for (const sql of accepted) {
+        assert.doesNotThrow(() => readonlySelect(db, sql));
+    }
+});
+
+test('readonlySelect rejects mutation keywords, semicolons, and comment-cloaked attacks', async () => {
+    const db = createStatsDb([]);
+    const rejected = [
+        'INSERT INTO installs DEFAULT VALUES',
+        'UPDATE installs SET revision = 1',
+        'DELETE FROM installs',
+        'DROP TABLE installs',
+        'ALTER TABLE installs ADD COLUMN x TEXT',
+        'CREATE TABLE x (id INTEGER)',
+        'TRUNCATE TABLE installs',
+        'REPLACE INTO installs DEFAULT VALUES',
+        'ATTACH DATABASE "x" AS x',
+        'DETACH DATABASE x',
+        'PRAGMA table_info(installs)',
+        'VACUUM',
+        'REINDEX',
+        'SELECT 1; SELECT 2',
+        '/* comment */ UPDATE installs SET revision = 1',
+        'SEL/*comment*/ECT 1',
+        'WITH rows AS (SELECT 1) DELETE FROM installs'
+    ];
+
+    for (const sql of rejected) {
+        assert.throws(() => readonlySelect(db, sql), /readonlySelect/);
+    }
+});
+
+test('stats handlers only access D1 through readonlySelect', async () => {
+    const env = createEnv({
+        installs: [
+            {
+                installationId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+                lastSeen: '2026-05-02T10:00:00.000Z',
+                createdAt: '2026-05-02T10:00:00.000Z',
+                sessions: 1,
+                studiesImported: 1
+            }
+        ]
+    });
+
+    await handleStatsSummary(env, { now: '2026-05-02T12:00:00.000Z' });
+    await handleStatsInstalls(createRequest(STATS_INSTALLS_PATH), env);
+
+    assert.deepEqual(env.STATS_DB.directPrepareCalls, []);
+});
+
+test('stats aggregate queries are independently read-only valid', async () => {
+    const env = createEnv({
+        installs: [
+            {
+                installationId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+                lastSeen: '2026-05-02T10:00:00.000Z',
+                createdAt: '2026-05-02T10:00:00.000Z',
+                sessions: 1,
+                studiesImported: 1
+            }
+        ]
+    });
+
+    await handleStatsSummary(env, { now: '2026-05-02T12:00:00.000Z' });
+
+    for (const sql of env.STATS_DB.recordedQueries) {
+        const validationDb = {
+            prepare() {
+                return {
+                    bind() {
+                        return this;
+                    },
+                    first() {},
+                    all() {}
+                };
+            }
+        };
+        assert.doesNotThrow(() => readonlySelect(validationDb, sql));
+    }
 });
 
 test('tampered dashboard cookies fall back to login and get cleared', async () => {

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -84,11 +84,7 @@ function createStatsDb(initialInstalls) {
 
     const db = {
         recordedQueries: [],
-        directPrepareCalls: [],
         prepare(query) {
-            if (!this.__readonlySelectActive) {
-                this.directPrepareCalls.push(query);
-            }
             this.recordedQueries.push(query);
             return {
                 args: [],
@@ -139,7 +135,7 @@ function createDb(initialSubscribers) {
         consent_version: subscriber.consent_version ?? 'v1'
     }));
 
-    return {
+    const db = {
         prepare(query) {
             return {
                 args: [],
@@ -200,6 +196,8 @@ function createDb(initialSubscribers) {
             };
         }
     };
+
+    return db;
 }
 
 function filterSubscribers(query, args, subscribers) {
@@ -268,8 +266,7 @@ function normalizeStatsRecord(row) {
         last_seen: row.last_seen,
         revision: row.revision,
         sessions: nonNegativeInteger(stats.sessions),
-        studies_imported: nonNegativeInteger(stats.studiesImported),
-        version: row.version
+        studies_imported: nonNegativeInteger(stats.studiesImported)
     };
 }
 
@@ -488,8 +485,7 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
                 lastSeen: '2026-05-02T10:00:00.000Z',
                 createdAt: '2026-04-01T00:00:00.000Z',
                 sessions: 4,
-                studiesImported: 10,
-                version: 1
+                studiesImported: 10
             },
             {
                 installationId: '22222222-2222-4222-8222-222222222222',
@@ -498,8 +494,7 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
                 lastSeen: '2026-04-29T10:00:00.000Z',
                 createdAt: '2026-05-01T04:00:00.000Z',
                 sessions: 7,
-                studiesImported: 2,
-                version: 1
+                studiesImported: 2
             },
             {
                 installationId: '33333333-3333-4333-8333-333333333333',
@@ -507,8 +502,7 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
                 firstSeen: '2026-05-02T00:00:00.000Z',
                 lastSeen: '2026-03-01T00:00:00.000Z',
                 createdAt: '2026-05-02T03:00:00.000Z',
-                statsJson: '{malformed-json',
-                version: 2
+                statsJson: '{malformed-json'
             }
         ]
     });
@@ -624,8 +618,7 @@ test('handleStatsInstalls paginates, sorts, and redacts install identifiers', as
                 firstSeen: '2026-04-01T01:00:00.000Z',
                 lastSeen: '2026-05-01T01:00:00.000Z',
                 sessions: 9,
-                studiesImported: 3,
-                version: 1
+                studiesImported: 3
             },
             {
                 installationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
@@ -633,8 +626,7 @@ test('handleStatsInstalls paginates, sorts, and redacts install identifiers', as
                 firstSeen: '2026-04-02T01:00:00.000Z',
                 lastSeen: '2026-05-02T01:00:00.000Z',
                 sessions: 2,
-                studiesImported: 4,
-                version: 2
+                studiesImported: 4
             },
             {
                 installationId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
@@ -642,8 +634,7 @@ test('handleStatsInstalls paginates, sorts, and redacts install identifiers', as
                 firstSeen: '2026-04-03T01:00:00.000Z',
                 lastSeen: '2026-04-30T01:00:00.000Z',
                 sessions: 5,
-                studiesImported: 6,
-                version: 1
+                studiesImported: 6
             }
         ]
     });
@@ -658,7 +649,7 @@ test('handleStatsInstalls paginates, sorts, and redacts install identifiers', as
     assert.equal(payload.installs[0].install_id_prefix, 'aaaaaaaa');
     assert.equal(payload.installs[0].install_id_prefix.length, 8);
     assert.equal(payload.installs[0].sessions, 9);
-    assert.equal(payload.installs[0].version, 1);
+    assert.equal(Object.hasOwn(payload.installs[0], 'version'), false);
     assert.deepEqual(payload.pagination, {
         page: 1,
         per_page: 2,
@@ -668,6 +659,7 @@ test('handleStatsInstalls paginates, sorts, and redacts install identifiers', as
     assert.doesNotMatch(serialized, new RegExp(fullId));
     assert.doesNotMatch(serialized, /installationId/);
     assert.doesNotMatch(serialized, /install_id"/);
+    assert.doesNotMatch(serialized, /"version"/);
 });
 
 test('handleStatsInstalls returns field-specific 400 payloads for invalid params', async () => {
@@ -893,6 +885,7 @@ test('readonlySelect rejects mutation keywords, semicolons, and comment-cloaked 
         'SELECT 1; SELECT 2',
         '/* comment */ UPDATE installs SET revision = 1',
         'SEL/*comment*/ECT 1',
+        'ＵＰＤＡＴＥ installs SET revision = 1',
         'WITH rows AS (SELECT 1) DELETE FROM installs'
     ];
 
@@ -901,23 +894,15 @@ test('readonlySelect rejects mutation keywords, semicolons, and comment-cloaked 
     }
 });
 
-test('stats handlers only access D1 through readonlySelect', async () => {
-    const env = createEnv({
-        installs: [
-            {
-                installationId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
-                lastSeen: '2026-05-02T10:00:00.000Z',
-                createdAt: '2026-05-02T10:00:00.000Z',
-                sessions: 1,
-                studiesImported: 1
-            }
-        ]
-    });
+test('dashboard worker routes D1 prepare calls through readonlySelect', () => {
+    const source = fs.readFileSync(new URL('../workers/dashboard/src/lib.mjs', import.meta.url), 'utf8');
+    const prepareMatches = [...source.matchAll(/\.prepare\(/g)];
 
-    await handleStatsSummary(env, { now: '2026-05-02T12:00:00.000Z' });
-    await handleStatsInstalls(createRequest(STATS_INSTALLS_PATH), env);
-
-    assert.deepEqual(env.STATS_DB.directPrepareCalls, []);
+    assert.equal(prepareMatches.length, 1);
+    assert.match(
+        source.slice(Math.max(0, prepareMatches[0].index - 300), prepareMatches[0].index + 300),
+        /function readonlySelect/
+    );
 });
 
 test('stats aggregate queries are independently read-only valid', async () => {

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -1,8 +1,7 @@
-# myRadOne Subscriber Dashboard
+# myRadOne Dashboard
 
-Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
-`myradone-subscribers` D1 database and anonymous install stats from the
-`myradone-stats` D1 database.
+Internal Cloudflare Worker dashboard for viewing subscriber analytics from
+`myradone-subscribers` and anonymous install stats from `myradone-stats`.
 
 ## Files
 
@@ -66,8 +65,8 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
   serve instead of relying on hand-maintained hash constants.
 - `401` API responses include `WWW-Authenticate: Bearer realm="myradone-dashboard"`
   so CLI and browser tooling get a clearer auth signal.
-- D1 access is read-only by convention, not by enforced binding mode. Stats
-  dashboard reads go through `readonlySelect`, which rejects semicolons,
+- D1 access is read-only by convention, not by enforced binding mode. Dashboard
+  D1 reads go through `readonlySelect`, which rejects semicolons,
   mutation/admin keywords, and anything other than `SELECT`/`WITH` after
   stripping SQL comments.
 - Stats API responses never include full install identifiers. The install list
@@ -169,7 +168,7 @@ you want meaningful dashboard output.
 
    ```bash
    npx wrangler d1 execute myradone-stats --local --config workers/dashboard/wrangler.toml \
-     --command "INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen, version) VALUES ('00000000-0000-4000-8000-000000000000', 1, '{\"sessions\":1,\"studiesImported\":2}', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', 1);"
+     --command "INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen) VALUES ('00000000-0000-4000-8000-000000000000', 1, '{\"sessions\":1,\"studiesImported\":2}', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z');"
    ```
 
 7. Run the worker:

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -1,7 +1,8 @@
 # myRadOne Subscriber Dashboard
 
 Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
-`myradone-subscribers` D1 database.
+`myradone-subscribers` D1 database and anonymous install stats from the
+`myradone-stats` D1 database.
 
 ## Files
 
@@ -25,6 +26,10 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
   signup totals.
 - `GET /api/subscribers` - Paginated subscriber list with allowlisted
   filters/sorts.
+- `GET /api/stats/summary` - Aggregate anonymous install, session, study, and
+  30-day new-install totals.
+- `GET /api/stats/installs` - Paginated anonymous install snapshots. Install
+  identifiers are truncated to an 8-character prefix.
 
 `/api/subscribers` supports these optional query parameters:
 
@@ -33,6 +38,14 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
 - `status` - `active` or `unsubscribed`
 - `source` - `landing`, `demo`, or `app`
 - `sort` - `subscribed_at`, `email`, `source`, or `status`
+- `order` - `asc` or `desc`
+
+`/api/stats/installs` supports these optional query parameters:
+
+- `page` - default `1`, minimum `1`
+- `per_page` - default `50`, maximum `100`
+- `sort` - `last_seen`, `first_seen`, `sessions`, `studies_imported`, or
+  `revision`
 - `order` - `asc` or `desc`
 
 ## Security Notes
@@ -53,8 +66,12 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
   serve instead of relying on hand-maintained hash constants.
 - `401` API responses include `WWW-Authenticate: Bearer realm="myradone-dashboard"`
   so CLI and browser tooling get a clearer auth signal.
-- D1 access is read-only by convention, not by enforced binding mode. This
-  worker only issues `SELECT` queries.
+- D1 access is read-only by convention, not by enforced binding mode. Stats
+  dashboard reads go through `readonlySelect`, which rejects semicolons,
+  mutation/admin keywords, and anything other than `SELECT`/`WITH` after
+  stripping SQL comments.
+- Stats API responses never include full install identifiers. The install list
+  only returns `install_id_prefix`, the first 8 characters of the UUID.
 
 ## Token Contract
 
@@ -80,20 +97,26 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from the
    npx wrangler d1 migrations apply myradone-subscribers --remote --config workers/dashboard/wrangler.toml
    ```
 
-3. Deploy the worker:
+3. Confirm the existing stats schema has been applied to `myradone-stats`:
+
+   ```bash
+   npx wrangler d1 migrations apply myradone-stats --remote --config workers/stats/wrangler.toml
+   ```
+
+4. Deploy the worker:
 
    ```bash
    npx wrangler deploy --config workers/dashboard/wrangler.toml
    ```
 
-4. Route configuration is managed in `wrangler.toml` (`[[routes]]` block)
+5. Route configuration is managed in `wrangler.toml` (`[[routes]]` block)
    per [ADR 013](../../docs/decisions/013-worker-routing-as-code.md). The
    `wrangler deploy` step above reconciles the `dashboard.myradone.com/*`
    route automatically; no Cloudflare UI change is required. Do not add or
    edit the route through the Cloudflare dashboard -- it will drift from the
    repo and the next deploy may reconcile it away.
 
-5. Verify the deployed dashboard token configuration:
+6. Verify the deployed dashboard token configuration:
 
    ```bash
    echo -n 'YOUR_TOKEN' | shasum -a 256 | head -c 12
@@ -129,20 +152,33 @@ you want meaningful dashboard output.
    npx wrangler d1 migrations apply myradone-subscribers --local --config workers/dashboard/wrangler.toml
    ```
 
-4. Seed test rows:
+4. Apply the stats schema locally:
+
+   ```bash
+   npx wrangler d1 migrations apply myradone-stats --local --config workers/stats/wrangler.toml
+   ```
+
+5. Seed test rows:
 
    ```bash
    npx wrangler d1 execute myradone-subscribers --local --config workers/dashboard/wrangler.toml \
      --command "INSERT INTO subscribers (email, source) VALUES ('test@example.com', 'landing'), ('demo@example.com', 'demo');"
    ```
 
-5. Run the worker:
+6. Optionally seed a local stats row:
+
+   ```bash
+   npx wrangler d1 execute myradone-stats --local --config workers/dashboard/wrangler.toml \
+     --command "INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen, version) VALUES ('00000000-0000-4000-8000-000000000000', 1, '{\"sessions\":1,\"studiesImported\":2}', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', 1);"
+   ```
+
+7. Run the worker:
 
    ```bash
    npx wrangler dev --config workers/dashboard/wrangler.toml
    ```
 
-6. Visit [http://localhost:8787/](http://localhost:8787/) and enter
+8. Visit [http://localhost:8787/](http://localhost:8787/) and enter
    `localtest-localtest-localtest-1234`.
 
 ## Verification

--- a/workers/dashboard/src/dashboard.html
+++ b/workers/dashboard/src/dashboard.html
@@ -610,7 +610,6 @@
                 <th><button class="sort-button stats-sort-button" data-stats-sort="sessions" type="button">Sessions</button></th>
                 <th><button class="sort-button stats-sort-button" data-stats-sort="studies_imported" type="button">Studies</button></th>
                 <th><button class="sort-button stats-sort-button" data-stats-sort="revision" type="button">Revision</button></th>
-                <th>Version</th>
               </tr>
             </thead>
             <tbody id="statsInstallsBody"></tbody>
@@ -645,6 +644,8 @@
         statsSort: 'last_seen',
         statsOrder: 'desc',
         statsTotalPages: 1,
+        subscribersRefreshPromise: null,
+        statsRefreshPromise: null,
         refreshHandle: null
       };
 
@@ -853,6 +854,16 @@
         return tr;
       }
 
+      function appendEmptyRow(body, colspan, message) {
+        const row = document.createElement('tr');
+        row.className = 'empty-row';
+        const cell = document.createElement('td');
+        cell.colSpan = colspan;
+        cell.textContent = message;
+        row.appendChild(cell);
+        body.appendChild(row);
+      }
+
       function renderSummary(summary) {
         elements.totalCount.textContent = String(summary.counts.total);
         elements.activeCount.textContent = String(summary.counts.active);
@@ -921,10 +932,7 @@
         elements.recentBody.replaceChildren();
 
         if (!payload.subscribers.length) {
-          const row = document.createElement('tr');
-          row.className = 'empty-row';
-          row.innerHTML = '<td colspan="4">No subscribers yet.</td>';
-          elements.recentBody.appendChild(row);
+          appendEmptyRow(elements.recentBody, 4, 'No subscribers yet.');
           return;
         }
 
@@ -943,10 +951,7 @@
         elements.nextPageButton.disabled = payload.pagination.page >= payload.pagination.total_pages;
 
         if (!payload.subscribers.length) {
-          const row = document.createElement('tr');
-          row.className = 'empty-row';
-          row.innerHTML = '<td colspan="5">No subscribers match the current filters.</td>';
-          elements.subscribersBody.appendChild(row);
+          appendEmptyRow(elements.subscribersBody, 5, 'No subscribers match the current filters.');
           return;
         }
 
@@ -984,10 +989,7 @@
 
         if (isLoading && !state.statsLoaded) {
           elements.statsInstallsBody.replaceChildren();
-          const row = document.createElement('tr');
-          row.className = 'empty-row';
-          row.innerHTML = '<td colspan="7">Loading install stats...</td>';
-          elements.statsInstallsBody.appendChild(row);
+          appendEmptyRow(elements.statsInstallsBody, 6, 'Loading install stats...');
         }
       }
 
@@ -1039,15 +1041,14 @@
           'last_seen',
           'sessions',
           'studies_imported',
-          'revision',
-          'version'
+          'revision'
         ];
 
         columns.forEach(function (column) {
           const td = document.createElement('td');
           if (column === 'first_seen' || column === 'last_seen') {
             td.textContent = formatDateTime(install[column]);
-          } else if (column === 'sessions' || column === 'studies_imported' || column === 'revision' || column === 'version') {
+          } else if (column === 'sessions' || column === 'studies_imported' || column === 'revision') {
             td.textContent = formatNumber(install[column]);
           } else {
             td.textContent = install[column] || '—';
@@ -1069,10 +1070,7 @@
         elements.statsNextPageButton.disabled = state.statsPage >= state.statsTotalPages;
 
         if (!payload.installs.length) {
-          const row = document.createElement('tr');
-          row.className = 'empty-row';
-          row.innerHTML = '<td colspan="7">No installs reporting yet.</td>';
-          elements.statsInstallsBody.appendChild(row);
+          appendEmptyRow(elements.statsInstallsBody, 6, 'No installs reporting yet.');
           return;
         }
 
@@ -1091,58 +1089,81 @@
         if (!opts.force && state.statsLoaded) {
           return;
         }
-
-        setStatsLoading(true);
-        showError('');
-
-        try {
-          const [summary, installs] = await Promise.all([
-            apiJson('/api/stats/summary'),
-            apiJson(buildStatsInstallsPath())
-          ]);
-
-          renderStatsSummary(summary);
-          renderStatsInstalls(installs);
-          syncStatsSortButtons();
-          state.statsLoaded = true;
-          elements.lastUpdated.textContent =
-            'Updated ' +
-            new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
-        } catch (error) {
-          showError(error.message || 'Dashboard request failed.');
-        } finally {
-          setStatsLoading(false);
+        if (state.statsRefreshPromise) {
+          return state.statsRefreshPromise;
         }
+
+        state.statsRefreshPromise = (async function () {
+          setStatsLoading(true);
+          elements.refreshButton.disabled = true;
+          showError('');
+
+          try {
+            const [summary, installs] = await Promise.all([
+              apiJson('/api/stats/summary'),
+              apiJson(buildStatsInstallsPath())
+            ]);
+
+            renderStatsSummary(summary);
+            renderStatsInstalls(installs);
+            syncStatsSortButtons();
+            state.statsLoaded = true;
+            elements.lastUpdated.textContent =
+              'Updated ' +
+              new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
+          } catch (error) {
+            showError(error.message || 'Dashboard request failed.');
+          } finally {
+            setStatsLoading(false);
+            elements.refreshButton.disabled = false;
+            state.statsRefreshPromise = null;
+          }
+        }());
+
+        return state.statsRefreshPromise;
       }
 
       async function refreshAll() {
-        elements.refreshButton.disabled = true;
-        showError('');
-
-        try {
-          const [summary, recentPayload, subscriberPayload] = await Promise.all([
-            apiJson('/api/summary'),
-            apiJson('/api/subscribers?per_page=10&sort=subscribed_at&order=desc'),
-            apiJson(buildSubscribersPath())
-          ]);
-
-          renderSummary(summary);
-          renderSourceBreakdown(summary.sources);
-          renderDailyChart(summary.daily);
-          renderRecent(recentPayload);
-          renderSubscribers(subscriberPayload);
-          syncSortButtons();
-          if (state.currentTab === 'stats' || state.statsLoaded) {
-            await refreshStats({ force: true });
-          }
-          elements.lastUpdated.textContent =
-            'Updated ' +
-            new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
-        } catch (error) {
-          showError(error.message || 'Dashboard request failed.');
-        } finally {
-          elements.refreshButton.disabled = false;
+        if (state.subscribersRefreshPromise) {
+          return state.subscribersRefreshPromise;
         }
+
+        state.subscribersRefreshPromise = (async function () {
+          elements.refreshButton.disabled = true;
+          showError('');
+
+          try {
+            const [summary, recentPayload, subscriberPayload] = await Promise.all([
+              apiJson('/api/summary'),
+              apiJson('/api/subscribers?per_page=10&sort=subscribed_at&order=desc'),
+              apiJson(buildSubscribersPath())
+            ]);
+
+            renderSummary(summary);
+            renderSourceBreakdown(summary.sources);
+            renderDailyChart(summary.daily);
+            renderRecent(recentPayload);
+            renderSubscribers(subscriberPayload);
+            syncSortButtons();
+            elements.lastUpdated.textContent =
+              'Updated ' +
+              new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
+          } catch (error) {
+            showError(error.message || 'Dashboard request failed.');
+          } finally {
+            elements.refreshButton.disabled = false;
+            state.subscribersRefreshPromise = null;
+          }
+        }());
+
+        return state.subscribersRefreshPromise;
+      }
+
+      function refreshCurrent() {
+        if (state.currentTab === 'stats') {
+          return refreshStats({ force: true });
+        }
+        return refreshAll();
       }
 
       function switchTab(name) {
@@ -1239,7 +1260,7 @@
       });
 
       elements.refreshButton.addEventListener('click', function () {
-        refreshAll();
+        refreshCurrent();
       });
 
       elements.subscribersTabButton.addEventListener('click', function () {
@@ -1255,7 +1276,7 @@
       });
 
       refreshAll();
-      state.refreshHandle = window.setInterval(refreshAll, 60000);
+      state.refreshHandle = window.setInterval(refreshCurrent, 60000);
     }());
   </script>
 </body>

--- a/workers/dashboard/src/dashboard.html
+++ b/workers/dashboard/src/dashboard.html
@@ -133,6 +133,41 @@
       display: block;
     }
 
+    .tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 0 0 18px;
+    }
+
+    .tab-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 42px;
+      padding: 0 16px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      color: var(--text);
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .tab-button:hover,
+    .tab-button.active {
+      border-color: var(--accent);
+      color: var(--accent-strong);
+    }
+
+    .tab-button.active {
+      background: var(--surface-alt);
+    }
+
+    .tab-panel.hidden {
+      display: none;
+    }
+
     .cards,
     .grid {
       display: grid;
@@ -396,123 +431,207 @@
 
     <div id="errorBanner" class="banner" role="alert"></div>
 
-    <section class="cards">
-      <article class="card">
-        <p class="card-label">Total subscribers</p>
-        <p id="totalCount" class="card-value">—</p>
-      </article>
-      <article class="card">
-        <p class="card-label">Active</p>
-        <p id="activeCount" class="card-value">—</p>
-      </article>
-      <article class="card">
-        <p class="card-label">Unsubscribed</p>
-        <p id="unsubscribedCount" class="card-value">—</p>
-      </article>
-    </section>
+    <nav class="tabs" role="tablist" aria-label="Dashboard sections">
+      <button id="subscribersTabButton" class="tab-button active" type="button" role="tab" aria-selected="true" aria-controls="subscribersTab">Subscribers</button>
+      <button id="statsTabButton" class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="statsTab">Stats</button>
+    </nav>
 
-    <section class="grid grid-two">
-      <article class="panel">
+    <section id="subscribersTab" class="tab-panel" role="tabpanel" aria-labelledby="subscribersTabButton">
+      <section class="cards">
+        <article class="card">
+          <p class="card-label">Total subscribers</p>
+          <p id="totalCount" class="card-value">—</p>
+        </article>
+        <article class="card">
+          <p class="card-label">Active</p>
+          <p id="activeCount" class="card-value">—</p>
+        </article>
+        <article class="card">
+          <p class="card-label">Unsubscribed</p>
+          <p id="unsubscribedCount" class="card-value">—</p>
+        </article>
+      </section>
+
+      <section class="grid grid-two">
+        <article class="panel">
+          <div class="panel-header">
+            <div>
+              <h2 class="panel-title">Source breakdown</h2>
+              <p class="panel-copy">Current mix by signup source.</p>
+            </div>
+          </div>
+          <div id="sourceBreakdown" class="source-list"></div>
+        </article>
+
+        <article class="panel">
+          <div class="panel-header">
+            <div>
+              <h2 class="panel-title">Last 30 days</h2>
+              <p class="panel-copy">Daily signup volume.</p>
+            </div>
+          </div>
+          <div id="dailyChart" class="chart"></div>
+        </article>
+      </section>
+
+      <section class="panel">
         <div class="panel-header">
           <div>
-            <h2 class="panel-title">Source breakdown</h2>
-            <p class="panel-copy">Current mix by signup source.</p>
+            <h2 class="panel-title">Recent signups</h2>
+            <p class="panel-copy">Latest entries, powered by the same subscriber listing endpoint.</p>
           </div>
         </div>
-        <div id="sourceBreakdown" class="source-list"></div>
-      </article>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Status</th>
+                <th>Source</th>
+                <th>Subscribed</th>
+              </tr>
+            </thead>
+            <tbody id="recentBody"></tbody>
+          </table>
+        </div>
+      </section>
 
-      <article class="panel">
+      <section class="panel" style="margin-top: 18px;">
         <div class="panel-header">
           <div>
-            <h2 class="panel-title">Last 30 days</h2>
-            <p class="panel-copy">Daily signup volume.</p>
+            <h2 class="panel-title">All subscribers</h2>
+            <p class="panel-copy">Filterable, sortable, paginated list.</p>
           </div>
         </div>
-        <div id="dailyChart" class="chart"></div>
-      </article>
+
+        <form id="filtersForm" class="filters">
+          <div class="field">
+            <label for="statusFilter">Status</label>
+            <select id="statusFilter" name="status">
+              <option value="">All statuses</option>
+              <option value="active">Active</option>
+              <option value="unsubscribed">Unsubscribed</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="sourceFilter">Source</label>
+            <select id="sourceFilter" name="source">
+              <option value="">All sources</option>
+              <option value="landing">Landing</option>
+              <option value="demo">Demo</option>
+              <option value="app">App</option>
+            </select>
+          </div>
+          <button type="submit" class="button">Apply filters</button>
+          <button id="clearFiltersButton" type="button" class="button">Clear</button>
+        </form>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th><button class="sort-button subscriber-sort-button" data-sort="email" type="button">Email</button></th>
+                <th><button class="sort-button subscriber-sort-button" data-sort="status" type="button">Status</button></th>
+                <th><button class="sort-button subscriber-sort-button" data-sort="source" type="button">Source</button></th>
+                <th><button class="sort-button subscriber-sort-button" data-sort="subscribed_at" type="button">Subscribed</button></th>
+                <th>Consent</th>
+              </tr>
+            </thead>
+            <tbody id="subscribersBody"></tbody>
+          </table>
+        </div>
+
+        <div class="pagination">
+          <span id="paginationLabel" class="meta">Page 1</span>
+          <div class="pagination-buttons">
+            <button id="prevPageButton" class="button" type="button">Previous</button>
+            <button id="nextPageButton" class="button" type="button">Next</button>
+          </div>
+        </div>
+      </section>
     </section>
 
-    <section class="panel">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">Recent signups</h2>
-          <p class="panel-copy">Latest entries, powered by the same subscriber listing endpoint.</p>
-        </div>
-      </div>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Email</th>
-              <th>Status</th>
-              <th>Source</th>
-              <th>Subscribed</th>
-            </tr>
-          </thead>
-          <tbody id="recentBody"></tbody>
-        </table>
-      </div>
-    </section>
+    <section id="statsTab" class="tab-panel hidden" role="tabpanel" aria-labelledby="statsTabButton">
+      <section class="cards">
+        <article class="card">
+          <p class="card-label">Total Installs</p>
+          <p id="statsTotalInstalls" class="card-value">—</p>
+        </article>
+        <article class="card">
+          <p class="card-label">Active 24h</p>
+          <p id="statsActive24h" class="card-value">—</p>
+        </article>
+        <article class="card">
+          <p class="card-label">Active 7d</p>
+          <p id="statsActive7d" class="card-value">—</p>
+        </article>
+        <article class="card">
+          <p class="card-label">Active 30d</p>
+          <p id="statsActive30d" class="card-value">—</p>
+        </article>
+      </section>
 
-    <section class="panel" style="margin-top: 18px;">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">All subscribers</h2>
-          <p class="panel-copy">Filterable, sortable, paginated list.</p>
-        </div>
-      </div>
+      <section class="cards">
+        <article class="card">
+          <p class="card-label">Total Sessions</p>
+          <p id="statsTotalSessions" class="card-value">—</p>
+        </article>
+        <article class="card">
+          <p class="card-label">Total Studies Imported</p>
+          <p id="statsTotalStudies" class="card-value">—</p>
+        </article>
+      </section>
 
-      <form id="filtersForm" class="filters">
-        <div class="field">
-          <label for="statusFilter">Status</label>
-          <select id="statusFilter" name="status">
-            <option value="">All statuses</option>
-            <option value="active">Active</option>
-            <option value="unsubscribed">Unsubscribed</option>
-          </select>
+      <section class="panel">
+        <div class="panel-header">
+          <div>
+            <h2 class="panel-title">New installs in last 30 days</h2>
+            <p class="panel-copy">Daily install volume.</p>
+          </div>
         </div>
-        <div class="field">
-          <label for="sourceFilter">Source</label>
-          <select id="sourceFilter" name="source">
-            <option value="">All sources</option>
-            <option value="landing">Landing</option>
-            <option value="demo">Demo</option>
-            <option value="app">App</option>
-          </select>
-        </div>
-        <button type="submit" class="button">Apply filters</button>
-        <button id="clearFiltersButton" type="button" class="button">Clear</button>
-      </form>
+        <div id="statsDailyList" class="source-list"></div>
+      </section>
 
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th><button class="sort-button" data-sort="email" type="button">Email</button></th>
-              <th><button class="sort-button" data-sort="status" type="button">Status</button></th>
-              <th><button class="sort-button" data-sort="source" type="button">Source</button></th>
-              <th><button class="sort-button" data-sort="subscribed_at" type="button">Subscribed</button></th>
-              <th>Consent</th>
-            </tr>
-          </thead>
-          <tbody id="subscribersBody"></tbody>
-        </table>
-      </div>
-
-      <div class="pagination">
-        <span id="paginationLabel" class="meta">Page 1</span>
-        <div class="pagination-buttons">
-          <button id="prevPageButton" class="button" type="button">Previous</button>
-          <button id="nextPageButton" class="button" type="button">Next</button>
+      <section class="panel" style="margin-top: 18px;">
+        <div class="panel-header">
+          <div>
+            <h2 class="panel-title">Installs</h2>
+            <p class="panel-copy">Paginated install activity, sorted by reporting metadata.</p>
+          </div>
         </div>
-      </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Install (prefix)</th>
+                <th><button class="sort-button stats-sort-button" data-stats-sort="first_seen" type="button">First seen</button></th>
+                <th><button class="sort-button stats-sort-button" data-stats-sort="last_seen" type="button">Last seen</button></th>
+                <th><button class="sort-button stats-sort-button" data-stats-sort="sessions" type="button">Sessions</button></th>
+                <th><button class="sort-button stats-sort-button" data-stats-sort="studies_imported" type="button">Studies</button></th>
+                <th><button class="sort-button stats-sort-button" data-stats-sort="revision" type="button">Revision</button></th>
+                <th>Version</th>
+              </tr>
+            </thead>
+            <tbody id="statsInstallsBody"></tbody>
+          </table>
+        </div>
+
+        <div class="pagination">
+          <span id="statsPaginationLabel" class="meta">Page 1</span>
+          <div class="pagination-buttons">
+            <button id="statsPrevPageButton" class="button" type="button">Previous</button>
+            <button id="statsNextPageButton" class="button" type="button">Next</button>
+          </div>
+        </div>
+      </section>
     </section>
   </main>
 
   <script>
     (function () {
       const state = {
+        currentTab: 'subscribers',
         page: 1,
         perPage: 50,
         sort: 'subscribed_at',
@@ -520,6 +639,12 @@
         status: '',
         source: '',
         totalPages: 1,
+        statsLoaded: false,
+        statsPage: 1,
+        statsPerPage: 50,
+        statsSort: 'last_seen',
+        statsOrder: 'desc',
+        statsTotalPages: 1,
         refreshHandle: null
       };
 
@@ -538,8 +663,24 @@
         refreshButton: document.getElementById('refreshButton'),
         sourceBreakdown: document.getElementById('sourceBreakdown'),
         sourceFilter: document.getElementById('sourceFilter'),
-        sortButtons: Array.from(document.querySelectorAll('.sort-button')),
+        statsActive24h: document.getElementById('statsActive24h'),
+        statsActive7d: document.getElementById('statsActive7d'),
+        statsActive30d: document.getElementById('statsActive30d'),
+        statsDailyList: document.getElementById('statsDailyList'),
+        statsInstallsBody: document.getElementById('statsInstallsBody'),
+        statsNextPageButton: document.getElementById('statsNextPageButton'),
+        statsPaginationLabel: document.getElementById('statsPaginationLabel'),
+        statsPrevPageButton: document.getElementById('statsPrevPageButton'),
+        statsSortButtons: Array.from(document.querySelectorAll('.stats-sort-button')),
+        statsTab: document.getElementById('statsTab'),
+        statsTabButton: document.getElementById('statsTabButton'),
+        statsTotalInstalls: document.getElementById('statsTotalInstalls'),
+        statsTotalSessions: document.getElementById('statsTotalSessions'),
+        statsTotalStudies: document.getElementById('statsTotalStudies'),
         statusFilter: document.getElementById('statusFilter'),
+        subscribersSortButtons: Array.from(document.querySelectorAll('.subscriber-sort-button')),
+        subscribersTab: document.getElementById('subscribersTab'),
+        subscribersTabButton: document.getElementById('subscribersTabButton'),
         subscribersBody: document.getElementById('subscribersBody'),
         totalCount: document.getElementById('totalCount'),
         unsubscribedCount: document.getElementById('unsubscribedCount')
@@ -611,6 +752,10 @@
         elements.errorBanner.classList.add('visible');
       }
 
+      function formatNumber(value) {
+        return new Intl.NumberFormat().format(Number(value) || 0);
+      }
+
       function buildSubscribersPath(overrides) {
         const params = new URLSearchParams();
         const query = Object.assign(
@@ -637,6 +782,27 @@
         });
 
         return '/api/subscribers?' + params.toString();
+      }
+
+      function buildStatsInstallsPath(overrides) {
+        const params = new URLSearchParams();
+        const query = Object.assign(
+          {
+            page: state.statsPage,
+            per_page: state.statsPerPage,
+            sort: state.statsSort,
+            order: state.statsOrder
+          },
+          overrides || {}
+        );
+
+        Object.keys(query).forEach(function (key) {
+          if (query[key] !== '' && query[key] != null) {
+            params.set(key, String(query[key]));
+          }
+        });
+
+        return '/api/stats/installs?' + params.toString();
       }
 
       async function apiJson(path) {
@@ -792,7 +958,7 @@
       }
 
       function syncSortButtons() {
-        elements.sortButtons.forEach(function (button) {
+        elements.subscribersSortButtons.forEach(function (button) {
           const field = button.dataset.sort;
           const isActive = field === state.sort;
           const arrow = !isActive ? '' : state.order === 'asc' ? ' ▲' : ' ▼';
@@ -800,9 +966,153 @@
         });
       }
 
+      function syncStatsSortButtons() {
+        elements.statsSortButtons.forEach(function (button) {
+          const field = button.dataset.statsSort;
+          const isActive = field === state.statsSort;
+          const arrow = !isActive ? '' : state.statsOrder === 'asc' ? ' ▲' : ' ▼';
+          button.textContent = button.textContent.replace(/ [▲▼]$/, '') + arrow;
+        });
+      }
+
+      function setStatsLoading(isLoading) {
+        elements.statsPrevPageButton.disabled = isLoading || state.statsPage <= 1;
+        elements.statsNextPageButton.disabled = isLoading || state.statsPage >= state.statsTotalPages;
+        elements.statsSortButtons.forEach(function (button) {
+          button.disabled = isLoading;
+        });
+
+        if (isLoading && !state.statsLoaded) {
+          elements.statsInstallsBody.replaceChildren();
+          const row = document.createElement('tr');
+          row.className = 'empty-row';
+          row.innerHTML = '<td colspan="7">Loading install stats...</td>';
+          elements.statsInstallsBody.appendChild(row);
+        }
+      }
+
+      function renderStatsSummary(payload) {
+        const installs = payload.installs || {};
+        const sessions = payload.sessions || {};
+        const studies = payload.studies || {};
+        const daily = payload.new_installs_daily || [];
+
+        elements.statsTotalInstalls.textContent = formatNumber(installs.total);
+        elements.statsActive24h.textContent = formatNumber(installs.active_24h);
+        elements.statsActive7d.textContent = formatNumber(installs.active_7d);
+        elements.statsActive30d.textContent = formatNumber(installs.active_30d);
+        elements.statsTotalSessions.textContent = formatNumber(sessions.total);
+        elements.statsTotalStudies.textContent = formatNumber(studies.total);
+        elements.statsDailyList.replaceChildren();
+
+        if (!Number(installs.total)) {
+          const empty = document.createElement('p');
+          empty.className = 'chart-empty';
+          empty.textContent = 'No install history reporting yet.';
+          elements.statsDailyList.appendChild(empty);
+          return;
+        }
+
+        daily.forEach(function (entry) {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'source-row';
+
+          const topline = document.createElement('div');
+          topline.className = 'source-topline';
+          const day = document.createElement('span');
+          day.textContent = formatDay(entry.day);
+          const count = document.createElement('span');
+          count.textContent = formatNumber(entry.count);
+
+          topline.appendChild(day);
+          topline.appendChild(count);
+          wrapper.appendChild(topline);
+          elements.statsDailyList.appendChild(wrapper);
+        });
+      }
+
+      function createStatsInstallRow(install) {
+        const tr = document.createElement('tr');
+        const columns = [
+          'install_id_prefix',
+          'first_seen',
+          'last_seen',
+          'sessions',
+          'studies_imported',
+          'revision',
+          'version'
+        ];
+
+        columns.forEach(function (column) {
+          const td = document.createElement('td');
+          if (column === 'first_seen' || column === 'last_seen') {
+            td.textContent = formatDateTime(install[column]);
+          } else if (column === 'sessions' || column === 'studies_imported' || column === 'revision' || column === 'version') {
+            td.textContent = formatNumber(install[column]);
+          } else {
+            td.textContent = install[column] || '—';
+          }
+          tr.appendChild(td);
+        });
+
+        return tr;
+      }
+
+      function renderStatsInstalls(payload) {
+        elements.statsInstallsBody.replaceChildren();
+
+        state.statsTotalPages = payload.pagination.total_pages || 1;
+        state.statsPage = payload.pagination.page || 1;
+        elements.statsPaginationLabel.textContent =
+          'Page ' + state.statsPage + ' of ' + state.statsTotalPages + ' • ' + payload.pagination.total + ' total';
+        elements.statsPrevPageButton.disabled = state.statsPage <= 1;
+        elements.statsNextPageButton.disabled = state.statsPage >= state.statsTotalPages;
+
+        if (!payload.installs.length) {
+          const row = document.createElement('tr');
+          row.className = 'empty-row';
+          row.innerHTML = '<td colspan="7">No installs reporting yet.</td>';
+          elements.statsInstallsBody.appendChild(row);
+          return;
+        }
+
+        payload.installs.forEach(function (install) {
+          elements.statsInstallsBody.appendChild(createStatsInstallRow(install));
+        });
+      }
+
       async function loadSubscribers() {
         const payload = await apiJson(buildSubscribersPath());
         renderSubscribers(payload);
+      }
+
+      async function refreshStats(options) {
+        const opts = options || {};
+        if (!opts.force && state.statsLoaded) {
+          return;
+        }
+
+        setStatsLoading(true);
+        showError('');
+
+        try {
+          const [summary, installs] = await Promise.all([
+            apiJson('/api/stats/summary'),
+            apiJson(buildStatsInstallsPath())
+          ]);
+
+          renderStatsSummary(summary);
+          renderStatsInstalls(installs);
+          syncStatsSortButtons();
+          state.statsLoaded = true;
+          elements.lastUpdated.textContent =
+            'Updated ' +
+            new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
+        } catch (error) {
+          showError(error.message || 'Dashboard request failed.');
+        } finally {
+          setStatsLoading(false);
+        }
       }
 
       async function refreshAll() {
@@ -822,6 +1132,9 @@
           renderRecent(recentPayload);
           renderSubscribers(subscriberPayload);
           syncSortButtons();
+          if (state.currentTab === 'stats' || state.statsLoaded) {
+            await refreshStats({ force: true });
+          }
           elements.lastUpdated.textContent =
             'Updated ' +
             new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date());
@@ -829,6 +1142,22 @@
           showError(error.message || 'Dashboard request failed.');
         } finally {
           elements.refreshButton.disabled = false;
+        }
+      }
+
+      function switchTab(name) {
+        state.currentTab = name;
+        const isStats = name === 'stats';
+
+        elements.subscribersTab.classList.toggle('hidden', isStats);
+        elements.statsTab.classList.toggle('hidden', !isStats);
+        elements.subscribersTabButton.classList.toggle('active', !isStats);
+        elements.statsTabButton.classList.toggle('active', isStats);
+        elements.subscribersTabButton.setAttribute('aria-selected', isStats ? 'false' : 'true');
+        elements.statsTabButton.setAttribute('aria-selected', isStats ? 'true' : 'false');
+
+        if (isStats) {
+          refreshStats();
         }
       }
 
@@ -849,7 +1178,7 @@
         refreshAll();
       });
 
-      elements.sortButtons.forEach(function (button) {
+      elements.subscribersSortButtons.forEach(function (button) {
         button.addEventListener('click', function () {
           const field = button.dataset.sort;
           if (state.sort === field) {
@@ -860,6 +1189,20 @@
           }
           state.page = 1;
           refreshAll();
+        });
+      });
+
+      elements.statsSortButtons.forEach(function (button) {
+        button.addEventListener('click', function () {
+          const field = button.dataset.statsSort;
+          if (state.statsSort === field) {
+            state.statsOrder = state.statsOrder === 'asc' ? 'desc' : 'asc';
+          } else {
+            state.statsSort = field;
+            state.statsOrder = field === 'last_seen' ? 'desc' : 'asc';
+          }
+          state.statsPage = 1;
+          refreshStats({ force: true });
         });
       });
 
@@ -879,8 +1222,32 @@
         refreshAll();
       });
 
+      elements.statsPrevPageButton.addEventListener('click', function () {
+        if (state.statsPage <= 1) {
+          return;
+        }
+        state.statsPage -= 1;
+        refreshStats({ force: true });
+      });
+
+      elements.statsNextPageButton.addEventListener('click', function () {
+        if (state.statsPage >= state.statsTotalPages) {
+          return;
+        }
+        state.statsPage += 1;
+        refreshStats({ force: true });
+      });
+
       elements.refreshButton.addEventListener('click', function () {
         refreshAll();
+      });
+
+      elements.subscribersTabButton.addEventListener('click', function () {
+        switchTab('subscribers');
+      });
+
+      elements.statsTabButton.addEventListener('click', function () {
+        switchTab('stats');
       });
 
       elements.logoutButton.addEventListener('click', function () {

--- a/workers/dashboard/src/dashboard.html
+++ b/workers/dashboard/src/dashboard.html
@@ -419,8 +419,8 @@
     <header class="page-header">
       <div>
         <p class="eyebrow">Internal</p>
-        <h1>myRadOne Subscribers</h1>
-        <p class="subtitle">Read-only visibility into email signup activity, source mix, and recent growth.</p>
+        <h1>myRadOne Dashboard</h1>
+        <p class="subtitle">Read-only visibility into subscriber and install activity.</p>
       </div>
       <div class="header-actions">
         <span id="lastUpdated" class="meta">Waiting for data…</span>

--- a/workers/dashboard/src/index.mjs
+++ b/workers/dashboard/src/index.mjs
@@ -12,7 +12,15 @@ import {
     readonlySelect
 } from './lib.mjs';
 
-export { authenticate, handleSession, handleStatsInstalls, handleStatsSummary, handleSubscribers, handleSummary, readonlySelect };
+export {
+    authenticate,
+    handleSession,
+    handleStatsInstalls,
+    handleStatsSummary,
+    handleSubscribers,
+    handleSummary,
+    readonlySelect
+};
 
 export async function handleDashboard(request, env) {
     return handleDashboardImpl(request, env, dashboardHtml);

--- a/workers/dashboard/src/index.mjs
+++ b/workers/dashboard/src/index.mjs
@@ -5,11 +5,14 @@ import {
     dispatchRequest,
     handleDashboard as handleDashboardImpl,
     handleSession,
+    handleStatsInstalls,
+    handleStatsSummary,
     handleSubscribers,
-    handleSummary
+    handleSummary,
+    readonlySelect
 } from './lib.mjs';
 
-export { authenticate, handleSession, handleSubscribers, handleSummary };
+export { authenticate, handleSession, handleStatsInstalls, handleStatsSummary, handleSubscribers, handleSummary, readonlySelect };
 
 export async function handleDashboard(request, env) {
     return handleDashboardImpl(request, env, dashboardHtml);

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -680,6 +680,7 @@ function statsDayBounds(now = new Date()) {
 
 function stripSqlComments(sql) {
     return String(sql)
+        .normalize('NFKC')
         .replace(/\/\*[\s\S]*?\*\//g, ' ')
         .replace(/--[^\r\n]*/g, ' ');
 }
@@ -702,23 +703,7 @@ function validateReadonlySql(sql) {
 
 export function readonlySelect(db, sql, params = []) {
     validateReadonlySql(sql);
-    const previousReadonlyState = db.__readonlySelectActive;
-    try {
-        db.__readonlySelectActive = true;
-    } catch {
-        // Some runtime bindings may be non-extensible proxies; validation still
-        // gates the query even when the test-only marker cannot be attached.
-    }
-    let statement;
-    try {
-        statement = db.prepare(sql).bind(...params);
-    } finally {
-        try {
-            db.__readonlySelectActive = previousReadonlyState;
-        } catch {
-            // See marker note above.
-        }
-    }
+    const statement = db.prepare(sql).bind(...params);
 
     return {
         first() {
@@ -781,7 +766,8 @@ function toSourceSummary(rows) {
 
 export async function handleSummary(env) {
     const countsRow =
-        (await env.SUBSCRIBERS_DB.prepare(
+        (await readonlySelect(
+            env.SUBSCRIBERS_DB,
             `SELECT
                 COUNT(*) AS total,
                 SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS active,
@@ -791,7 +777,8 @@ export async function handleSummary(env) {
 
     const sourceRows =
         (
-            await env.SUBSCRIBERS_DB.prepare(
+            await readonlySelect(
+                env.SUBSCRIBERS_DB,
                 `SELECT source, status, COUNT(*) AS count
                  FROM subscribers
                  GROUP BY source, status
@@ -801,7 +788,8 @@ export async function handleSummary(env) {
 
     const dailyRows =
         (
-            await env.SUBSCRIBERS_DB.prepare(
+            await readonlySelect(
+                env.SUBSCRIBERS_DB,
                 `WITH RECURSIVE days(day) AS (
                     SELECT date('now', '-29 days')
                     UNION ALL
@@ -849,21 +837,23 @@ export async function handleSubscribers(request, env) {
     const offset = (query.page - 1) * query.perPage;
 
     const countRow =
-        (await env.SUBSCRIBERS_DB.prepare(`SELECT COUNT(*) AS total FROM subscribers ${whereSql}`)
-            .bind(...bindings)
-            .first()) || {};
+        (await readonlySelect(
+            env.SUBSCRIBERS_DB,
+            `SELECT COUNT(*) AS total FROM subscribers ${whereSql}`,
+            bindings
+        ).first()) || {};
 
     const rows =
         (
-            await env.SUBSCRIBERS_DB.prepare(
+            await readonlySelect(
+                env.SUBSCRIBERS_DB,
                 `SELECT id, email, status, subscribed_at, source, consent_version
                  FROM subscribers
                  ${whereSql}
                  ORDER BY ${sortColumn} ${sortDirection}, id ${sortDirection}
-                 LIMIT ? OFFSET ?`
-            )
-                .bind(...bindings, query.perPage, offset)
-                .all()
+                 LIMIT ? OFFSET ?`,
+                [...bindings, query.perPage, offset]
+            ).all()
         ).results || [];
 
     const total = normalizeCount(countRow.total);
@@ -961,8 +951,7 @@ function normalizeInstallRow(row) {
         last_seen: isoDateString(row.last_seen),
         revision: normalizeInt(row.revision),
         sessions: normalizeInt(row.sessions),
-        studies_imported: normalizeInt(row.studies_imported),
-        version: normalizeInt(row.version)
+        studies_imported: normalizeInt(row.studies_imported)
     };
 }
 
@@ -991,8 +980,7 @@ export async function handleStatsInstalls(request, env) {
                     CASE
                         WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.studiesImported') AS INTEGER), 0)
                         ELSE 0
-                    END AS studies_imported,
-                    version
+                    END AS studies_imported
                  FROM installs
                  ORDER BY ${sortColumn} ${sortDirection}, install_id ${sortDirection}
                  LIMIT ? OFFSET ?`,

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -497,14 +497,14 @@ function createLoginHtml(errorMessage = '') {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>myRadOne Subscriber Dashboard Login</title>
+  <title>myRadOne Dashboard Login</title>
   ${createAuthPageStyles()}
 </head>
 <body>
   <main class="card">
     <p class="eyebrow">Internal</p>
-    <h1>myRadOne Subscribers</h1>
-    <p>Enter the dashboard token to load the protected subscriber analytics view.</p>
+    <h1>myRadOne Dashboard</h1>
+    <p>Enter the dashboard token to load the protected analytics view.</p>
     <form id="loginForm">
       <label>
         Dashboard token
@@ -527,7 +527,7 @@ function createMisconfigHtml(reason) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>myRadOne Subscriber Dashboard Misconfigured</title>
+  <title>myRadOne Dashboard Misconfigured</title>
   ${createAuthPageStyles()}
 </head>
 <body>

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -3,6 +3,8 @@ export const CONFIG_PATH = '/api/config';
 export const SESSION_PATH = '/api/session';
 export const SUMMARY_PATH = '/api/summary';
 export const SUBSCRIBERS_PATH = '/api/subscribers';
+export const STATS_SUMMARY_PATH = '/api/stats/summary';
+export const STATS_INSTALLS_PATH = '/api/stats/installs';
 
 const DASHBOARD_SESSION_COOKIE = 'myradone_dashboard_token';
 const DASHBOARD_MISCONFIG_ERROR = 'Dashboard misconfigured';
@@ -10,11 +12,19 @@ const DASHBOARD_TOKEN_MIN_LENGTH = 32;
 const VALID_STATUSES = new Set(['active', 'unsubscribed']);
 const VALID_SOURCES = new Set(['landing', 'demo', 'app']);
 const VALID_ORDERS = new Set(['asc', 'desc']);
+const MUTATION_SQL_KEYWORDS = /\b(?:INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|REPLACE|ATTACH|DETACH|PRAGMA|VACUUM|REINDEX)\b/i;
 const SORT_COLUMNS = new Map([
     ['subscribed_at', 'subscribed_at'],
     ['email', 'email'],
     ['source', 'source'],
     ['status', 'status']
+]);
+const INSTALLS_SORT_COLUMNS = new Map([
+    ['last_seen', 'last_seen'],
+    ['first_seen', 'first_seen'],
+    ['sessions', 'sessions'],
+    ['studies_imported', 'studies_imported'],
+    ['revision', 'revision']
 ]);
 const SOURCE_ORDER = ['landing', 'demo', 'app'];
 const SOURCE_ORDER_SQL = "CASE source WHEN 'landing' THEN 0 WHEN 'demo' THEN 1 WHEN 'app' THEN 2 ELSE 3 END";
@@ -91,10 +101,11 @@ const LOGIN_PAGE_SCRIPT = `(function () {
   });
 }());`;
 class HttpError extends Error {
-    constructor(status, message) {
+    constructor(status, message, field = null) {
         super(message);
         this.name = 'HttpError';
         this.status = status;
+        this.field = field;
     }
 }
 
@@ -537,6 +548,10 @@ function badRequest(message) {
     throw new HttpError(400, message);
 }
 
+function badRequestField(message, field) {
+    throw new HttpError(400, message, field);
+}
+
 function methodNotAllowed() {
     throw new HttpError(405, 'Method not allowed');
 }
@@ -559,6 +574,23 @@ function parseIntegerParam(rawValue, fallback, { min = 1, max = Number.MAX_SAFE_
 
     if (parsed < min || parsed > max) {
         badRequest('Integer parameter out of range');
+    }
+
+    return parsed;
+}
+
+function parseStatsIntegerParam(rawValue, fallback, field, { min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+    if (rawValue == null || rawValue === '') {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(rawValue, 10);
+    if (!Number.isFinite(parsed) || String(parsed) !== String(rawValue).trim()) {
+        badRequestField('Invalid integer parameter', field);
+    }
+
+    if (parsed < min || parsed > max) {
+        badRequestField('Integer parameter out of range', field);
     }
 
     return parsed;
@@ -599,9 +631,103 @@ function parseSubscribersQuery(request) {
     };
 }
 
+function parseStatsInstallsQuery(request) {
+    const url = new URL(request.url);
+    const page = parseStatsIntegerParam(url.searchParams.get('page'), 1, 'page', { min: 1 });
+    const perPage = parseStatsIntegerParam(url.searchParams.get('per_page'), 50, 'per_page', { min: 1, max: 100 });
+    const sort = (url.searchParams.get('sort') || 'last_seen').toLowerCase();
+    const order = (url.searchParams.get('order') || 'desc').toLowerCase();
+
+    if (!INSTALLS_SORT_COLUMNS.has(sort)) {
+        badRequestField('Invalid sort column', 'sort');
+    }
+
+    if (!VALID_ORDERS.has(order)) {
+        badRequestField('Invalid sort order', 'order');
+    }
+
+    return { page, perPage, sort, order };
+}
+
 function normalizeCount(value) {
     const count = Number(value);
-    return Number.isFinite(count) ? count : 0;
+    return Number.isFinite(count) && count > 0 ? Math.trunc(count) : 0;
+}
+
+function normalizeInt(value) {
+    return normalizeCount(value);
+}
+
+function isoDateString(value) {
+    const timestamp = Date.parse(value);
+    return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : '';
+}
+
+function utcDay(value) {
+    return value.toISOString().slice(0, 10);
+}
+
+function statsDayBounds(now = new Date()) {
+    const date = now instanceof Date ? now : new Date(now);
+    const today = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+    const start = new Date(today);
+    start.setUTCDate(today.getUTCDate() - 29);
+    return {
+        startDay: utcDay(start),
+        todayDay: utcDay(today)
+    };
+}
+
+function stripSqlComments(sql) {
+    return String(sql)
+        .replace(/\/\*[\s\S]*?\*\//g, ' ')
+        .replace(/--[^\r\n]*/g, ' ');
+}
+
+function validateReadonlySql(sql) {
+    const stripped = stripSqlComments(sql);
+    if (stripped.includes(';')) {
+        throw new Error('readonlySelect only allows a single read-only statement without semicolons');
+    }
+
+    const firstToken = stripped.trim().match(/^[A-Za-z]+/)?.[0]?.toUpperCase();
+    if (firstToken !== 'SELECT' && firstToken !== 'WITH') {
+        throw new Error('readonlySelect only allows SELECT or WITH statements');
+    }
+
+    if (MUTATION_SQL_KEYWORDS.test(stripped)) {
+        throw new Error('readonlySelect rejected mutation or admin SQL keyword');
+    }
+}
+
+export function readonlySelect(db, sql, params = []) {
+    validateReadonlySql(sql);
+    const previousReadonlyState = db.__readonlySelectActive;
+    try {
+        db.__readonlySelectActive = true;
+    } catch {
+        // Some runtime bindings may be non-extensible proxies; validation still
+        // gates the query even when the test-only marker cannot be attached.
+    }
+    let statement;
+    try {
+        statement = db.prepare(sql).bind(...params);
+    } finally {
+        try {
+            db.__readonlySelectActive = previousReadonlyState;
+        } catch {
+            // See marker note above.
+        }
+    }
+
+    return {
+        first() {
+            return statement.first();
+        },
+        all() {
+            return statement.all();
+        }
+    };
 }
 
 function buildSubscribersWhereClause(filters) {
@@ -745,6 +871,140 @@ export async function handleSubscribers(request, env) {
 
     return {
         subscribers: rows.map(normalizeSubscriberRow),
+        pagination: {
+            page: query.page,
+            per_page: query.perPage,
+            total,
+            total_pages: totalPages
+        }
+    };
+}
+
+export async function handleStatsSummary(env, options = {}) {
+    const { startDay, todayDay } = statsDayBounds(options.now);
+    const now = options.now ? new Date(options.now) : new Date();
+    const nowMs = now.getTime();
+    const active24hSince = new Date(nowMs - 24 * 60 * 60 * 1000).toISOString();
+    const active7dSince = new Date(nowMs - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const active30dSince = new Date(nowMs - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    const totalsRow =
+        (await readonlySelect(
+            env.STATS_DB,
+            `SELECT
+                COUNT(*) AS installs_total,
+                SUM(CASE WHEN last_seen >= ? THEN 1 ELSE 0 END) AS active_24h,
+                SUM(CASE WHEN last_seen >= ? THEN 1 ELSE 0 END) AS active_7d,
+                SUM(CASE WHEN last_seen >= ? THEN 1 ELSE 0 END) AS active_30d,
+                SUM(CASE
+                    WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.sessions') AS INTEGER), 0)
+                    ELSE 0
+                END) AS sessions_total,
+                SUM(CASE
+                    WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.studiesImported') AS INTEGER), 0)
+                    ELSE 0
+                END) AS studies_total
+             FROM installs`,
+            [active24hSince, active7dSince, active30dSince]
+        ).first()) || {};
+
+    const dailyRows =
+        (
+            await readonlySelect(
+                env.STATS_DB,
+                `WITH RECURSIVE days(day) AS (
+                    SELECT date(?)
+                    UNION ALL
+                    SELECT date(day, '+1 day')
+                    FROM days
+                    WHERE day < date(?)
+                )
+                SELECT days.day AS day, COALESCE(counts.count, 0) AS count
+                FROM days
+                LEFT JOIN (
+                    SELECT date(created_at) AS day, COUNT(*) AS count
+                    FROM installs
+                    WHERE created_at >= datetime(?)
+                    GROUP BY date(created_at)
+                ) AS counts
+                  ON counts.day = days.day
+                ORDER BY days.day ASC`,
+                [startDay, todayDay, startDay]
+            ).all()
+        ).results || [];
+
+    return {
+        installs: {
+            total: normalizeCount(totalsRow.installs_total),
+            active_24h: normalizeCount(totalsRow.active_24h),
+            active_7d: normalizeCount(totalsRow.active_7d),
+            active_30d: normalizeCount(totalsRow.active_30d)
+        },
+        sessions: {
+            total: normalizeCount(totalsRow.sessions_total)
+        },
+        studies: {
+            total: normalizeCount(totalsRow.studies_total)
+        },
+        new_installs_daily: dailyRows.map((row) => ({
+            day: row.day,
+            count: normalizeCount(row.count)
+        }))
+    };
+}
+
+function normalizeInstallRow(row) {
+    const installId = typeof row.install_id === 'string' ? row.install_id : '';
+    return {
+        install_id_prefix: installId.slice(0, 8),
+        first_seen: isoDateString(row.first_seen),
+        last_seen: isoDateString(row.last_seen),
+        revision: normalizeInt(row.revision),
+        sessions: normalizeInt(row.sessions),
+        studies_imported: normalizeInt(row.studies_imported),
+        version: normalizeInt(row.version)
+    };
+}
+
+export async function handleStatsInstalls(request, env) {
+    const query = parseStatsInstallsQuery(request);
+    const sortColumn = INSTALLS_SORT_COLUMNS.get(query.sort);
+    const sortDirection = query.order.toUpperCase();
+    const offset = (query.page - 1) * query.perPage;
+
+    const countRow =
+        (await readonlySelect(env.STATS_DB, `SELECT COUNT(*) AS total FROM installs`).first()) || {};
+
+    const rows =
+        (
+            await readonlySelect(
+                env.STATS_DB,
+                `SELECT
+                    install_id,
+                    first_seen,
+                    last_seen,
+                    revision,
+                    CASE
+                        WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.sessions') AS INTEGER), 0)
+                        ELSE 0
+                    END AS sessions,
+                    CASE
+                        WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.studiesImported') AS INTEGER), 0)
+                        ELSE 0
+                    END AS studies_imported,
+                    version
+                 FROM installs
+                 ORDER BY ${sortColumn} ${sortDirection}, install_id ${sortDirection}
+                 LIMIT ? OFFSET ?`,
+                [query.perPage, offset]
+            ).all()
+        ).results || [];
+
+    const total = normalizeCount(countRow.total);
+    const totalPages = Math.max(1, Math.ceil(total / query.perPage || 1));
+
+    return {
+        installs: rows.map(normalizeInstallRow),
         pagination: {
             page: query.page,
             per_page: query.perPage,
@@ -915,6 +1175,22 @@ export async function dispatchRequest(request, env, dashboardHtml) {
         return jsonResponse(await handleSubscribers(request, env));
     }
 
+    if (pathname === STATS_SUMMARY_PATH) {
+        requireGet(request);
+        if (!(await authenticate(request, env))) {
+            return await createUnauthorizedResponse(pathname, request);
+        }
+        return jsonResponse(await handleStatsSummary(env));
+    }
+
+    if (pathname === STATS_INSTALLS_PATH) {
+        requireGet(request);
+        if (!(await authenticate(request, env))) {
+            return await createUnauthorizedResponse(pathname, request);
+        }
+        return jsonResponse(await handleStatsInstalls(request, env));
+    }
+
     return jsonResponse({ error: 'Not found' }, 404);
 }
 
@@ -926,7 +1202,8 @@ export async function createErrorResponse(request, error) {
             const loginHtml = createLoginHtml(error.message);
             return htmlResponse(loginHtml, error.status, await buildInlineScriptCsp(loginHtml));
         }
-        return jsonResponse({ error: error.message }, error.status);
+        const payload = error.field ? { error: error.message, field: error.field } : { error: error.message };
+        return jsonResponse(payload, error.status);
     }
 
     console.error('dashboard worker failed', error);

--- a/workers/dashboard/wrangler.toml
+++ b/workers/dashboard/wrangler.toml
@@ -18,6 +18,11 @@ binding = "SUBSCRIBERS_DB"
 database_name = "myradone-subscribers"
 database_id = "33a16c5c-0618-47a8-b351-7af2f4f979e9"
 
+[[d1_databases]]
+binding = "STATS_DB"
+database_name = "myradone-stats"
+database_id = "5f9d6a5b-ef20-4a4d-8600-972ecebb690e"
+
 [[ratelimits]]
 name = "DASHBOARD_RATE_LIMIT"
 namespace_id = "2026041201"


### PR DESCRIPTION
## Summary
- add dashboard API endpoints for anonymous stats summaries and paginated install snapshots
- bind the dashboard worker to the existing `myradone-stats` D1 as `STATS_DB`
- add a Stats tab to the dashboard shell with install/activity cards, 30-day new-install history, and a paginated installs table
- enforce read-only stats queries through `readonlySelect` and tests, and only expose install ID prefixes

## Validation
- `node --test tests/dashboard-worker.test.mjs`
- `node --test tests/*.test.mjs`
- `npx wrangler@latest deploy --dry-run --config workers/dashboard/wrangler.toml`
- inline dashboard script parse check via `new Function(...)`
- `biome lint .` (passes with existing unrelated style warnings)
- `npx playwright test` -> 540 passed, 4 skipped

## Deploy Notes
Deployment is intentionally separate from this PR. After merge and explicit go signal, deploy with `npx wrangler deploy --config workers/dashboard/wrangler.toml` and smoke `/api/stats/summary` plus `/api/stats/installs?per_page=1`.
