### PR TITLE
[codex] Serialize sync version allocation

### DIFF
--- a/server/routes/sync.py
+++ b/server/routes/sync.py
@@ -91,6 +91,64 @@ def _validate_device(db, user_id, device_id):
     return error_response is None
 
 
+def _process_client_changes(db, user_id, device_id, changes):
+    """Apply client changes and return accepted/rejected sync response entries."""
+    accepted = []
+    rejected = []
+
+    if not isinstance(changes, list):
+        return accepted, rejected
+
+    for change in changes:
+        if not isinstance(change, dict):
+            continue
+
+        # Validate required fields
+        required_fields = ('operation_uuid', 'table', 'key', 'operation')
+        if not all(change.get(f) for f in required_fields):
+            continue
+
+        # Belt-and-suspenders: reject comment changes with empty record_uuid.
+        # The comments.record_uuid column is nullable in SQLite (can't add
+        # NOT NULL to existing column), so we enforce non-null here.
+        change_key = (change.get('key') or '').strip()
+        if change.get('table') == 'comments' and not change_key:
+            rejected.append(
+                {
+                    'operation_uuid': change['operation_uuid'],
+                    'key': change.get('key', ''),
+                    'reason': 'empty_record_uuid',
+                    'current_sync_version': 0,
+                    'current_data': {},
+                }
+            )
+            continue
+
+        result = process_change(db, user_id, device_id, change)
+
+        if result['status'] == 'accepted':
+            accepted.append(
+                {
+                    'operation_uuid': result['operation_uuid'],
+                    'key': result['key'],
+                    'sync_version': result['sync_version'],
+                }
+            )
+            continue
+
+        rejected.append(
+            {
+                'operation_uuid': result['operation_uuid'],
+                'key': result['key'],
+                'reason': result['reason'],
+                'current_sync_version': result['current_sync_version'],
+                'current_data': result['current_data'],
+            }
+        )
+
+    return accepted, rejected
+
+
 @sync_bp.route('/api/sync', methods=['POST'])
 def sync():
     """Main sync endpoint per SYNC-CONTRACT-V1.md."""
@@ -124,67 +182,37 @@ def sync():
         except CursorInvalidError:
             return jsonify({'error': 'cursor_expired', 'hint': 'full_resync'}), 410
 
-    # -- Process client changes --
-    accepted = []
-    rejected = []
+    if db.in_transaction:
+        raise RuntimeError('sync validation opened a transaction before BEGIN IMMEDIATE')
 
-    if isinstance(changes, list):
-        for change in changes:
-            if not isinstance(change, dict):
-                continue
+    try:
+        # In WAL mode, BEGIN IMMEDIATE takes a RESERVED lock: readers continue,
+        # but writers serialize around sync_version allocation.
+        db.execute('BEGIN IMMEDIATE')
 
-            # Validate required fields
-            required_fields = ('operation_uuid', 'table', 'key', 'operation')
-            if not all(change.get(f) for f in required_fields):
-                continue
+        # -- Process client changes --
+        accepted, rejected = _process_client_changes(db, user_id, device_id, changes)
 
-            # Belt-and-suspenders: reject comment changes with empty record_uuid.
-            # The comments.record_uuid column is nullable in SQLite (can't add
-            # NOT NULL to existing column), so we enforce non-null here.
-            change_key = (change.get('key') or '').strip()
-            if change.get('table') == 'comments' and not change_key:
-                rejected.append(
-                    {
-                        'operation_uuid': change['operation_uuid'],
-                        'key': change.get('key', ''),
-                        'reason': 'empty_record_uuid',
-                        'current_sync_version': 0,
-                        'current_data': {},
-                    }
-                )
-                continue
+        # -- Compute remote changes --
+        remote_changes = compute_remote_changes(db, user_id, device_id, cursor_position)
 
-            result = process_change(db, user_id, device_id, change)
+        # -- Issue new cursor at current max sync_version for this user --
+        new_position = get_max_sync_version(db, user_id)
+        new_cursor = issue_cursor(db, user_id, device_id, new_position)
 
-            if result['status'] == 'accepted':
-                accepted.append(
-                    {
-                        'operation_uuid': result['operation_uuid'],
-                        'key': result['key'],
-                        'sync_version': result['sync_version'],
-                    }
-                )
-            else:
-                entry = {
-                    'operation_uuid': result['operation_uuid'],
-                    'key': result['key'],
-                    'reason': result['reason'],
-                    'current_sync_version': result['current_sync_version'],
-                    'current_data': result['current_data'],
-                }
-                rejected.append(entry)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
 
-    # -- Compute remote changes --
-    remote_changes = compute_remote_changes(db, user_id, device_id, cursor_position)
-
-    # -- Issue new cursor at current max sync_version for this user --
-    new_position = get_max_sync_version(db, user_id)
-    new_cursor = issue_cursor(db, user_id, device_id, new_position)
-
-    # Opportunistically clean up expired cursors (cheap, bounded work)
-    cleanup_expired_cursors(db)
-
-    db.commit()
+    try:
+        # Cursor cleanup is opportunistic and does not participate in version
+        # allocation, so keep it outside the write-serialization window.
+        cleanup_expired_cursors(db)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.warning('Failed to clean up expired sync cursors', exc_info=True)
 
     server_time = int(time.time() * 1000)
 

--- a/server/sync/delta.py
+++ b/server/sync/delta.py
@@ -229,7 +229,16 @@ def get_max_sync_version(db, user_id=None):
 
 
 def _next_sync_version(db, table, key, device_id, user_id):
