### PR TITLE
Reword 'invalid' to 'non-DICOM' in import banner

### DIFF
--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -986,7 +986,7 @@
         const parts = [];
         if (copied > 0) parts.push(`${copied} copied`);
         if (skipped > 0) parts.push(`${skipped} skipped`);
-        if (invalid > 0) parts.push(`${invalid} invalid`);
+        if (invalid > 0) parts.push(`${invalid} non-DICOM`);
         if (errors > 0) parts.push(`${errors} errors`);
 
         let detail = `${processed}/${discovered} files processed`;
@@ -1027,7 +1027,7 @@
             messageParts.push(`${skipped} duplicate${skipped !== 1 ? 's' : ''} skipped`);
         }
         if (invalid > 0) {
-            messageParts.push(`${invalid} invalid`);
+            messageParts.push(`${invalid} non-DICOM file${invalid !== 1 ? 's' : ''} skipped`);
         }
         if (errors > 0) {
             messageParts.push(`${errors} error${errors !== 1 ? 's' : ''}`);

--- a/tests/desktop-import.spec.js
+++ b/tests/desktop-import.spec.js
@@ -1698,7 +1698,7 @@ test.describe('Desktop import integration', () => {
         const bannerText = await page.locator('#importResultText').textContent();
         expect(bannerText).toContain('Imported 5 files');
         expect(bannerText).toContain('2 duplicates skipped');
-        expect(bannerText).toContain('1 invalid');
+        expect(bannerText).toContain('1 non-DICOM file skipped');
         expect(bannerText).toContain('3.5s');
 
         // The banner should have the success class (no errors or collisions)


### PR DESCRIPTION
## Summary

The post-import banner says "X invalid" which reads like an accusation that the user's images were broken. The reality is those files were not DICOM at all -- thumbnails, DICOMDIR indexes, README/HTML viewer pages, hidden macOS files, vendor cruft typically shipped on hospital CDs. The 88% rejection rate Gabriel observed was mostly that kind of folder noise, not damaged scans.

This PR renames the user-facing label to "non-DICOM" so the message is honest and removes the implication of user fault.

## Changes

- \`docs/js/app/library.js\` banner: \`X invalid\` -> \`X non-DICOM file(s) skipped\`
- \`docs/js/app/library.js\` progress detail: \`X invalid\` -> \`X non-DICOM\`
- \`tests/desktop-import.spec.js\` updated assertion to match the new banner string

## What did not change

- The internal \`result.invalid\` data field stays as-is. Tests that read the data structure (e.g. \`expect(result.invalid).toBe(2)\`) are unaffected.
- The reject pipeline behavior in \`import-pipeline.js\` is unchanged. Same files get rejected; only the user-facing wording is updated.

## Test plan

- [ ] Drop a CD-style folder with a mix of DICOM and non-DICOM files. Banner reads \`Imported N files. M non-DICOM files skipped.\` (no "invalid" anywhere).
- [ ] Single non-DICOM file (M=1): banner reads \`1 non-DICOM file skipped\` (singular).
- [ ] CI: \`tests/desktop-import.spec.js\` displayImportResult test passes against the new string.

claude