-    """Allocate the next sync_version for a user-scoped record."""
+    """Allocate the next sync_version for a user-scoped record.
+
+    Caller must hold an immediate write transaction before invoking this
+    function. The MAX(sync_version) read followed by the write below can
+    otherwise race under concurrent sync pushes, allocating duplicate versions
+    and causing cursor-based pulls to silently miss changes.
+    """
+    if not db.in_transaction:
+        raise RuntimeError('sync_version allocation requires an active write transaction')
+
     now = int(time.time())
     new_version = get_max_sync_version(db, user_id) + 1
     db.execute(

--- a/tests/sync-version-race.spec.js
+++ b/tests/sync-version-race.spec.js
@@ -1,0 +1,93 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+
+/**
+ * Regression coverage for concurrent sync version allocation.
+ *
+ * The server cursor protocol relies on sync_version being unique and monotonic
+ * for each user. Concurrent pushes used to race when allocating
+ * MAX(sync_version) + 1, which could make later cursor pulls miss changes.
+ */
+
+const { test, expect } = require('@playwright/test');
+const {
+    BASE_URL,
+    registerDevice,
+    syncAndExpectOk,
+    syncRequest,
+    commentInsertChange,
+    setupSyncUser,
+} = require('./sync-helpers');
+
+test.describe('Sync Version Allocation Race', () => {
+    test('concurrent pushes allocate distinct versions and cursor pulls do not miss changes', async ({ request }) => {
+        const { access_token, device_id: deviceA } = await setupSyncUser(request);
+        const { device_id: deviceB } = await registerDevice(request, BASE_URL, access_token);
+        const { device_id: deviceC } = await registerDevice(request, BASE_URL, access_token);
+
+        const changeCount = 12;
+        const changes = Array.from({ length: changeCount }, (_, index) =>
+            commentInsertChange({ text: `Concurrent sync comment ${index}` }),
+        );
+
+        const pushedTextsByKey = Object.fromEntries(changes.map((change) => [change.key, change.data.text]));
+        expect(new Set(Object.keys(pushedTextsByKey)).size).toBe(changeCount);
+
+        // `flask run` serves requests on worker threads by default, so these
+        // Promise.all pushes exercise concurrent sync handlers against SQLite.
+        const pushResults = await Promise.all(
+            changes.map(async (change, index) => {
+                const deviceId = index % 2 === 0 ? deviceA : deviceB;
+                const response = await syncRequest(request, BASE_URL, access_token, deviceId, null, [change]);
+                const text = await response.text();
+                let body;
+                try {
+                    body = JSON.parse(text);
+                } catch {
+                    body = { raw: text };
+                }
+                return { status: response.status(), body };
+            }),
+        );
+
+        const acceptedVersions = [];
+        for (const result of pushResults) {
+            expect(result.status, JSON.stringify(result.body)).toBe(200);
+            expect(result.body.accepted).toHaveLength(1);
+            expect(result.body.rejected).toHaveLength(0);
+            expect(typeof result.body.accepted[0].sync_version).toBe('number');
+            acceptedVersions.push(result.body.accepted[0].sync_version);
+        }
+
+        const sortedVersions = [...acceptedVersions].sort((a, b) => a - b);
+        const expectedVersions = Array.from({ length: changeCount }, (_, index) => sortedVersions[0] + index);
+        expect(new Set(acceptedVersions).size).toBe(changeCount);
+        expect(sortedVersions[0]).toBeGreaterThan(0);
+        expect(sortedVersions).toEqual(expectedVersions);
+
+        const pullResult = await syncAndExpectOk(request, BASE_URL, access_token, deviceC, null, []);
+        const pushedKeys = changes.map((change) => change.key).sort();
+        const pulledKeys = pullResult.remote_changes.map((change) => change.key).sort();
+        const pulledVersions = pullResult.remote_changes.map((change) => change.sync_version).sort((a, b) => a - b);
+        const pulledTextsByKey = Object.fromEntries(
+            pullResult.remote_changes.map((change) => [change.key, change.data.text]),
+        );
+
+        expect(pullResult.accepted).toEqual([]);
+        expect(pullResult.rejected).toEqual([]);
+        expect(pullResult.remote_changes).toHaveLength(changeCount);
+        expect(pulledKeys).toEqual(pushedKeys);
+        expect(pulledVersions).toEqual(sortedVersions);
+        expect(pulledTextsByKey).toEqual(pushedTextsByKey);
+
+        const followUpPull = await syncAndExpectOk(
+            request,
+            BASE_URL,
+            access_token,
+            deviceC,
+            pullResult.delta_cursor,
+            [],
+        );
+        expect(followUpPull.remote_changes).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- wrap the `/api/sync` write phase in `BEGIN IMMEDIATE` so sync version allocation is serialized
- rollback explicitly on sync write-phase exceptions and document the transaction invariant on `_next_sync_version`
- add a concurrent sync regression spec using two push devices and a third pull-only device

## Why
`_next_sync_version()` used `MAX(sync_version) + 1` before writing. Concurrent sync pushes for the same user could allocate duplicate versions, and cursor pulls using `sync_version > cursor` could then silently miss a committed change.

Closes #101.

## Validation
- `python3 -m py_compile server/routes/sync.py server/sync/delta.py`
- `node --check tests/sync-version-race.spec.js`
- `npx playwright test tests/sync-version-race.spec.js`
- `npx playwright test tests/sync-version-race.spec.js --repeat-each=20`
- `npm run lint:py`
- `npm run format:py:check`
- `npx biome format tests/sync-version-race.spec.js`
- `npx biome lint tests/sync-version-race.spec.js`
- `npx playwright test` (541 passed, 4 skipped)