### PR TITLE
[codex] Add usage stats consent modal

### DIFF
--- a/desktop/src-tauri/migrations/008_instrumentation.sql
+++ b/desktop/src-tauri/migrations/008_instrumentation.sql
@@ -4,8 +4,8 @@ CREATE TABLE IF NOT EXISTS instrumentation (
     revision INTEGER NOT NULL DEFAULT 0,
     installation_id TEXT NOT NULL,
     first_seen TEXT NOT NULL,
+    last_seen TEXT NOT NULL,
     sessions INTEGER NOT NULL DEFAULT 0,
     studies_imported INTEGER NOT NULL DEFAULT 0,
-    share_enabled INTEGER NOT NULL DEFAULT 0,
-    consent_decision_at TEXT
+    share_enabled INTEGER NOT NULL DEFAULT 0
 );

--- a/desktop/src-tauri/migrations/008_instrumentation.sql
+++ b/desktop/src-tauri/migrations/008_instrumentation.sql
@@ -4,8 +4,8 @@ CREATE TABLE IF NOT EXISTS instrumentation (
     revision INTEGER NOT NULL DEFAULT 0,
     installation_id TEXT NOT NULL,
     first_seen TEXT NOT NULL,
-    last_seen TEXT NOT NULL,
     sessions INTEGER NOT NULL DEFAULT 0,
     studies_imported INTEGER NOT NULL DEFAULT 0,
-    share_enabled INTEGER NOT NULL DEFAULT 0
+    share_enabled INTEGER NOT NULL DEFAULT 0,
+    consent_decision_at TEXT
 );

--- a/desktop/src-tauri/migrations/009_drop_last_seen.sql
+++ b/desktop/src-tauri/migrations/009_drop_last_seen.sql
@@ -1,3 +1,9 @@
+-- Move the desktop instrumentation table from the v0.3.2 shape to the v0.4
+-- consent shape. Migration 008 is intentionally kept as the historical schema
+-- that shipped with last_seen and without consent_decision_at; this migration
+-- adds consent_decision_at first, then rebuilds the table without last_seen.
+ALTER TABLE instrumentation ADD COLUMN consent_decision_at TEXT;
+
 DROP TABLE IF EXISTS instrumentation_next;
 
 CREATE TABLE IF NOT EXISTS instrumentation_next (
@@ -32,7 +38,7 @@ SELECT
     sessions,
     studies_imported,
     share_enabled,
-    NULL
+    consent_decision_at
 FROM instrumentation;
 
 DROP TABLE instrumentation;

--- a/desktop/src-tauri/migrations/009_drop_last_seen.sql
+++ b/desktop/src-tauri/migrations/009_drop_last_seen.sql
@@ -1,0 +1,40 @@
+DROP TABLE IF EXISTS instrumentation_next;
+
+CREATE TABLE IF NOT EXISTS instrumentation_next (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    version INTEGER NOT NULL DEFAULT 1,
+    revision INTEGER NOT NULL DEFAULT 0,
+    installation_id TEXT NOT NULL,
+    first_seen TEXT NOT NULL,
+    sessions INTEGER NOT NULL DEFAULT 0,
+    studies_imported INTEGER NOT NULL DEFAULT 0,
+    share_enabled INTEGER NOT NULL DEFAULT 0,
+    consent_decision_at TEXT
+);
+
+INSERT OR REPLACE INTO instrumentation_next (
+    id,
+    version,
+    revision,
+    installation_id,
+    first_seen,
+    sessions,
+    studies_imported,
+    share_enabled,
+    consent_decision_at
+)
+SELECT
+    id,
+    version,
+    revision,
+    installation_id,
+    first_seen,
+    sessions,
+    studies_imported,
+    share_enabled,
+    NULL
+FROM instrumentation;
+
+DROP TABLE instrumentation;
+
+ALTER TABLE instrumentation_next RENAME TO instrumentation;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -276,6 +276,12 @@ fn desktop_db_migrations() -> Vec<Migration> {
             sql: include_str!("../migrations/008_instrumentation.sql"),
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 9,
+            description: "drop_last_seen_from_instrumentation",
+            sql: include_str!("../migrations/009_drop_last_seen.sql"),
+            kind: MigrationKind::Up,
+        },
     ]
 }
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1708,7 +1708,6 @@ header {
     border: none;
     background: transparent;
     color: var(--color-text-primary);
-    overflow: hidden;
 }
 
 .usage-stats-consent-dialog::backdrop {
@@ -1716,15 +1715,11 @@ header {
 }
 
 .usage-stats-consent-content {
-    display: flex;
-    flex-direction: column;
-    max-height: calc(100vh - 2rem);
     padding: 1.5rem;
     border: 1px solid var(--color-border);
     border-radius: 8px;
     background-color: var(--color-bg-surface);
     box-shadow: var(--shadow-lg);
-    overflow: hidden;
 }
 
 .usage-stats-consent-content h2 {
@@ -1743,11 +1738,9 @@ header {
 }
 
 .usage-stats-consent-stats {
-    min-height: 0;
     margin-top: 1rem;
     padding-top: 1rem;
     border-top: 1px solid var(--color-border-subtle);
-    overflow-y: auto;
 }
 
 .usage-stats-consent-stats h3 {
@@ -1819,7 +1812,6 @@ header {
 }
 
 .usage-stats-consent-actions {
-    flex: 0 0 auto;
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 0.75rem;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1796,24 +1796,6 @@ header {
     margin-bottom: 0;
 }
 
-.usage-stats-consent-link {
-    margin-top: 0.1rem;
-    padding: 0;
-    border: none;
-    background: transparent;
-    color: var(--color-accent);
-    font: inherit;
-    font-size: 0.9rem;
-    font-weight: 600;
-    text-decoration: underline;
-    cursor: pointer;
-}
-
-.usage-stats-consent-link:focus-visible {
-    outline: 3px solid var(--color-amber-100);
-    outline-offset: 3px;
-}
-
 .usage-stats-consent-actions {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1739,8 +1739,6 @@ header {
 
 .usage-stats-consent-stats {
     margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--color-border-subtle);
 }
 
 .usage-stats-consent-box {
@@ -1791,9 +1789,7 @@ header {
 }
 
 .usage-stats-consent-negative {
-    margin-top: 0.65rem;
-    padding-top: 0.8rem;
-    border-top: 1px solid var(--color-border-subtle);
+    margin-top: 0.9rem;
 }
 
 .usage-stats-consent-negative p:last-child {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1708,6 +1708,7 @@ header {
     border: none;
     background: transparent;
     color: var(--color-text-primary);
+    margin: auto;
 }
 
 .usage-stats-consent-dialog::backdrop {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1784,7 +1784,13 @@ header {
 }
 
 .usage-stats-consent-negative {
-    margin-top: 0.9rem;
+    margin-top: 0.65rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid var(--color-border-subtle);
+}
+
+.usage-stats-consent-negative p:last-child {
+    margin-bottom: 0;
 }
 
 .usage-stats-consent-link {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1702,7 +1702,7 @@ header {
    ========================================================================== */
 
 .usage-stats-consent-dialog {
-    width: min(520px, calc(100vw - 2rem));
+    width: min(640px, calc(100vw - 2rem));
     max-height: calc(100vh - 2rem);
     padding: 0;
     border: none;
@@ -1737,17 +1737,18 @@ header {
     line-height: 1.55;
 }
 
-.usage-stats-consent-details {
+.usage-stats-consent-stats {
     margin-top: 1rem;
     padding-top: 1rem;
     border-top: 1px solid var(--color-border-subtle);
 }
 
-.usage-stats-consent-details summary {
+.usage-stats-consent-stats h3 {
+    margin: 0;
     color: var(--color-text-primary);
     font-size: 0.95rem;
     font-weight: 600;
-    cursor: pointer;
+    line-height: 1.35;
 }
 
 .usage-stats-consent-list {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1697,7 +1697,149 @@ header {
 }
 
 /* ==========================================================================
-   5b. ACCOUNT UI
+   5b. USAGE STATS CONSENT
+   First-launch consent dialog for anonymous instrumentation
+   ========================================================================== */
+
+.usage-stats-consent-dialog {
+    width: min(520px, calc(100vw - 2rem));
+    max-height: calc(100vh - 2rem);
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--color-text-primary);
+}
+
+.usage-stats-consent-dialog::backdrop {
+    background-color: rgba(15, 30, 20, 0.72);
+}
+
+.usage-stats-consent-content {
+    padding: 1.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background-color: var(--color-bg-surface);
+    box-shadow: var(--shadow-lg);
+}
+
+.usage-stats-consent-content h2 {
+    margin: 0 0 0.75rem;
+    color: var(--color-charcoal);
+    font-family: var(--font-serif);
+    font-size: 1.35rem;
+    line-height: 1.25;
+}
+
+.usage-stats-consent-content p {
+    margin: 0 0 0.8rem;
+    color: var(--color-text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.55;
+}
+
+.usage-stats-consent-details {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border-subtle);
+}
+
+.usage-stats-consent-details summary {
+    color: var(--color-text-primary);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.usage-stats-consent-list {
+    margin: 0.9rem 0 0;
+}
+
+.usage-stats-consent-list div {
+    display: grid;
+    grid-template-columns: minmax(8rem, 1fr) minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.usage-stats-consent-list div:last-child {
+    border-bottom: none;
+}
+
+.usage-stats-consent-list dt,
+.usage-stats-consent-list dd {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+.usage-stats-consent-list dt {
+    color: var(--color-text-secondary);
+}
+
+.usage-stats-consent-list dd {
+    color: var(--color-text-primary);
+    font-weight: 600;
+    text-align: right;
+}
+
+.usage-stats-consent-negative {
+    margin-top: 0.9rem;
+}
+
+.usage-stats-consent-link {
+    margin-top: 0.1rem;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--color-accent);
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.usage-stats-consent-link:focus-visible {
+    outline: 3px solid var(--color-amber-100);
+    outline-offset: 3px;
+}
+
+.usage-stats-consent-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-top: 1.35rem;
+}
+
+.usage-stats-consent-btn {
+    min-height: 42px;
+    padding: 0.7rem 0.85rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background-color: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        color 0.15s ease;
+}
+
+.usage-stats-consent-btn:hover {
+    border-color: var(--color-accent);
+    background-color: var(--color-amber-50);
+}
+
+.usage-stats-consent-btn:focus-visible {
+    outline: 3px solid var(--color-amber-100);
+    outline-offset: 2px;
+}
+
+/* ==========================================================================
+   5c. ACCOUNT UI
    Login/signup modal and account status indicator (cloud mode)
    ========================================================================== */
 
@@ -2047,6 +2189,19 @@ header {
 
     .help-viewer-content {
         padding: 1.25rem;
+    }
+
+    .usage-stats-consent-content {
+        padding: 1.15rem;
+    }
+
+    .usage-stats-consent-actions,
+    .usage-stats-consent-list div {
+        grid-template-columns: 1fr;
+    }
+
+    .usage-stats-consent-list dd {
+        text-align: left;
     }
 }
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1743,6 +1743,13 @@ header {
     border-top: 1px solid var(--color-border-subtle);
 }
 
+.usage-stats-consent-box {
+    padding: 0.9rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 8px;
+    background-color: var(--color-bg-surface);
+}
+
 .usage-stats-consent-stats h3 {
     margin: 0;
     color: var(--color-text-primary);

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1708,6 +1708,7 @@ header {
     border: none;
     background: transparent;
     color: var(--color-text-primary);
+    overflow: hidden;
 }
 
 .usage-stats-consent-dialog::backdrop {
@@ -1715,11 +1716,15 @@ header {
 }
 
 .usage-stats-consent-content {
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 2rem);
     padding: 1.5rem;
     border: 1px solid var(--color-border);
     border-radius: 8px;
     background-color: var(--color-bg-surface);
     box-shadow: var(--shadow-lg);
+    overflow: hidden;
 }
 
 .usage-stats-consent-content h2 {
@@ -1738,9 +1743,11 @@ header {
 }
 
 .usage-stats-consent-stats {
+    min-height: 0;
     margin-top: 1rem;
     padding-top: 1rem;
     border-top: 1px solid var(--color-border-subtle);
+    overflow-y: auto;
 }
 
 .usage-stats-consent-stats h3 {
@@ -1812,6 +1819,7 @@ header {
 }
 
 .usage-stats-consent-actions {
+    flex: 0 0 auto;
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 0.75rem;

--- a/docs/decisions/008-local-first-instrumentation.md
+++ b/docs/decisions/008-local-first-instrumentation.md
@@ -1,7 +1,7 @@
 # ADR 008: Local-First Instrumentation
 
 ## Status
-Accepted (Stage 1 implemented)
+Accepted (Stage 1 implemented; v0.4 consent update applied)
 
 ## Context
 
@@ -56,7 +56,7 @@ These five principles emerged from the benchmarking and guide this decision:
 
 ## Decision
 
-Implement local-only usage counters that are stored in app-data and surfaced to the user in a visible "Usage Stats" panel. No data leaves the machine. The user sees exactly what the app tracks -- the stats panel is the privacy policy.
+Implement local-first usage counters that are stored in app-data and surfaced to the user in a visible "Usage Stats" panel. No data leaves the machine until the user explicitly consents in the first-launch usage-stats dialog. The user sees exactly what the app tracks -- the stats panel is the privacy policy.
 
 ### Two-stream architecture
 
@@ -69,7 +69,7 @@ Implement local-only usage counters that are stored in app-data and surfaced to 
 **Telemetry stream** (usage counters):
 - Aggregate counters of app behavior (sessions, features used, modalities seen, errors)
 - No PHI, no patient identifiers, no file paths, no study content
-- Stored locally, surfaced to user, optionally synced in cloud mode
+- Stored locally, surfaced to user, optionally shared as aggregate counters after explicit consent
 - The app's operational data -- safe to collect and display
 
 These streams share no storage, no API, and no persistence layer. The separation is architectural, not just policy.
@@ -80,17 +80,17 @@ Stage 1 ships with a deliberately minimal counter set. The event taxonomy will g
 
 **Identity and timing:**
 - `installationId` -- per-installation UUID via `crypto.randomUUID()`. Survives `resetStats()` so a reset does not invalidate the cloud mapping. Will later be mapped to account IDs in cloud mode.
-- `firstSeen` -- ISO timestamp of the first app open (members-since date).
-- `lastSeen` -- ISO timestamp of the most recent mutation.
+- `firstSeen` -- ISO timestamp of the first app open (members-since date). Local-only. Shown to the user as "Using since" and never sent to the stats worker.
 
 **Usage counters:**
 - `sessions` -- incremented once per app open (`trackAppOpen()`).
 - `studiesImported` -- incremented by user-initiated imports only (`trackStudiesImported(count)`). This counter does NOT increase for viewer opens, refreshes, rescans, auto-loads, or sample-data loads.
 
 **Schema bookkeeping:**
-- `version` -- schema version (currently 1). `migrateStats()` runs on every read and adds missing fields with zero defaults; fields are never removed.
+- `version` -- schema version (currently 1). `migrateStats()` runs on every read, adds missing fields with defaults, and removes deprecated local fields such as `lastSeen`.
 - `revision` -- monotonic integer incremented on every `saveStats()` call. The server will upsert only if `incoming.revision > stored.revision`, preventing stale writes from overwriting newer local state.
 - `shareEnabled` -- boolean toggle for phone-home. Stored locally; not included in phone-home payloads.
+- `consentDecisionAt` -- ISO timestamp of the user's first-launch consent choice. Stored locally; required with `shareEnabled === true` before any phone-home request is allowed.
 
 Additional counters (feature usage, modality breakdown, errors) are deferred to a later stage. The sealed API means new counters are added via new helpers, not by opening a generic `trackEvent(category, action)` surface.
 
@@ -120,11 +120,12 @@ The stats panel is a section in the existing help modal (opened via the `?` butt
 
 Stage 1 shows:
 - **Using since** -- formatted `firstSeen` date
-- **Last opened** -- formatted `lastSeen` date
 - **Sessions** -- the `sessions` counter
 - **Studies imported** -- the `studiesImported` counter
 - **Share anonymous usage stats** -- checkbox bound to `setShareEnabled()`; off by default
 - A short disclosure paragraph explaining exactly what is and is not shared
+
+The first-launch consent dialog is the up-front sharing decision surface. It shows the same live local counters in plain language and records the decision through `recordConsentDecision()`. Closing the dialog without choosing leaves `consentDecisionAt` unset and prevents network sharing even if an older install had `shareEnabled === true`.
 
 This is not gamification (no levels, no points, no streaks). It is a transparent accounting of what the app knows about how it has been used. As counters are added in later stages, the panel grows inline -- the goal is a positive, identity-affirming portrait of the user's workflow rather than raw counter tables.
 
@@ -196,11 +197,12 @@ The module deliberately does NOT expose a free-form `trackEvent(category, action
 
 | Function | Notes |
 |---|---|
-| `trackAppOpen()` | Async. Awaits `initPromise`, increments `sessions`, updates `lastSeen`, flushes immediately so the session count persists before the next page navigation. |
-| `trackStudiesImported(count)` | Async. Awaits `initPromise`, validates `count` is a positive integer, increments `studiesImported`, updates `lastSeen`, flushes immediately. |
+| `trackAppOpen()` | Async. Awaits `initPromise`, increments `sessions`, flushes immediately so the session count persists before the next page navigation. |
+| `trackStudiesImported(count)` | Async. Awaits `initPromise`, validates `count` is a positive integer, increments `studiesImported`, flushes immediately. |
 | `getStats()` | Returns a defensive copy of the stats object, or `null` if instrumentation is disabled. |
-| `resetStats()` | Resets counters but preserves `installationId` and `shareEnabled`. |
-| `setShareEnabled(bool)` / `isShareEnabled()` | Phone-home toggle. Enabling (false to true) triggers one immediate POST after the flush settles. |
+| `resetStats()` | Resets counters but preserves `installationId`, `firstSeen`, `shareEnabled`, and `consentDecisionAt`. |
+| `recordConsentDecision(bool)` | Atomic first-launch consent write. Sets `shareEnabled`, stamps `consentDecisionAt`, persists, and sends one immediate POST only when the choice is share. |
+| `setShareEnabled(bool)` / `isShareEnabled()` | Existing stats-panel toggle. It can change sharing after a decision exists, but it does not stamp `consentDecisionAt`. |
 | `renderStatsPanel(container)` | Renders the stats table, share toggle, and disclosure paragraph into the help modal section. |
 | `ready` | Promise that resolves when `init()` has loaded stats from storage. Exposed for tests and for any caller that needs deterministic startup ordering. |
 
@@ -214,14 +216,14 @@ The module deliberately does NOT expose a free-form `trackEvent(category, action
   "revision": 42,
   "installationId": "e54ce9f8-2d2e-4c6b-9a7b-5a1c3b8b8c7a",
   "firstSeen": "2026-04-06T14:30:00.000Z",
-  "lastSeen": "2026-04-08T09:17:22.341Z",
   "sessions": 17,
   "studiesImported": 6,
-  "shareEnabled": false
+  "shareEnabled": false,
+  "consentDecisionAt": null
 }
 ```
 
-`migrateStats(blob)` runs on every read. Missing fields are added with zero/default values. Fields are never removed so old installs never lose data. The `version` field is rewritten to the current schema version on every load.
+`migrateStats(blob)` runs on every read. Missing fields are added with zero/default values, `firstSeen` is preserved for the user's own panel, and the deprecated `lastSeen` field is removed. The `version` field is rewritten to the current schema version on every load.
 
 **Desktop SQLite schema** (migration `desktop/src-tauri/migrations/008_instrumentation.sql`):
 
@@ -232,14 +234,14 @@ CREATE TABLE IF NOT EXISTS instrumentation (
     revision INTEGER NOT NULL DEFAULT 0,
     installation_id TEXT NOT NULL,
     first_seen TEXT NOT NULL,
-    last_seen TEXT NOT NULL,
     sessions INTEGER NOT NULL DEFAULT 0,
     studies_imported INTEGER NOT NULL DEFAULT 0,
-    share_enabled INTEGER NOT NULL DEFAULT 0
+    share_enabled INTEGER NOT NULL DEFAULT 0,
+    consent_decision_at TEXT
 );
 ```
 
-The `CHECK (id = 1)` guarantees a single row; writes use `INSERT ... ON CONFLICT(id) DO UPDATE`.
+The `CHECK (id = 1)` guarantees a single row; writes use `INSERT ... ON CONFLICT(id) DO UPDATE`. Migration `009_drop_last_seen.sql` removes the old desktop `last_seen` column for installs that already ran the earlier instrumentation schema.
 
 ### Write debouncing and flush lifecycle
 
@@ -259,11 +261,13 @@ Personal mode uses the raw new-study count from the drop handler, which is alrea
 
 ### Phone-home transport
 
-Phone-home is off by default. Enabling the toggle in the stats panel (`setShareEnabled(true)`):
+Phone-home is off by default and requires effective consent: `shareEnabled === true && consentDecisionAt != null`. The first-launch consent dialog records that decision with `recordConsentDecision(true)`:
 
-1. Persists `shareEnabled = true` via a normal flush.
+1. Persists `shareEnabled = true` and `consentDecisionAt = now` in the same stats write.
 2. Sends one immediate POST of the current persisted state.
 3. From then on, every subsequent `saveStats()` schedules a debounced POST 5 seconds later (debounced so a burst of saves produces a single network request).
+
+Closing the dialog without choosing leaves `consentDecisionAt` unset. This blocks phone-home for retroactive v0.3.2 upgraders even when their legacy local blob has `shareEnabled === true`.
 
 The endpoint is `https://api.myradone.com/api/stats` (allowlisted in Tauri CSP `connect-src`). Requests are fire-and-forget: failures are silent and never surface to the UI. The payload is:
 
@@ -272,14 +276,12 @@ The endpoint is `https://api.myradone.com/api/stats` (allowlisted in Tauri CSP `
   "version": 1,
   "revision": 42,
   "installationId": "e54ce9f8-...",
-  "firstSeen": "2026-04-06T14:30:00.000Z",
-  "lastSeen": "2026-04-08T09:17:22.341Z",
   "sessions": 17,
   "studiesImported": 6
 }
 ```
 
-`shareEnabled` is deliberately NOT in the payload. It is a local UI preference; the server does not need to know whether the client has the checkbox checked, only that a request arrived.
+`firstSeen`, `lastSeen`, `shareEnabled`, and `consentDecisionAt` are deliberately NOT in the payload. `firstSeen` is local-only; `lastSeen` is deprecated; the consent fields are local UI state. The stats worker continues to accept legacy `firstSeen` and `lastSeen` fields from older clients, validates them if present, and strips them before persistence.
 
 ### Integration points
 

--- a/docs/decisions/008-local-first-instrumentation.md
+++ b/docs/decisions/008-local-first-instrumentation.md
@@ -106,7 +106,7 @@ Additional counters (feature usage, modality breakdown, errors) are deferred to 
 
 ### Storage
 
-- Desktop: SQLite `instrumentation` table (single row enforced by `CHECK (id = 1)`), created by migration `008_instrumentation.sql`. Shares the existing `viewer.db` database.
+- Desktop: SQLite `instrumentation` table (single row enforced by `CHECK (id = 1)`), created by migration `008_instrumentation.sql` and moved to the consent-aware shape by `009_drop_last_seen.sql`. Shares the existing `viewer.db` database.
 - Personal (localhost Flask): `localStorage` under the key `dicom-viewer-instrumentation-v1`.
 - Demo (GitHub Pages): disabled. No storage writes, no network requests, no stats section in the help modal.
 - Preview (Vercel PR previews): disabled. Same behavior as demo so preview builds don't touch production state.
@@ -122,7 +122,7 @@ Stage 1 shows:
 - **Using since** -- formatted `firstSeen` date
 - **Sessions** -- the `sessions` counter
 - **Studies imported** -- the `studiesImported` counter
-- **Share anonymous usage stats** -- checkbox bound to `setShareEnabled()`; off by default
+- **Share anonymous usage stats** -- checkbox that records an initial consent choice when needed, then uses `setShareEnabled()` for later changes; off by default
 - A short disclosure paragraph explaining exactly what is and is not shared
 
 The first-launch consent dialog is the up-front sharing decision surface. It shows the same live local counters in plain language and records the decision through `recordConsentDecision()`. Closing the dialog without choosing leaves `consentDecisionAt` unset and prevents network sharing even if an older install had `shareEnabled === true`.
@@ -202,7 +202,7 @@ The module deliberately does NOT expose a free-form `trackEvent(category, action
 | `getStats()` | Returns a defensive copy of the stats object, or `null` if instrumentation is disabled. |
 | `resetStats()` | Resets counters but preserves `installationId`, `firstSeen`, `shareEnabled`, and `consentDecisionAt`. |
 | `recordConsentDecision(bool)` | Atomic first-launch consent write. Sets `shareEnabled`, stamps `consentDecisionAt`, persists, and sends one immediate POST only when the choice is share. |
-| `setShareEnabled(bool)` / `isShareEnabled()` | Existing stats-panel toggle. It can change sharing after a decision exists, but it does not stamp `consentDecisionAt`. |
+| `setShareEnabled(bool)` / `isShareEnabled()` | Existing stats-panel toggle helper. It can change sharing after a decision exists, but it does not stamp `consentDecisionAt`; the panel routes first-time choices through `recordConsentDecision()`. |
 | `renderStatsPanel(container)` | Renders the stats table, share toggle, and disclosure paragraph into the help modal section. |
 | `ready` | Promise that resolves when `init()` has loaded stats from storage. Exposed for tests and for any caller that needs deterministic startup ordering. |
 
@@ -225,7 +225,7 @@ The module deliberately does NOT expose a free-form `trackEvent(category, action
 
 `migrateStats(blob)` runs on every read. Missing fields are added with zero/default values, `firstSeen` is preserved for the user's own panel, and the deprecated `lastSeen` field is removed. The `version` field is rewritten to the current schema version on every load.
 
-**Desktop SQLite schema** (migration `desktop/src-tauri/migrations/008_instrumentation.sql`):
+**Desktop SQLite schema after migration `009_drop_last_seen.sql`:**
 
 ```sql
 CREATE TABLE IF NOT EXISTS instrumentation (
@@ -241,7 +241,7 @@ CREATE TABLE IF NOT EXISTS instrumentation (
 );
 ```
 
-The `CHECK (id = 1)` guarantees a single row; writes use `INSERT ... ON CONFLICT(id) DO UPDATE`. Migration `009_drop_last_seen.sql` removes the old desktop `last_seen` column for installs that already ran the earlier instrumentation schema.
+The `CHECK (id = 1)` guarantees a single row; writes use `INSERT ... ON CONFLICT(id) DO UPDATE`. Migration `008_instrumentation.sql` is intentionally kept as the historical v0.3.2 schema with `last_seen` and without `consent_decision_at`; migration `009_drop_last_seen.sql` adds `consent_decision_at`, preserves it during the table rebuild, and removes `last_seen`.
 
 ### Write debouncing and flush lifecycle
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://api.myradone.com; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob: 'wasm-unsafe-eval'; object-src 'none'; base-uri 'self'">
     <title>myradone</title>
-    <link rel="stylesheet" href="css/style.css?v=7">
+    <link rel="stylesheet" href="css/style.css?v=8">
 
     <!-- DICOM parsing library -->
     <script src="js/vendor/dicomParser.min.js"></script>
@@ -274,8 +274,8 @@ Copyright (c) 2026 Divergent Health Technologies
             <p>
                 No medical images, patient data, file paths, study details, or report contents are included.
             </p>
-            <details class="usage-stats-consent-details" open>
-                <summary>Stats that would be shared</summary>
+            <section class="usage-stats-consent-stats" aria-labelledby="usageStatsConsentStatsTitle">
+                <h3 id="usageStatsConsentStatsTitle">Stats that would be shared</h3>
                 <dl class="usage-stats-consent-list">
                     <div>
                         <dt>A random ID for this install</dt>
@@ -295,7 +295,7 @@ Copyright (c) 2026 Divergent Health Technologies
                     We do not include your IP address in the stats payload or store it with your install stats.
                 </p>
                 <button id="usageStatsConsentOpenStats" class="usage-stats-consent-link" type="button">Open Usage Stats</button>
-            </details>
+            </section>
             <div class="usage-stats-consent-actions">
                 <button id="usageStatsConsentDecline" class="usage-stats-consent-btn" type="button">Don't share</button>
                 <button id="usageStatsConsentShare" class="usage-stats-consent-btn" type="button">Share</button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -296,8 +296,8 @@ Copyright (c) 2026 Divergent Health Technologies
                 <button id="usageStatsConsentOpenStats" class="usage-stats-consent-link" type="button">Open Usage Stats</button>
             </section>
             <div class="usage-stats-consent-actions">
-                <button id="usageStatsConsentShare" class="usage-stats-consent-btn" type="button">Share</button>
-                <button id="usageStatsConsentDecline" class="usage-stats-consent-btn" type="button">Don't share</button>
+                <button id="usageStatsConsentShare" class="usage-stats-consent-btn" type="button">Agree</button>
+                <button id="usageStatsConsentDecline" class="usage-stats-consent-btn" type="button">Deny</button>
             </div>
         </div>
     </dialog>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://api.myradone.com; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob: 'wasm-unsafe-eval'; object-src 'none'; base-uri 'self'">
     <title>myradone</title>
-    <link rel="stylesheet" href="css/style.css?v=9">
+    <link rel="stylesheet" href="css/style.css?v=10">
 
     <!-- DICOM parsing library -->
     <script src="js/vendor/dicomParser.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -268,11 +268,7 @@ Copyright (c) 2026 Divergent Health Technologies
         <div class="usage-stats-consent-content">
             <h2 id="usageStatsConsentTitle">Please help us improve myRadOne.</h2>
             <p id="usageStatsConsentDescription">
-                myRadOne can share a small usage stats payload with Divergent Health to help improve the app.
-                It includes only app opens and study import counts.
-            </p>
-            <p>
-                No medical images, patient data, file paths, study details, or report contents are included.
+                Only if you allow it, myRadOne can share the following stats back to the developer:
             </p>
             <section class="usage-stats-consent-stats" aria-labelledby="usageStatsConsentStatsTitle">
                 <h3 id="usageStatsConsentStatsTitle">Stats that would be shared</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,7 +295,6 @@ Copyright (c) 2026 Divergent Health Technologies
                         for users like you. Thanks in advance for your support!
                     </p>
                 </div>
-                <button id="usageStatsConsentOpenStats" class="usage-stats-consent-link" type="button">Open Usage Stats</button>
             </section>
             <div class="usage-stats-consent-actions">
                 <button id="usageStatsConsentShare" class="usage-stats-consent-btn" type="button">Agree</button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://api.myradone.com; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob: 'wasm-unsafe-eval'; object-src 'none'; base-uri 'self'">
     <title>myradone</title>
-    <link rel="stylesheet" href="css/style.css?v=11">
+    <link rel="stylesheet" href="css/style.css?v=12">
 
     <!-- DICOM parsing library -->
     <script src="js/vendor/dicomParser.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://api.myradone.com; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob: 'wasm-unsafe-eval'; object-src 'none'; base-uri 'self'">
     <title>myradone</title>
-    <link rel="stylesheet" href="css/style.css?v=8">
+    <link rel="stylesheet" href="css/style.css?v=9">
 
     <!-- DICOM parsing library -->
     <script src="js/vendor/dicomParser.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://api.myradone.com; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob: 'wasm-unsafe-eval'; object-src 'none'; base-uri 'self'">
     <title>myradone</title>
-    <link rel="stylesheet" href="css/style.css?v=9">
+    <link rel="stylesheet" href="css/style.css?v=11">
 
     <!-- DICOM parsing library -->
     <script src="js/vendor/dicomParser.min.js"></script>
@@ -271,21 +271,23 @@ Copyright (c) 2026 Divergent Health Technologies
                 Only if you allow it, myRadOne can share the following stats back to the developer:
             </p>
             <section class="usage-stats-consent-stats" aria-labelledby="usageStatsConsentStatsTitle">
-                <h3 id="usageStatsConsentStatsTitle">Stats</h3>
-                <dl class="usage-stats-consent-list">
-                    <div>
-                        <dt>A random ID for this install</dt>
-                        <dd id="usageStatsConsentInstallId">Unknown</dd>
-                    </div>
-                    <div>
-                        <dt>Total times you've opened the app</dt>
-                        <dd id="usageStatsConsentSessions">0</dd>
-                    </div>
-                    <div>
-                        <dt>Total studies you've imported</dt>
-                        <dd id="usageStatsConsentStudiesImported">0</dd>
-                    </div>
-                </dl>
+                <div class="usage-stats-consent-box">
+                    <h3 id="usageStatsConsentStatsTitle">Stats</h3>
+                    <dl class="usage-stats-consent-list">
+                        <div>
+                            <dt>A random ID for this install</dt>
+                            <dd id="usageStatsConsentInstallId">Unknown</dd>
+                        </div>
+                        <div>
+                            <dt>Total times you've opened the app</dt>
+                            <dd id="usageStatsConsentSessions">0</dd>
+                        </div>
+                        <div>
+                            <dt>Total studies you've imported</dt>
+                            <dd id="usageStatsConsentStudiesImported">0</dd>
+                        </div>
+                    </dl>
+                </div>
                 <div class="usage-stats-consent-negative">
                     <p>No images, no personal information, absolutely nothing else. Just those three numbers.</p>
                     <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -297,8 +297,8 @@ Copyright (c) 2026 Divergent Health Technologies
                 <button id="usageStatsConsentOpenStats" class="usage-stats-consent-link" type="button">Open Usage Stats</button>
             </section>
             <div class="usage-stats-consent-actions">
-                <button id="usageStatsConsentDecline" class="usage-stats-consent-btn" type="button">Don't share</button>
                 <button id="usageStatsConsentShare" class="usage-stats-consent-btn" type="button">Share</button>
+                <button id="usageStatsConsentDecline" class="usage-stats-consent-btn" type="button">Don't share</button>
             </div>
         </div>
     </dialog>

--- a/docs/index.html
+++ b/docs/index.html
@@ -271,7 +271,7 @@ Copyright (c) 2026 Divergent Health Technologies
                 Only if you allow it, myRadOne can share the following stats back to the developer:
             </p>
             <section class="usage-stats-consent-stats" aria-labelledby="usageStatsConsentStatsTitle">
-                <h3 id="usageStatsConsentStatsTitle">Stats that would be shared</h3>
+                <h3 id="usageStatsConsentStatsTitle">Stats</h3>
                 <dl class="usage-stats-consent-list">
                     <div>
                         <dt>A random ID for this install</dt>

--- a/docs/index.html
+++ b/docs/index.html
@@ -263,6 +263,46 @@ Copyright (c) 2026 Divergent Health Technologies
         </div>
     </div>
 
+    <!-- USAGE STATS CONSENT MODAL -->
+    <dialog id="usageStatsConsentDialog" class="usage-stats-consent-dialog" aria-labelledby="usageStatsConsentTitle" aria-describedby="usageStatsConsentDescription">
+        <div class="usage-stats-consent-content">
+            <h2 id="usageStatsConsentTitle">Share anonymous usage stats?</h2>
+            <p id="usageStatsConsentDescription">
+                myRadOne can share a small usage stats payload with Divergent Health to help improve the app.
+                It includes only app opens and study import counts.
+            </p>
+            <p>
+                No medical images, patient data, file paths, study details, or report contents are included.
+            </p>
+            <details class="usage-stats-consent-details" open>
+                <summary>Stats that would be shared</summary>
+                <dl class="usage-stats-consent-list">
+                    <div>
+                        <dt>A random ID for this install</dt>
+                        <dd id="usageStatsConsentInstallId">Unknown</dd>
+                    </div>
+                    <div>
+                        <dt>Total times you've opened the app</dt>
+                        <dd id="usageStatsConsentSessions">0</dd>
+                    </div>
+                    <div>
+                        <dt>Total studies you've imported</dt>
+                        <dd id="usageStatsConsentStudiesImported">0</dd>
+                    </div>
+                </dl>
+                <p class="usage-stats-consent-negative">
+                    Nothing else. No images, no patient data, no file paths, no dates, no device name.
+                    We do not include your IP address in the stats payload or store it with your install stats.
+                </p>
+                <button id="usageStatsConsentOpenStats" class="usage-stats-consent-link" type="button">Open Usage Stats</button>
+            </details>
+            <div class="usage-stats-consent-actions">
+                <button id="usageStatsConsentDecline" class="usage-stats-consent-btn" type="button">Don't share</button>
+                <button id="usageStatsConsentShare" class="usage-stats-consent-btn" type="button">Share</button>
+            </div>
+        </div>
+    </dialog>
+
     <script src="js/app/state.js"></script>
     <script src="js/app/dom.js"></script>
     <script src="js/app/utils.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: blob: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://api.myradone.com; img-src 'self' data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob: 'wasm-unsafe-eval'; object-src 'none'; base-uri 'self'">
     <title>myradone</title>
-    <link rel="stylesheet" href="css/style.css?v=10">
+    <link rel="stylesheet" href="css/style.css?v=9">
 
     <!-- DICOM parsing library -->
     <script src="js/vendor/dicomParser.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -286,10 +286,13 @@ Copyright (c) 2026 Divergent Health Technologies
                         <dd id="usageStatsConsentStudiesImported">0</dd>
                     </div>
                 </dl>
-                <p class="usage-stats-consent-negative">
-                    Nothing else. No images, no patient data, no file paths, no dates, no device name.
-                    We do not include your IP address in the stats payload or store it with your install stats.
-                </p>
+                <div class="usage-stats-consent-negative">
+                    <p>No images, no personal information, absolutely nothing else. Just those three numbers.</p>
+                    <p>
+                        This information won't be sent elsewhere. It will be used exclusively to improve the application
+                        for users like you. Thanks in advance for your support!
+                    </p>
+                </div>
                 <button id="usageStatsConsentOpenStats" class="usage-stats-consent-link" type="button">Open Usage Stats</button>
             </section>
             <div class="usage-stats-consent-actions">

--- a/docs/index.html
+++ b/docs/index.html
@@ -266,7 +266,7 @@ Copyright (c) 2026 Divergent Health Technologies
     <!-- USAGE STATS CONSENT MODAL -->
     <dialog id="usageStatsConsentDialog" class="usage-stats-consent-dialog" aria-labelledby="usageStatsConsentTitle" aria-describedby="usageStatsConsentDescription">
         <div class="usage-stats-consent-content">
-            <h2 id="usageStatsConsentTitle">Share anonymous usage stats?</h2>
+            <h2 id="usageStatsConsentTitle">Please help us improve myRadOne.</h2>
             <p id="usageStatsConsentDescription">
                 myRadOne can share a small usage stats payload with Divergent Health to help improve the app.
                 It includes only app opens and study import counts.

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -487,6 +487,12 @@
     function initializeUsageStatsConsentDialog(appOpenPromise) {
         if (config?.features?.instrumentation !== true) return;
 
+        const isLocalAutomatedTestRun =
+            navigator.webdriver === true &&
+            window.__DICOM_VIEWER_FORCE_CONSENT_MODAL__ !== true &&
+            (window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost');
+        if (isLocalAutomatedTestRun) return;
+
         const dialog = $('usageStatsConsentDialog');
         if (!dialog || typeof dialog.showModal !== 'function') return;
 

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -484,14 +484,20 @@
         if (studiesEl) studiesEl.textContent = String(stats.studiesImported ?? 0);
     }
 
+    function shouldSkipUsageStatsConsentDialogForLocalAutomation() {
+        const isLocalHost = window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost';
+        const forceDialog = window.__DICOM_VIEWER_FORCE_CONSENT_MODAL__ === true;
+
+        // Most Playwright specs exercise unrelated app flows on localhost. Keep
+        // the first-launch dialog out of those local automated runs; consent
+        // specs opt in with __DICOM_VIEWER_FORCE_CONSENT_MODAL__.
+        return navigator.webdriver === true && isLocalHost && !forceDialog;
+    }
+
     function initializeUsageStatsConsentDialog(appOpenPromise) {
         if (config?.features?.instrumentation !== true) return;
 
-        const isLocalAutomatedTestRun =
-            navigator.webdriver === true &&
-            window.__DICOM_VIEWER_FORCE_CONSENT_MODAL__ !== true &&
-            (window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost');
-        if (isLocalAutomatedTestRun) return;
+        if (shouldSkipUsageStatsConsentDialogForLocalAutomation()) return;
 
         const dialog = $('usageStatsConsentDialog');
         if (!dialog || typeof dialog.showModal !== 'function') return;

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -471,6 +471,86 @@
             });
     }
 
+    function updateUsageStatsConsentDialog() {
+        const stats = window.Instrumentation?.getStats?.();
+        if (!stats) return;
+
+        const installIdEl = $('usageStatsConsentInstallId');
+        const sessionsEl = $('usageStatsConsentSessions');
+        const studiesEl = $('usageStatsConsentStudiesImported');
+
+        if (installIdEl) installIdEl.textContent = String(stats.installationId || '').slice(0, 8) || 'Unknown';
+        if (sessionsEl) sessionsEl.textContent = String(stats.sessions ?? 0);
+        if (studiesEl) studiesEl.textContent = String(stats.studiesImported ?? 0);
+    }
+
+    function initializeUsageStatsConsentDialog(appOpenPromise) {
+        if (config?.features?.instrumentation !== true) return;
+
+        const dialog = $('usageStatsConsentDialog');
+        if (!dialog || typeof dialog.showModal !== 'function') return;
+
+        const declineBtn = $('usageStatsConsentDecline');
+        const shareBtn = $('usageStatsConsentShare');
+        const openStatsBtn = $('usageStatsConsentOpenStats');
+        const buttons = [declineBtn, shareBtn].filter(Boolean);
+
+        const setPending = (pending) => {
+            for (const button of buttons) {
+                button.disabled = pending;
+            }
+        };
+
+        const choose = async (enabled) => {
+            setPending(true);
+            try {
+                await window.Instrumentation?.recordConsentDecision?.(enabled);
+                if (dialog.open) {
+                    dialog.close(enabled ? 'share' : 'decline');
+                }
+            } finally {
+                setPending(false);
+            }
+        };
+
+        declineBtn?.addEventListener('click', () => {
+            void choose(false);
+        });
+        shareBtn?.addEventListener('click', () => {
+            void choose(true);
+        });
+        openStatsBtn?.addEventListener('click', () => {
+            if (dialog.open) {
+                dialog.close('usage-stats');
+            }
+            openHelpViewer();
+            requestAnimationFrame(() => {
+                const contentEl = $('helpContent');
+                const statsSection = contentEl?.querySelector('#help-usage-stats');
+                statsSection?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
+        });
+
+        void (async () => {
+            try {
+                await window.Instrumentation?.ready;
+                if (appOpenPromise && typeof appOpenPromise.then === 'function') {
+                    await appOpenPromise;
+                }
+            } catch {
+                return;
+            }
+
+            const stats = window.Instrumentation?.getStats?.();
+            if (!stats || stats.consentDecisionAt != null) return;
+
+            updateUsageStatsConsentDialog();
+            if (!dialog.open) {
+                dialog.showModal();
+            }
+        })();
+    }
+
     studiesTableHead.addEventListener('click', handleSortClick);
     studiesTableHead.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -676,7 +756,9 @@
     // ---- Instrumentation: track app open (ADR 008) ----
     // Fire-and-forget. trackAppOpen awaits the module's init promise
     // internally so the first session is not dropped during the startup race.
-    void window.Instrumentation?.trackAppOpen();
+    const appOpenInstrumentationPromise = window.Instrumentation?.trackAppOpen();
+    void appOpenInstrumentationPromise;
+    initializeUsageStatsConsentDialog(appOpenInstrumentationPromise);
 
     // ---- App initialization ----
 

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -486,12 +486,12 @@
 
     function shouldSkipUsageStatsConsentDialogForLocalAutomation() {
         const isLocalHost = window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost';
-        const forceDialog = window.__DICOM_VIEWER_FORCE_CONSENT_MODAL__ === true;
+        const allowDialogInTests = window.__ALLOW_CONSENT_MODAL_IN_TESTS__ === true;
 
         // Most Playwright specs exercise unrelated app flows on localhost. Keep
         // the first-launch dialog out of those local automated runs; consent
-        // specs opt in with __DICOM_VIEWER_FORCE_CONSENT_MODAL__.
-        return navigator.webdriver === true && isLocalHost && !forceDialog;
+        // specs opt in with __ALLOW_CONSENT_MODAL_IN_TESTS__.
+        return navigator.webdriver === true && isLocalHost && !allowDialogInTests;
     }
 
     function initializeUsageStatsConsentDialog(appOpenPromise) {

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -504,7 +504,6 @@
 
         const declineBtn = $('usageStatsConsentDecline');
         const shareBtn = $('usageStatsConsentShare');
-        const openStatsBtn = $('usageStatsConsentOpenStats');
         const buttons = [declineBtn, shareBtn].filter(Boolean);
 
         const setPending = (pending) => {
@@ -530,17 +529,6 @@
         });
         shareBtn?.addEventListener('click', () => {
             void choose(true);
-        });
-        openStatsBtn?.addEventListener('click', () => {
-            if (dialog.open) {
-                dialog.close('usage-stats');
-            }
-            openHelpViewer();
-            requestAnimationFrame(() => {
-                const contentEl = $('helpContent');
-                const statsSection = contentEl?.querySelector('#help-usage-stats');
-                statsSection?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            });
         });
 
         void (async () => {

--- a/docs/js/instrumentation.js
+++ b/docs/js/instrumentation.js
@@ -160,9 +160,9 @@ const Instrumentation = (() => {
     }
 
     async function ensureDesktopDb() {
-        // The instrumentation table is created by Rust migration 008
-        // (desktop/src-tauri/migrations/008_instrumentation.sql), which is
-        // the canonical schema. We only need to confirm the DB handle loads.
+        // The instrumentation table is created by Rust migration 008 and
+        // moved to the consent-aware shape by migration 009. We only need to
+        // confirm the DB handle loads.
         await getDesktopDb();
     }
 
@@ -557,8 +557,12 @@ const Instrumentation = (() => {
         const toggle = document.createElement('input');
         toggle.type = 'checkbox';
         toggle.id = 'statsShareToggle';
-        toggle.checked = !!stats.shareEnabled;
+        toggle.checked = hasEffectiveConsent();
         toggle.addEventListener('change', () => {
+            if (stats.consentDecisionAt == null) {
+                void recordConsentDecision(toggle.checked);
+                return;
+            }
             setShareEnabled(toggle.checked);
         });
         label.appendChild(toggle);

--- a/docs/js/instrumentation.js
+++ b/docs/js/instrumentation.js
@@ -47,16 +47,16 @@ const Instrumentation = (() => {
             revision: 0,
             installationId: crypto.randomUUID(),
             firstSeen: new Date().toISOString(),
-            lastSeen: new Date().toISOString(),
             sessions: 0,
             studiesImported: 0,
             shareEnabled: false,
+            consentDecisionAt: null,
         };
     }
 
     /**
      * Migrate a loaded stats blob to the current schema.
-     * Adds missing fields with sensible defaults. Never removes fields.
+     * Adds missing fields with sensible defaults and removes retired fields.
      */
     function migrateStats(blob) {
         if (!blob || typeof blob !== 'object') {
@@ -75,9 +75,6 @@ const Instrumentation = (() => {
         if (typeof migrated.firstSeen !== 'string' || !migrated.firstSeen) {
             migrated.firstSeen = now;
         }
-        if (typeof migrated.lastSeen !== 'string' || !migrated.lastSeen) {
-            migrated.lastSeen = now;
-        }
         if (typeof migrated.sessions !== 'number' || !Number.isFinite(migrated.sessions)) {
             migrated.sessions = 0;
         }
@@ -87,8 +84,12 @@ const Instrumentation = (() => {
         if (typeof migrated.shareEnabled !== 'boolean') {
             migrated.shareEnabled = false;
         }
+        if (typeof migrated.consentDecisionAt !== 'string' || !migrated.consentDecisionAt) {
+            migrated.consentDecisionAt = null;
+        }
 
         migrated.version = SCHEMA_VERSION;
+        delete migrated.lastSeen;
         return migrated;
     }
 
@@ -176,10 +177,10 @@ const Instrumentation = (() => {
                 revision: row.revision,
                 installationId: row.installation_id,
                 firstSeen: row.first_seen,
-                lastSeen: row.last_seen,
                 sessions: row.sessions,
                 studiesImported: row.studies_imported,
                 shareEnabled: row.share_enabled === 1,
+                consentDecisionAt: row.consent_decision_at || null,
             };
         } catch (error) {
             console.warn('Instrumentation: failed to load from desktop SQL:', error);
@@ -191,26 +192,26 @@ const Instrumentation = (() => {
         try {
             const db = await getDesktopDb();
             await db.execute(
-                `INSERT INTO ${DESKTOP_TABLE} (id, version, revision, installation_id, first_seen, last_seen, sessions, studies_imported, share_enabled)
+                `INSERT INTO ${DESKTOP_TABLE} (id, version, revision, installation_id, first_seen, sessions, studies_imported, share_enabled, consent_decision_at)
                  VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT(id) DO UPDATE SET
                      version = excluded.version,
                      revision = excluded.revision,
                      installation_id = excluded.installation_id,
                      first_seen = excluded.first_seen,
-                     last_seen = excluded.last_seen,
                      sessions = excluded.sessions,
                      studies_imported = excluded.studies_imported,
-                     share_enabled = excluded.share_enabled`,
+                     share_enabled = excluded.share_enabled,
+                     consent_decision_at = excluded.consent_decision_at`,
                 [
                     blob.version,
                     blob.revision,
                     blob.installationId,
                     blob.firstSeen,
-                    blob.lastSeen,
                     blob.sessions,
                     blob.studiesImported,
                     blob.shareEnabled ? 1 : 0,
+                    blob.consentDecisionAt,
                 ],
             );
         } catch (error) {
@@ -229,9 +230,10 @@ const Instrumentation = (() => {
         return migrateStats(loadFromLocalStorage());
     }
 
-    async function saveStats() {
+    async function saveStats(options = {}) {
         if (!stats) return;
 
+        const { schedule = true } = options;
         stats.revision += 1;
 
         if (useDesktopSql) {
@@ -241,7 +243,9 @@ const Instrumentation = (() => {
         }
 
         dirty = false;
-        schedulePhoneHome();
+        if (schedule) {
+            schedulePhoneHome();
+        }
     }
 
     // =====================================================================
@@ -254,15 +258,17 @@ const Instrumentation = (() => {
             version: stats.version,
             revision: stats.revision,
             installationId: stats.installationId,
-            firstSeen: stats.firstSeen,
-            lastSeen: stats.lastSeen,
             sessions: stats.sessions,
             studiesImported: stats.studiesImported,
         };
     }
 
+    function hasEffectiveConsent() {
+        return stats?.shareEnabled === true && stats?.consentDecisionAt != null;
+    }
+
     function sendPhoneHome() {
-        if (!stats?.shareEnabled) return;
+        if (!hasEffectiveConsent()) return;
 
         const payload = buildPayload();
         if (!payload) return;
@@ -281,7 +287,7 @@ const Instrumentation = (() => {
     }
 
     function schedulePhoneHome() {
-        if (!stats?.shareEnabled) return;
+        if (!hasEffectiveConsent()) return;
 
         if (phoneHomeTimer) {
             clearTimeout(phoneHomeTimer);
@@ -319,7 +325,6 @@ const Instrumentation = (() => {
         if (!stats) return;
 
         stats.sessions += 1;
-        stats.lastSeen = new Date().toISOString();
         dirty = true;
 
         // Flush immediately on app open so the session count persists
@@ -350,7 +355,6 @@ const Instrumentation = (() => {
         if (!Number.isInteger(count) || count <= 0) return;
 
         stats.studiesImported += count;
-        stats.lastSeen = new Date().toISOString();
         dirty = true;
         await flush();
     }
@@ -364,13 +368,17 @@ const Instrumentation = (() => {
     function resetStats() {
         if (!stats) return;
 
-        // Preserve installationId and shareEnabled across reset
+        // Preserve stable identity and consent metadata across reset.
         const preservedId = stats.installationId;
         const preservedShare = stats.shareEnabled;
+        const preservedConsentDecisionAt = stats.consentDecisionAt;
+        const preservedFirstSeen = stats.firstSeen;
 
         const fresh = createDefaultStats();
         fresh.installationId = preservedId;
+        fresh.firstSeen = preservedFirstSeen;
         fresh.shareEnabled = preservedShare;
+        fresh.consentDecisionAt = preservedConsentDecisionAt;
 
         stats = fresh;
         dirty = true;
@@ -381,20 +389,29 @@ const Instrumentation = (() => {
         if (!stats) return;
 
         const value = !!enabled;
+        if (stats.shareEnabled === value) return;
+
+        const wasEffectivelyEnabled = hasEffectiveConsent();
         const wasEnabled = stats.shareEnabled;
         stats.shareEnabled = value;
         dirty = true;
-        void flush();
+        const shouldSendImmediate = value && !wasEffectivelyEnabled && hasEffectiveConsent();
+        const flushPromise = flush({ schedule: !shouldSendImmediate });
+
+        if (!value && phoneHomeTimer) {
+            clearTimeout(phoneHomeTimer);
+            phoneHomeTimer = null;
+        }
 
         // Enabling sharing sends one immediate POST of current persisted state
-        if (value && !wasEnabled) {
+        // when a prior consent decision makes it effective.
+        if (value && !wasEnabled && shouldSendImmediate) {
             // Clear any pending debounced POST and send immediately
             if (phoneHomeTimer) {
                 clearTimeout(phoneHomeTimer);
                 phoneHomeTimer = null;
             }
-            // Wait a tick for flush to complete, then send
-            setTimeout(() => sendPhoneHome(), 100);
+            void flushPromise.then(() => sendPhoneHome());
         }
     }
 
@@ -402,13 +419,40 @@ const Instrumentation = (() => {
         return stats?.shareEnabled === true;
     }
 
+    async function recordConsentDecision(enabled) {
+        if (initPromise) {
+            try {
+                await initPromise;
+            } catch {
+                // init() never throws, but be defensive.
+            }
+        }
+
+        if (!stats) return;
+
+        stats.shareEnabled = !!enabled;
+        stats.consentDecisionAt = new Date().toISOString();
+        dirty = true;
+
+        if (phoneHomeTimer) {
+            clearTimeout(phoneHomeTimer);
+            phoneHomeTimer = null;
+        }
+
+        await flush({ schedule: false });
+
+        if (enabled) {
+            sendPhoneHome();
+        }
+    }
+
     // =====================================================================
     // LIFECYCLE
     // =====================================================================
 
-    async function flush() {
+    async function flush(options = {}) {
         if (!dirty || !stats) return;
-        await saveStats();
+        await saveStats(options);
     }
 
     async function init() {
@@ -481,7 +525,7 @@ const Instrumentation = (() => {
         }
 
         // Build the panel via DOM construction + textContent rather than
-        // innerHTML interpolation. stats.firstSeen and stats.lastSeen come
+        // innerHTML interpolation. stats.firstSeen comes
         // from persistent storage (localStorage or SQLite) and formatDate
         // falls back to the raw ISO string if parsing fails -- any process
         // with write access to app storage could otherwise inject HTML.
@@ -505,7 +549,6 @@ const Instrumentation = (() => {
         };
 
         addRow('Using since', formatDate(stats.firstSeen));
-        addRow('Last opened', formatDate(stats.lastSeen));
         addRow('Sessions', stats.sessions);
         addRow('Studies imported', stats.studiesImported);
 
@@ -546,6 +589,7 @@ const Instrumentation = (() => {
         getStats,
         resetStats,
         setShareEnabled,
+        recordConsentDecision,
         isShareEnabled,
         renderStatsPanel,
         ready: initPromise,

--- a/tests/dashboard-worker.test.mjs
+++ b/tests/dashboard-worker.test.mjs
@@ -74,8 +74,6 @@ function createStatsDb(initialInstalls) {
         return {
             install_id: install.installationId,
             revision: install.revision ?? index,
-            first_seen: install.firstSeen ?? '2026-04-12T00:00:00.000Z',
-            last_seen: install.lastSeen ?? '2026-04-12T00:00:00.000Z',
             created_at: install.createdAt ?? '2026-04-12T00:00:00.000Z',
             stats_json: statsJson,
             version: install.version ?? 1
@@ -262,32 +260,24 @@ function normalizeStatsRecord(row) {
     const stats = parseStatsJson(row.stats_json);
     return {
         install_id: row.install_id,
-        first_seen: row.first_seen,
-        last_seen: row.last_seen,
         revision: row.revision,
         sessions: nonNegativeInteger(stats.sessions),
-        studies_imported: nonNegativeInteger(stats.studiesImported)
+        studies_imported: nonNegativeInteger(stats.studiesImported),
+        version: row.version
     };
 }
 
-function buildStatsTotals(installs, args) {
-    const [active24hSince, active7dSince, active30dSince] = args;
+function buildStatsTotals(installs) {
     return installs.reduce(
         (totals, row) => {
             const stats = parseStatsJson(row.stats_json);
             totals.installs_total += 1;
-            totals.active_24h += Date.parse(row.last_seen) >= Date.parse(active24hSince) ? 1 : 0;
-            totals.active_7d += Date.parse(row.last_seen) >= Date.parse(active7dSince) ? 1 : 0;
-            totals.active_30d += Date.parse(row.last_seen) >= Date.parse(active30dSince) ? 1 : 0;
             totals.sessions_total += nonNegativeInteger(stats.sessions);
             totals.studies_total += nonNegativeInteger(stats.studiesImported);
             return totals;
         },
         {
             installs_total: 0,
-            active_24h: 0,
-            active_7d: 0,
-            active_30d: 0,
             sessions_total: 0,
             studies_total: 0
         }
@@ -315,7 +305,7 @@ function buildInstallDailyRows(installs, args) {
 function extractInstallSort(query) {
     const match = query.match(/ORDER BY ([a-z_]+) (ASC|DESC), install_id (ASC|DESC)/i);
     return {
-        column: match ? match[1] : 'last_seen',
+        column: match ? match[1] : 'sessions',
         direction: match ? match[2].toLowerCase() : 'desc'
     };
 }
@@ -457,11 +447,9 @@ test('handleStatsSummary returns zero shape and 30 UTC days on an empty database
     const env = createEnv({ installs: [] });
     const payload = await handleStatsSummary(env, { now: '2026-05-02T15:45:00.000Z' });
 
+    assert.deepEqual(Object.keys(payload), ['installs', 'sessions', 'studies', 'new_installs_daily']);
     assert.deepEqual(payload.installs, {
-        total: 0,
-        active_24h: 0,
-        active_7d: 0,
-        active_30d: 0
+        total: 0
     });
     assert.deepEqual(payload.sessions, { total: 0 });
     assert.deepEqual(payload.studies, { total: 0 });
@@ -481,8 +469,6 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
             {
                 installationId: '11111111-1111-4111-8111-111111111111',
                 revision: 3,
-                firstSeen: '2026-04-01T00:00:00.000Z',
-                lastSeen: '2026-05-02T10:00:00.000Z',
                 createdAt: '2026-04-01T00:00:00.000Z',
                 sessions: 4,
                 studiesImported: 10
@@ -490,8 +476,6 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
             {
                 installationId: '22222222-2222-4222-8222-222222222222',
                 revision: 5,
-                firstSeen: '2026-03-01T00:00:00.000Z',
-                lastSeen: '2026-04-29T10:00:00.000Z',
                 createdAt: '2026-05-01T04:00:00.000Z',
                 sessions: 7,
                 studiesImported: 2
@@ -499,8 +483,6 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
             {
                 installationId: '33333333-3333-4333-8333-333333333333',
                 revision: 9,
-                firstSeen: '2026-05-02T00:00:00.000Z',
-                lastSeen: '2026-03-01T00:00:00.000Z',
                 createdAt: '2026-05-02T03:00:00.000Z',
                 statsJson: '{malformed-json'
             }
@@ -510,10 +492,7 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
     const payload = await handleStatsSummary(env, { now: '2026-05-02T12:00:00.000Z' });
 
     assert.deepEqual(payload.installs, {
-        total: 3,
-        active_24h: 1,
-        active_7d: 2,
-        active_30d: 2
+        total: 3
     });
     assert.deepEqual(payload.sessions, { total: 11 });
     assert.deepEqual(payload.studies, { total: 12 });
@@ -521,13 +500,11 @@ test('handleStatsSummary aggregates seeded installs defensively', async () => {
     assert.equal(payload.new_installs_daily.find((row) => row.day === '2026-05-02').count, 1);
 });
 
-test('new installs daily uses created_at rather than first_seen', async () => {
+test('new installs daily uses created_at for daily buckets', async () => {
     const env = createEnv({
         installs: [
             {
                 installationId: '44444444-4444-4444-8444-444444444444',
-                firstSeen: '2026-05-02T11:00:00.000Z',
-                lastSeen: '2026-05-02T11:00:00.000Z',
                 createdAt: '2026-04-20T03:00:00.000Z',
                 sessions: 1,
                 studiesImported: 1
@@ -615,41 +592,43 @@ test('handleStatsInstalls paginates, sorts, and redacts install identifiers', as
             {
                 installationId: fullId,
                 revision: 1,
-                firstSeen: '2026-04-01T01:00:00.000Z',
-                lastSeen: '2026-05-01T01:00:00.000Z',
                 sessions: 9,
-                studiesImported: 3
+                studiesImported: 3,
+                version: 7
             },
             {
                 installationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
                 revision: 2,
-                firstSeen: '2026-04-02T01:00:00.000Z',
-                lastSeen: '2026-05-02T01:00:00.000Z',
                 sessions: 2,
                 studiesImported: 4
             },
             {
                 installationId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
                 revision: 3,
-                firstSeen: '2026-04-03T01:00:00.000Z',
-                lastSeen: '2026-04-30T01:00:00.000Z',
                 sessions: 5,
                 studiesImported: 6
             }
         ]
     });
 
-    const payload = await handleStatsInstalls(
-        createRequest(`${STATS_INSTALLS_PATH}?sort=sessions&order=desc&per_page=2&page=1`),
-        env
-    );
+    const payload = await handleStatsInstalls(createRequest(`${STATS_INSTALLS_PATH}?per_page=2&page=1`), env);
     const serialized = JSON.stringify(payload);
 
     assert.equal(payload.installs.length, 2);
-    assert.equal(payload.installs[0].install_id_prefix, 'aaaaaaaa');
-    assert.equal(payload.installs[0].install_id_prefix.length, 8);
-    assert.equal(payload.installs[0].sessions, 9);
-    assert.equal(Object.hasOwn(payload.installs[0], 'version'), false);
+    assert.deepEqual(Object.keys(payload.installs[0]), [
+        'install_id_prefix',
+        'revision',
+        'sessions',
+        'studies_imported',
+        'version'
+    ]);
+    assert.deepEqual(payload.installs[0], {
+        install_id_prefix: 'aaaaaaaa',
+        revision: 1,
+        sessions: 9,
+        studies_imported: 3,
+        version: 7
+    });
     assert.deepEqual(payload.pagination, {
         page: 1,
         per_page: 2,
@@ -659,7 +638,7 @@ test('handleStatsInstalls paginates, sorts, and redacts install identifiers', as
     assert.doesNotMatch(serialized, new RegExp(fullId));
     assert.doesNotMatch(serialized, /installationId/);
     assert.doesNotMatch(serialized, /install_id"/);
-    assert.doesNotMatch(serialized, /"version"/);
+    assert.doesNotMatch(serialized, /first_seen|last_seen/);
 });
 
 test('handleStatsInstalls returns field-specific 400 payloads for invalid params', async () => {
@@ -668,6 +647,8 @@ test('handleStatsInstalls returns field-specific 400 payloads for invalid params
         [`${STATS_INSTALLS_PATH}?page=0`, 'page'],
         [`${STATS_INSTALLS_PATH}?per_page=200`, 'per_page'],
         [`${STATS_INSTALLS_PATH}?sort=unknown`, 'sort'],
+        [`${STATS_INSTALLS_PATH}?sort=last_seen`, 'sort'],
+        [`${STATS_INSTALLS_PATH}?sort=first_seen`, 'sort'],
         [`${STATS_INSTALLS_PATH}?order=sideways`, 'order']
     ];
 
@@ -910,7 +891,6 @@ test('stats aggregate queries are independently read-only valid', async () => {
         installs: [
             {
                 installationId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
-                lastSeen: '2026-05-02T10:00:00.000Z',
                 createdAt: '2026-05-02T10:00:00.000Z',
                 sessions: 1,
                 studiesImported: 1

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -192,7 +192,7 @@ test.describe('Instrumentation: consent modal', () => {
         await waitForStats(page, (stats) => stats.sessions === 1);
 
         await waitForConsentDialog(page);
-        await expect(page.locator('#usageStatsConsentTitle')).toHaveText('Share anonymous usage stats?');
+        await expect(page.locator('#usageStatsConsentTitle')).toHaveText('Please help us improve myRadOne.');
         await expect(page.locator('#usageStatsConsentStatsTitle')).toHaveText('Stats that would be shared');
         await expect(page.locator('#usageStatsConsentDialog summary')).toHaveCount(0);
         const stats = await readStats(page);

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -196,7 +196,7 @@ test.describe('Instrumentation: consent modal', () => {
         await expect(page.locator('#usageStatsConsentDescription')).toHaveText(
             'Only if you allow it, myRadOne can share the following stats back to the developer:',
         );
-        await expect(page.locator('#usageStatsConsentStatsTitle')).toHaveText('Stats that would be shared');
+        await expect(page.locator('#usageStatsConsentStatsTitle')).toHaveText('Stats');
         await expect(page.locator('#usageStatsConsentDialog summary')).toHaveCount(0);
         const stats = await readStats(page);
         await expect(page.locator('#usageStatsConsentInstallId')).toHaveText(stats.installationId.slice(0, 8));

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -182,7 +182,7 @@ test.describe('Instrumentation: consent modal', () => {
         // Local WebDriver runs skip the dialog by default so unrelated specs are
         // not blocked by first-launch consent. These specs exercise it directly.
         await page.addInitScript(() => {
-            window.__DICOM_VIEWER_FORCE_CONSENT_MODAL__ = true;
+            window.__ALLOW_CONSENT_MODAL_IN_TESTS__ = true;
         });
     });
 
@@ -318,6 +318,35 @@ test.describe('Instrumentation: consent modal', () => {
         await page.waitForTimeout(5500);
 
         expect(posts).toHaveLength(1);
+        const stats = await readStats(page);
+        expect(stats.shareEnabled).toBe(true);
+        expect(stats.consentDecisionAt).toEqual(expect.any(String));
+    });
+
+    test('stats panel toggle records consent after dismissed first-launch modal', async ({ page }) => {
+        const posts = await collectPhoneHomePosts(page);
+
+        await clearInstrumentationStorage(page);
+        await page.goto(APP_URL);
+        const dialog = await waitForConsentDialog(page);
+
+        await page.keyboard.press('Escape');
+        await expect(dialog).toBeHidden();
+
+        const toggleCheckedBefore = await page.evaluate(() => {
+            const container = document.createElement('div');
+            document.body.appendChild(container);
+            window.Instrumentation?.renderStatsPanel?.(container);
+            const toggle = container.querySelector('#statsShareToggle');
+            const checked = toggle?.checked;
+            toggle?.click();
+            return checked;
+        });
+
+        expect(toggleCheckedBefore).toBe(false);
+        await waitForStats(page, (stats) => stats.shareEnabled === true && stats.consentDecisionAt != null);
+        await expect.poll(() => posts.length).toBe(1);
+
         const stats = await readStats(page);
         expect(stats.shareEnabled).toBe(true);
         expect(stats.consentDecisionAt).toEqual(expect.any(String));

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -193,7 +193,8 @@ test.describe('Instrumentation: consent modal', () => {
 
         await waitForConsentDialog(page);
         await expect(page.locator('#usageStatsConsentTitle')).toHaveText('Share anonymous usage stats?');
-        await expect(page.locator('.usage-stats-consent-details')).toHaveJSProperty('open', true);
+        await expect(page.locator('#usageStatsConsentStatsTitle')).toHaveText('Stats that would be shared');
+        await expect(page.locator('#usageStatsConsentDialog summary')).toHaveCount(0);
         const stats = await readStats(page);
         await expect(page.locator('#usageStatsConsentInstallId')).toHaveText(stats.installationId.slice(0, 8));
         await expect(page.locator('#usageStatsConsentSessions')).toHaveText('1');

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -165,6 +165,12 @@ async function waitForStats(page, predicate, timeout = 5000) {
 // ============================================================================
 
 test.describe('Instrumentation: consent modal', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.addInitScript(() => {
+            window.__DICOM_VIEWER_FORCE_CONSENT_MODAL__ = true;
+        });
+    });
+
     test('shows first-launch consent modal with current local stats', async ({ page }) => {
         await clearInstrumentationStorage(page);
         await page.goto(APP_URL);

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -210,16 +210,6 @@ test.describe('Instrumentation: consent modal', () => {
         );
     });
 
-    test('keeps consent action buttons visible in a short viewport', async ({ page }) => {
-        await page.setViewportSize({ width: 640, height: 520 });
-        await clearInstrumentationStorage(page);
-        await page.goto(APP_URL);
-        await waitForConsentDialog(page);
-
-        await expect(page.getByRole('button', { name: 'Agree', exact: true })).toBeInViewport();
-        await expect(page.getByRole('button', { name: 'Deny' })).toBeInViewport();
-    });
-
     test('does not show consent modal after a decision has been recorded', async ({ page }) => {
         await seedInstrumentationStats(
             page,

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -210,6 +210,16 @@ test.describe('Instrumentation: consent modal', () => {
         );
     });
 
+    test('keeps consent action buttons visible in a short viewport', async ({ page }) => {
+        await page.setViewportSize({ width: 640, height: 520 });
+        await clearInstrumentationStorage(page);
+        await page.goto(APP_URL);
+        await waitForConsentDialog(page);
+
+        await expect(page.getByRole('button', { name: 'Agree', exact: true })).toBeInViewport();
+        await expect(page.getByRole('button', { name: 'Deny' })).toBeInViewport();
+    });
+
     test('does not show consent modal after a decision has been recorded', async ({ page }) => {
         await seedInstrumentationStats(
             page,

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -203,10 +203,10 @@ test.describe('Instrumentation: consent modal', () => {
         await expect(page.locator('#usageStatsConsentSessions')).toHaveText('1');
         await expect(page.locator('#usageStatsConsentStudiesImported')).toHaveText('0');
         await expect(page.locator('#usageStatsConsentDialog')).toContainText(
-            'Nothing else. No images, no patient data, no file paths, no dates, no device name.',
+            'No images, no personal information, absolutely nothing else. Just those three numbers.',
         );
         await expect(page.locator('#usageStatsConsentDialog')).toContainText(
-            'We do not include your IP address in the stats payload or store it with your install stats.',
+            "This information won't be sent elsewhere. It will be used exclusively to improve the application for users like you.",
         );
     });
 

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -193,6 +193,9 @@ test.describe('Instrumentation: consent modal', () => {
 
         await waitForConsentDialog(page);
         await expect(page.locator('#usageStatsConsentTitle')).toHaveText('Please help us improve myRadOne.');
+        await expect(page.locator('#usageStatsConsentDescription')).toHaveText(
+            'Only if you allow it, myRadOne can share the following stats back to the developer:',
+        );
         await expect(page.locator('#usageStatsConsentStatsTitle')).toHaveText('Stats that would be shared');
         await expect(page.locator('#usageStatsConsentDialog summary')).toHaveCount(0);
         const stats = await readStats(page);

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -38,11 +38,14 @@
 // is off by default on fresh install.
 //
 const { test, expect } = require('@playwright/test');
+const path = require('path');
 
 const APP_URL = 'http://127.0.0.1:5001/?nolib';
 const TEST_URL = 'http://127.0.0.1:5001/?test';
 const STORAGE_KEY = 'dicom-viewer-instrumentation-v1';
 const DESKTOP_RUNTIME_WAIT_TIMEOUT_MS = 5_000;
+const PHONE_HOME_URL = 'https://api.myradone.com/api/stats';
+const MOCK_SQL_INIT_PATH = path.join(__dirname, 'mock-tauri-sql-init.js');
 
 /**
  * Playwright gives each test a fresh browser context with empty localStorage
@@ -73,6 +76,68 @@ async function readStats(page) {
     }, STORAGE_KEY);
 }
 
+async function seedInstrumentationStats(page, blob) {
+    await page.addInitScript(
+        ({ key, stats }) => {
+            if (!window.localStorage.getItem(key)) {
+                window.localStorage.setItem(key, JSON.stringify(stats));
+            }
+        },
+        { key: STORAGE_KEY, stats: blob },
+    );
+}
+
+function makeLegacyStats(overrides = {}) {
+    return {
+        version: 1,
+        revision: 7,
+        installationId: 'legacy-installation-id',
+        firstSeen: '2026-01-02T03:04:05.000Z',
+        lastSeen: '2026-02-03T04:05:06.000Z',
+        sessions: 4,
+        studiesImported: 9,
+        shareEnabled: false,
+        ...overrides,
+    };
+}
+
+async function collectPhoneHomePosts(page) {
+    const posts = [];
+    await page.route(PHONE_HOME_URL, async (route) => {
+        const request = route.request();
+        const corsHeaders = {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'content-type',
+        };
+
+        if (request.method() === 'OPTIONS') {
+            await route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+            return;
+        }
+
+        if (request.method() === 'POST') {
+            posts.push(request.postDataJSON());
+        }
+
+        await route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    });
+    return posts;
+}
+
+async function waitForConsentDialog(page) {
+    const dialog = page.locator('#usageStatsConsentDialog');
+    await expect(dialog).toBeVisible();
+    return dialog;
+}
+
+async function readMockDesktopDb(page) {
+    return await page.evaluate(() => {
+        const raw = window.localStorage.getItem('mock-tauri-sql:sqlite:viewer.db');
+        return raw ? JSON.parse(raw) : null;
+    });
+}
+
 /**
  * Poll the in-memory instrumentation stats until a predicate holds.
  * Useful for awaiting async flush() writes without relying on timers.
@@ -94,6 +159,230 @@ async function waitForStats(page, predicate, timeout = 5000) {
         { timeout },
     );
 }
+
+// ============================================================================
+// Consent modal and phone-home gating
+// ============================================================================
+
+test.describe('Instrumentation: consent modal', () => {
+    test('shows first-launch consent modal with current local stats', async ({ page }) => {
+        await clearInstrumentationStorage(page);
+        await page.goto(APP_URL);
+        await waitForStats(page, (stats) => stats.sessions === 1);
+
+        await waitForConsentDialog(page);
+        await expect(page.locator('#usageStatsConsentTitle')).toHaveText('Share anonymous usage stats?');
+        await expect(page.locator('.usage-stats-consent-details')).toHaveJSProperty('open', true);
+        const stats = await readStats(page);
+        await expect(page.locator('#usageStatsConsentInstallId')).toHaveText(stats.installationId.slice(0, 8));
+        await expect(page.locator('#usageStatsConsentSessions')).toHaveText('1');
+        await expect(page.locator('#usageStatsConsentStudiesImported')).toHaveText('0');
+        await expect(page.locator('#usageStatsConsentDialog')).toContainText(
+            'Nothing else. No images, no patient data, no file paths, no dates, no device name.',
+        );
+        await expect(page.locator('#usageStatsConsentDialog')).toContainText(
+            'We do not include your IP address in the stats payload or store it with your install stats.',
+        );
+    });
+
+    test('does not show consent modal after a decision has been recorded', async ({ page }) => {
+        await seedInstrumentationStats(
+            page,
+            makeLegacyStats({
+                shareEnabled: false,
+                consentDecisionAt: '2026-03-04T05:06:07.000Z',
+            }),
+        );
+
+        await page.goto(APP_URL);
+        await waitForStats(page, (stats) => stats.sessions === 5);
+
+        await expect(page.locator('#usageStatsConsentDialog')).toBeHidden();
+    });
+
+    test("Don't share records consent without sending a POST", async ({ page }) => {
+        const posts = await collectPhoneHomePosts(page);
+
+        await clearInstrumentationStorage(page);
+        await page.goto(APP_URL);
+        await waitForConsentDialog(page);
+
+        await page.getByRole('button', { name: "Don't share" }).click();
+        await waitForStats(page, (stats) => stats.consentDecisionAt != null && stats.shareEnabled === false);
+        await page.waitForTimeout(300);
+
+        const stats = await readStats(page);
+        expect(stats.consentDecisionAt).toEqual(expect.any(String));
+        expect(stats.shareEnabled).toBe(false);
+        expect(posts).toEqual([]);
+    });
+
+    test('Share records consent and sends one POST with exact payload keys', async ({ page }) => {
+        const posts = await collectPhoneHomePosts(page);
+
+        await clearInstrumentationStorage(page);
+        await page.goto(APP_URL);
+        await waitForConsentDialog(page);
+
+        await page.getByRole('button', { name: 'Share', exact: true }).click();
+        await expect.poll(() => posts.length).toBe(1);
+
+        const payload = posts[0];
+        expect(Object.keys(payload).sort()).toEqual(
+            ['installationId', 'revision', 'sessions', 'studiesImported', 'version'].sort(),
+        );
+        expect(payload.sessions).toBe(1);
+        expect(payload.studiesImported).toBe(0);
+        expect(payload.firstSeen).toBeUndefined();
+        expect(payload.lastSeen).toBeUndefined();
+
+        const stats = await readStats(page);
+        expect(stats.shareEnabled).toBe(true);
+        expect(stats.consentDecisionAt).toEqual(expect.any(String));
+    });
+
+    test('Escape closes without stamping consent and reprompts on next launch', async ({ page }) => {
+        await clearInstrumentationStorage(page);
+        await page.goto(APP_URL);
+        const dialog = await waitForConsentDialog(page);
+
+        await page.keyboard.press('Escape');
+        await expect(dialog).toBeHidden();
+
+        let stats = await readStats(page);
+        expect(stats.consentDecisionAt).toBeNull();
+
+        await page.reload();
+        await waitForStats(page, (nextStats) => nextStats.sessions === 2);
+        await waitForConsentDialog(page);
+
+        stats = await readStats(page);
+        expect(stats.consentDecisionAt).toBeNull();
+    });
+
+    test("retroactive shareEnabled true prompts and Don't share disables sharing", async ({ page }) => {
+        const posts = await collectPhoneHomePosts(page);
+        await seedInstrumentationStats(page, makeLegacyStats({ shareEnabled: true }));
+
+        await page.goto(APP_URL);
+        await waitForStats(page, (stats) => stats.sessions === 5);
+        await waitForConsentDialog(page);
+
+        await page.getByRole('button', { name: "Don't share" }).click();
+        await waitForStats(page, (stats) => stats.consentDecisionAt != null && stats.shareEnabled === false);
+        await page.waitForTimeout(300);
+
+        const stats = await readStats(page);
+        expect(stats.shareEnabled).toBe(false);
+        expect(stats.consentDecisionAt).toEqual(expect.any(String));
+        expect(posts).toEqual([]);
+    });
+
+    test('legacy sharing leaks no POST before consent, then Share sends exactly one POST', async ({ page }) => {
+        const posts = await collectPhoneHomePosts(page);
+        await seedInstrumentationStats(page, makeLegacyStats({ shareEnabled: true }));
+
+        await page.goto(APP_URL);
+        await waitForConsentDialog(page);
+
+        await page.waitForTimeout(5500);
+        await page.evaluate(() => {
+            window.dispatchEvent(new Event('beforeunload'));
+        });
+        await page.waitForTimeout(100);
+        expect(posts).toEqual([]);
+
+        await page.getByRole('button', { name: 'Share', exact: true }).click();
+        await expect.poll(() => posts.length).toBe(1);
+        await page.waitForTimeout(5500);
+
+        expect(posts).toHaveLength(1);
+        const stats = await readStats(page);
+        expect(stats.shareEnabled).toBe(true);
+        expect(stats.consentDecisionAt).toEqual(expect.any(String));
+    });
+
+    test('reset preserves installation identity, firstSeen, and consent fields', async ({ page }) => {
+        await seedInstrumentationStats(
+            page,
+            makeLegacyStats({
+                shareEnabled: false,
+                consentDecisionAt: '2026-03-04T05:06:07.000Z',
+            }),
+        );
+
+        await page.goto(APP_URL);
+        await waitForStats(page, (stats) => stats.sessions === 5);
+
+        const before = await readStats(page);
+        await page.evaluate(() => {
+            window.Instrumentation?.resetStats?.();
+        });
+        await waitForStats(page, (stats) => stats.sessions === 0 && stats.studiesImported === 0);
+
+        const after = await readStats(page);
+        expect(after.installationId).toBe(before.installationId);
+        expect(after.firstSeen).toBe(before.firstSeen);
+        expect(after.shareEnabled).toBe(before.shareEnabled);
+        expect(after.consentDecisionAt).toBe(before.consentDecisionAt);
+        expect(after.sessions).toBe(0);
+        expect(after.studiesImported).toBe(0);
+    });
+
+    test('stats migration removes lastSeen and preserves firstSeen', async ({ page }) => {
+        await seedInstrumentationStats(page, makeLegacyStats({ shareEnabled: false }));
+
+        await page.goto(APP_URL);
+        await waitForStats(page, (stats) => stats.sessions === 5);
+
+        const stats = await readStats(page);
+        expect(stats.firstSeen).toBe('2026-01-02T03:04:05.000Z');
+        expect(stats.lastSeen).toBeUndefined();
+        expect(stats.consentDecisionAt).toBeNull();
+    });
+
+    test('desktop SQL bridge persists consent schema without last_seen', async ({ page }) => {
+        await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
+        await page.addInitScript(() => {
+            window.__TAURI__ = {
+                sql: window.__createMockTauriSql(),
+            };
+            window.__DICOM_VIEWER_TAURI_STORAGE_READY__ = Promise.resolve(window.__TAURI__);
+            window.__DICOM_VIEWER_TAURI_READY__ = Promise.resolve(window.__TAURI__);
+        });
+
+        await page.goto(APP_URL);
+        await page.waitForFunction(() => {
+            const raw = window.localStorage.getItem('mock-tauri-sql:sqlite:viewer.db');
+            if (!raw) return false;
+            const state = JSON.parse(raw);
+            return state.instrumentation?.[0]?.sessions === 1;
+        });
+
+        const localRaw = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
+        expect(localRaw).toBeNull();
+
+        let db = await readMockDesktopDb(page);
+        let row = db.instrumentation[0];
+        expect(row.first_seen).toEqual(expect.any(String));
+        expect(row.last_seen).toBeUndefined();
+        expect(row.consent_decision_at).toBeNull();
+
+        await waitForConsentDialog(page);
+        await page.getByRole('button', { name: "Don't share" }).click();
+        await page.waitForFunction(() => {
+            const raw = window.localStorage.getItem('mock-tauri-sql:sqlite:viewer.db');
+            const state = raw ? JSON.parse(raw) : null;
+            return state?.instrumentation?.[0]?.consent_decision_at != null;
+        });
+
+        db = await readMockDesktopDb(page);
+        row = db.instrumentation[0];
+        expect(row.share_enabled).toBe(0);
+        expect(row.consent_decision_at).toEqual(expect.any(String));
+        expect(row.last_seen).toBeUndefined();
+    });
+});
 
 // ============================================================================
 // Personal mode: basic counters
@@ -118,10 +407,10 @@ test.describe('Instrumentation: personal mode counters', () => {
                         revision: params[1],
                         installation_id: params[2],
                         first_seen: params[3],
-                        last_seen: params[4],
-                        sessions: params[5],
-                        studies_imported: params[6],
-                        share_enabled: params[7],
+                        sessions: params[4],
+                        studies_imported: params[5],
+                        share_enabled: params[6],
+                        consent_decision_at: params[7],
                     };
                     return { rowsAffected: 1 };
                 },
@@ -158,6 +447,8 @@ test.describe('Instrumentation: personal mode counters', () => {
         expect(dbState.loadCount).toBeGreaterThan(0);
         expect(dbState.row).not.toBeNull();
         expect(dbState.row.sessions).toBe(1);
+        expect(dbState.row.last_seen).toBeUndefined();
+        expect(dbState.row.consent_decision_at).toBeNull();
     });
 
     test('records first session on fresh load (no startup race drop)', async ({ page }) => {

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -208,6 +208,7 @@ test.describe('Instrumentation: consent modal', () => {
         await expect(page.locator('#usageStatsConsentDialog')).toContainText(
             "This information won't be sent elsewhere. It will be used exclusively to improve the application for users like you.",
         );
+        await expect(page.getByRole('button', { name: 'Open Usage Stats' })).toHaveCount(0);
     });
 
     test('does not show consent modal after a decision has been recorded', async ({ page }) => {

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -164,8 +164,23 @@ async function waitForStats(page, predicate, timeout = 5000) {
 // Consent modal and phone-home gating
 // ============================================================================
 
+test.describe('Instrumentation: consent modal local automation guard', () => {
+    test('skips first-launch consent modal on local WebDriver runs unless forced', async ({ page }) => {
+        await clearInstrumentationStorage(page);
+        await page.goto(APP_URL);
+        await waitForStats(page, (stats) => stats.sessions === 1);
+
+        await expect(page.locator('#usageStatsConsentDialog')).toBeHidden();
+        const stats = await readStats(page);
+        expect(stats.consentDecisionAt).toBeNull();
+        expect(stats.shareEnabled).toBe(false);
+    });
+});
+
 test.describe('Instrumentation: consent modal', () => {
     test.beforeEach(async ({ page }) => {
+        // Local WebDriver runs skip the dialog by default so unrelated specs are
+        // not blocked by first-launch consent. These specs exercise it directly.
         await page.addInitScript(() => {
             window.__DICOM_VIEWER_FORCE_CONSENT_MODAL__ = true;
         });

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -226,7 +226,7 @@ test.describe('Instrumentation: consent modal', () => {
         await expect(page.locator('#usageStatsConsentDialog')).toBeHidden();
     });
 
-    test("Deny records consent without sending a POST", async ({ page }) => {
+    test('Deny records consent without sending a POST', async ({ page }) => {
         const posts = await collectPhoneHomePosts(page);
 
         await clearInstrumentationStorage(page);
@@ -286,7 +286,7 @@ test.describe('Instrumentation: consent modal', () => {
         expect(stats.consentDecisionAt).toBeNull();
     });
 
-    test("retroactive shareEnabled true prompts and Deny disables sharing", async ({ page }) => {
+    test('retroactive shareEnabled true prompts and Deny disables sharing', async ({ page }) => {
         const posts = await collectPhoneHomePosts(page);
         await seedInstrumentationStats(page, makeLegacyStats({ shareEnabled: true }));
 

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -225,14 +225,14 @@ test.describe('Instrumentation: consent modal', () => {
         await expect(page.locator('#usageStatsConsentDialog')).toBeHidden();
     });
 
-    test("Don't share records consent without sending a POST", async ({ page }) => {
+    test("Deny records consent without sending a POST", async ({ page }) => {
         const posts = await collectPhoneHomePosts(page);
 
         await clearInstrumentationStorage(page);
         await page.goto(APP_URL);
         await waitForConsentDialog(page);
 
-        await page.getByRole('button', { name: "Don't share" }).click();
+        await page.getByRole('button', { name: 'Deny' }).click();
         await waitForStats(page, (stats) => stats.consentDecisionAt != null && stats.shareEnabled === false);
         await page.waitForTimeout(300);
 
@@ -242,14 +242,14 @@ test.describe('Instrumentation: consent modal', () => {
         expect(posts).toEqual([]);
     });
 
-    test('Share records consent and sends one POST with exact payload keys', async ({ page }) => {
+    test('Agree records consent and sends one POST with exact payload keys', async ({ page }) => {
         const posts = await collectPhoneHomePosts(page);
 
         await clearInstrumentationStorage(page);
         await page.goto(APP_URL);
         await waitForConsentDialog(page);
 
-        await page.getByRole('button', { name: 'Share', exact: true }).click();
+        await page.getByRole('button', { name: 'Agree', exact: true }).click();
         await expect.poll(() => posts.length).toBe(1);
 
         const payload = posts[0];
@@ -285,7 +285,7 @@ test.describe('Instrumentation: consent modal', () => {
         expect(stats.consentDecisionAt).toBeNull();
     });
 
-    test("retroactive shareEnabled true prompts and Don't share disables sharing", async ({ page }) => {
+    test("retroactive shareEnabled true prompts and Deny disables sharing", async ({ page }) => {
         const posts = await collectPhoneHomePosts(page);
         await seedInstrumentationStats(page, makeLegacyStats({ shareEnabled: true }));
 
@@ -293,7 +293,7 @@ test.describe('Instrumentation: consent modal', () => {
         await waitForStats(page, (stats) => stats.sessions === 5);
         await waitForConsentDialog(page);
 
-        await page.getByRole('button', { name: "Don't share" }).click();
+        await page.getByRole('button', { name: 'Deny' }).click();
         await waitForStats(page, (stats) => stats.consentDecisionAt != null && stats.shareEnabled === false);
         await page.waitForTimeout(300);
 
@@ -303,7 +303,7 @@ test.describe('Instrumentation: consent modal', () => {
         expect(posts).toEqual([]);
     });
 
-    test('legacy sharing leaks no POST before consent, then Share sends exactly one POST', async ({ page }) => {
+    test('legacy sharing leaks no POST before consent, then Agree sends exactly one POST', async ({ page }) => {
         const posts = await collectPhoneHomePosts(page);
         await seedInstrumentationStats(page, makeLegacyStats({ shareEnabled: true }));
 
@@ -317,7 +317,7 @@ test.describe('Instrumentation: consent modal', () => {
         await page.waitForTimeout(100);
         expect(posts).toEqual([]);
 
-        await page.getByRole('button', { name: 'Share', exact: true }).click();
+        await page.getByRole('button', { name: 'Agree', exact: true }).click();
         await expect.poll(() => posts.length).toBe(1);
         await page.waitForTimeout(5500);
 
@@ -423,7 +423,7 @@ test.describe('Instrumentation: consent modal', () => {
         expect(row.consent_decision_at).toBeNull();
 
         await waitForConsentDialog(page);
-        await page.getByRole('button', { name: "Don't share" }).click();
+        await page.getByRole('button', { name: 'Deny' }).click();
         await page.waitForFunction(() => {
             const raw = window.localStorage.getItem('mock-tauri-sql:sqlite:viewer.db');
             const state = raw ? JSON.parse(raw) : null;

--- a/tests/mock-tauri-sql-init.js
+++ b/tests/mock-tauri-sql-init.js
@@ -31,8 +31,8 @@
             // ADR 008: Local-first instrumentation. Singleton row (id = 1).
             // Desktop tests that do not exercise instrumentation still need
             // this table present so desktop SQL selects do not error out.
-            // The canonical schema lives in
-            // desktop/src-tauri/migrations/008_instrumentation.sql.
+            // The canonical schema is the post-009 desktop instrumentation
+            // shape: consent_decision_at present, last_seen retired.
             instrumentation: [],
             meta: {
                 lastCommentId: 0,

--- a/tests/mock-tauri-sql-init.js
+++ b/tests/mock-tauri-sql-init.js
@@ -2,7 +2,7 @@
 //
 // Mock Tauri SQL plugin for Playwright desktop tests.
 // Simulates plugin:sql commands using localStorage-backed in-memory tables.
-// Schema mirrors desktop/src-tauri/migrations/ (001 through 007).
+// Schema mirrors desktop/src-tauri/migrations/ (001 through 009).
 (() => {
     if (typeof window === 'undefined') return;
 
@@ -553,10 +553,10 @@
                         revision,
                         installationId,
                         firstSeen,
-                        lastSeen,
                         sessions,
                         studiesImported,
                         shareEnabled,
+                        consentDecisionAt,
                     ] = values;
                     const existing = state.instrumentation.find((row) => row.id === 1);
                     if (existing) {
@@ -564,10 +564,11 @@
                         existing.revision = revision;
                         existing.installation_id = installationId;
                         existing.first_seen = firstSeen;
-                        existing.last_seen = lastSeen;
+                        delete existing.last_seen;
                         existing.sessions = sessions;
                         existing.studies_imported = studiesImported;
                         existing.share_enabled = shareEnabled;
+                        existing.consent_decision_at = consentDecisionAt ?? null;
                     } else {
                         state.instrumentation.push({
                             id: 1,
@@ -575,10 +576,10 @@
                             revision,
                             installation_id: installationId,
                             first_seen: firstSeen,
-                            last_seen: lastSeen,
                             sessions,
                             studies_imported: studiesImported,
                             share_enabled: shareEnabled,
+                            consent_decision_at: consentDecisionAt ?? null,
                         });
                     }
                     persistState(db, state);

--- a/tests/stats-worker.test.mjs
+++ b/tests/stats-worker.test.mjs
@@ -20,8 +20,6 @@ function validPayload(overrides = {}) {
         version: 1,
         revision: 1,
         installationId: VALID_INSTALL_ID,
-        firstSeen: '2026-04-08T12:00:00.000Z',
-        lastSeen: '2026-04-09T08:30:00.000Z',
         sessions: 3,
         studiesImported: 2,
         ...overrides
@@ -30,14 +28,18 @@ function validPayload(overrides = {}) {
 
 // In-memory D1 double. Stores one row per install_id and enforces the
 // "only upsert when incoming.revision > stored.revision" guard.
-function createDb(initialInstalls = []) {
+function createDb(initialInstalls = [], options = {}) {
     const installs = new Map(
         initialInstalls.map((row) => [row.install_id, { ...row }])
     );
+    const preparedQueries = [];
+    const now = () => new Date().toISOString();
 
     return {
         installs,
+        preparedQueries,
         prepare(query) {
+            preparedQueries.push(query);
             return {
                 args: [],
                 bind(...args) {
@@ -48,18 +50,29 @@ function createDb(initialInstalls = []) {
                     if (!query.startsWith('INSERT INTO installs')) {
                         throw new Error(`Unhandled run() query: ${query}`);
                     }
-                    const [installId, revision, statsJson, firstSeen, lastSeen, version] =
-                        this.args;
+                    if (
+                        options.requireSeenColumns &&
+                        query.includes('INSERT INTO installs (install_id, revision, stats_json, version)')
+                    ) {
+                        throw new Error('NOT NULL constraint failed: installs.first_seen');
+                    }
+                    const [installId, revision, statsJson, version] = this.args;
+                    const fallbackSeenColumns = query.includes('first_seen, last_seen');
                     const existing = installs.get(installId);
                     if (!existing) {
                         installs.set(installId, {
                             install_id: installId,
                             revision,
                             stats_json: statsJson,
-                            first_seen: firstSeen,
-                            last_seen: lastSeen,
+                            ...(fallbackSeenColumns
+                                ? {
+                                      first_seen: now(),
+                                      last_seen: now()
+                                  }
+                                : {}),
                             version,
-                            updated_at: new Date().toISOString()
+                            created_at: now(),
+                            updated_at: now()
                         });
                         return { success: true };
                     }
@@ -67,10 +80,11 @@ function createDb(initialInstalls = []) {
                     if (revision > existing.revision) {
                         existing.revision = revision;
                         existing.stats_json = statsJson;
-                        existing.last_seen = lastSeen;
+                        if (fallbackSeenColumns) {
+                            existing.last_seen = now();
+                        }
                         existing.version = version;
-                        existing.updated_at = new Date().toISOString();
-                        // first_seen intentionally not updated.
+                        existing.updated_at = now();
                     }
                     return { success: true };
                 }
@@ -101,7 +115,7 @@ function createEnv({ db = createDb(), allowedOrigins = 'https://myradone.com' } 
 // validateStatsPayload
 // -----------------------------------------------------------------------
 
-test('validateStatsPayload: accepts a well-formed payload', () => {
+test('validateStatsPayload: accepts a well-formed payload without timestamps', () => {
     const result = validateStatsPayload(validPayload());
     assert.equal(result.ok, true);
     assert.equal(result.payload.installationId, VALID_INSTALL_ID);
@@ -111,11 +125,28 @@ test('validateStatsPayload: accepts a well-formed payload', () => {
         'version',
         'revision',
         'installationId',
-        'firstSeen',
-        'lastSeen',
         'sessions',
         'studiesImported'
     ]);
+});
+
+test('validateStatsPayload: accepts and strips legacy timestamps', () => {
+    const result = validateStatsPayload(
+        validPayload({
+            firstSeen: '2026-04-08T12:00:00.000Z',
+            lastSeen: '2026-04-09T08:30:00.000Z'
+        })
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(Object.keys(result.payload), [
+        'version',
+        'revision',
+        'installationId',
+        'sessions',
+        'studiesImported'
+    ]);
+    assert.equal('firstSeen' in result.payload, false);
+    assert.equal('lastSeen' in result.payload, false);
 });
 
 test('validateStatsPayload: rejects non-objects', () => {
@@ -163,11 +194,16 @@ test('validateStatsPayload: rejects non-integer or negative counters', () => {
     }
 });
 
-test('validateStatsPayload: rejects invalid timestamps', () => {
+test('validateStatsPayload: rejects invalid timestamps when present', () => {
     const badDates = ['', null, undefined, 'not-a-date', 123456];
     for (const bad of badDates) {
         const result = validateStatsPayload(validPayload({ firstSeen: bad }));
         assert.equal(result.ok, false, `firstSeen=${bad} should fail`);
+        assert.equal(result.field, 'firstSeen');
+
+        const lastSeenResult = validateStatsPayload(validPayload({ lastSeen: bad }));
+        assert.equal(lastSeenResult.ok, false, `lastSeen=${bad} should fail`);
+        assert.equal(lastSeenResult.field, 'lastSeen');
     }
 });
 
@@ -198,7 +234,9 @@ test('upsertInstall: inserts a new row on first write', async () => {
     assert.equal(db.installs.size, 1);
     const row = db.installs.get(VALID_INSTALL_ID);
     assert.equal(row.revision, 1);
-    assert.equal(row.first_seen, '2026-04-08T12:00:00.000Z');
+    assert.equal(row.version, 1);
+    assert.equal('first_seen' in row, false);
+    assert.equal('last_seen' in row, false);
 });
 
 test('upsertInstall: higher revision overwrites stored row', async () => {
@@ -208,13 +246,11 @@ test('upsertInstall: higher revision overwrites stored row', async () => {
         db,
         validPayload({
             revision: 5,
-            sessions: 10,
-            lastSeen: '2026-04-10T00:00:00.000Z'
+            sessions: 10
         })
     );
     const row = db.installs.get(VALID_INSTALL_ID);
     assert.equal(row.revision, 5);
-    assert.equal(row.last_seen, '2026-04-10T00:00:00.000Z');
     const stored = JSON.parse(row.stats_json);
     assert.equal(stored.sessions, 10);
 });
@@ -229,12 +265,74 @@ test('upsertInstall: stale revision is silently ignored', async () => {
     assert.equal(stored.sessions, 10, 'stale write should not overwrite');
 });
 
-test('upsertInstall: first_seen is preserved on upsert', async () => {
+test('upsertInstall: created_at is preserved on upsert', async () => {
     const db = createDb();
-    await upsertInstall(db, validPayload({ revision: 1, firstSeen: '2026-01-01T00:00:00.000Z' }));
-    await upsertInstall(db, validPayload({ revision: 2, firstSeen: '2099-12-31T23:59:59.000Z' }));
+    await upsertInstall(db, validPayload({ revision: 1, sessions: 1 }));
+    const insertedCreatedAt = db.installs.get(VALID_INSTALL_ID).created_at;
+    await upsertInstall(db, validPayload({ revision: 2, sessions: 2 }));
     const row = db.installs.get(VALID_INSTALL_ID);
-    assert.equal(row.first_seen, '2026-01-01T00:00:00.000Z');
+    assert.equal(row.created_at, insertedCreatedAt);
+});
+
+test('upsertInstall: stores exact normalized JSON keys', async () => {
+    const legacyPayload = validPayload({
+        firstSeen: '2026-04-08T12:00:00.000Z',
+        lastSeen: '2026-04-09T08:30:00.000Z'
+    });
+    const validation = validateStatsPayload(legacyPayload);
+    assert.equal(validation.ok, true);
+
+    const db = createDb();
+    await upsertInstall(db, legacyPayload);
+    const row = db.installs.get(VALID_INSTALL_ID);
+    const stored = JSON.parse(row.stats_json);
+    assert.deepEqual(Object.keys(stored), [
+        'version',
+        'revision',
+        'installationId',
+        'sessions',
+        'studiesImported'
+    ]);
+    assert.deepEqual(stored, validation.payload);
+});
+
+test('upsertInstall: retries old NOT NULL seen-column schema without storing timestamps in stats_json', async () => {
+    const db = createDb([], { requireSeenColumns: true });
+    await upsertInstall(
+        db,
+        validPayload({
+            firstSeen: '2026-04-08T12:00:00.000Z',
+            lastSeen: '2026-04-09T08:30:00.000Z'
+        })
+    );
+
+    assert.equal(db.preparedQueries.length, 2);
+    assert.match(db.preparedQueries[0], /INSERT INTO installs \(install_id, revision, stats_json, version\)/);
+    assert.match(db.preparedQueries[1], /INSERT INTO installs \(install_id, revision, stats_json, first_seen, last_seen, version\)/);
+
+    const row = db.installs.get(VALID_INSTALL_ID);
+    assert.equal(typeof row.first_seen, 'string');
+    assert.equal(typeof row.last_seen, 'string');
+    const stored = JSON.parse(row.stats_json);
+    assert.deepEqual(Object.keys(stored), [
+        'version',
+        'revision',
+        'installationId',
+        'sessions',
+        'studiesImported'
+    ]);
+    assert.equal('firstSeen' in stored, false);
+    assert.equal('lastSeen' in stored, false);
+});
+
+test('upsertInstall: INSERT column shape does not reference seen columns', async () => {
+    const db = createDb();
+    await upsertInstall(db, validPayload());
+    const query = db.preparedQueries[0];
+    assert.match(query, /INSERT INTO installs \(install_id, revision, stats_json, version\)/);
+    assert.match(query, /VALUES \(\?, \?, \?, \?\)/);
+    assert.doesNotMatch(query, /\bfirst_seen\b/);
+    assert.doesNotMatch(query, /\blast_seen\b/);
 });
 
 // -----------------------------------------------------------------------

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -26,9 +26,11 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from
 - `GET /api/subscribers` - Paginated subscriber list with allowlisted
   filters/sorts.
 - `GET /api/stats/summary` - Aggregate anonymous install, session, study, and
-  30-day new-install totals.
+  30-day new-install totals based on `created_at`.
 - `GET /api/stats/installs` - Paginated anonymous install snapshots. Install
-  identifiers are truncated to an 8-character prefix.
+  identifiers are truncated to an 8-character prefix, and rows only include
+  `install_id_prefix`, `revision`, `sessions`, `studies_imported`, and
+  `version`.
 
 `/api/subscribers` supports these optional query parameters:
 
@@ -43,9 +45,33 @@ Internal Cloudflare Worker dashboard for viewing subscriber analytics from
 
 - `page` - default `1`, minimum `1`
 - `per_page` - default `50`, maximum `100`
-- `sort` - `last_seen`, `first_seen`, `sessions`, `studies_imported`, or
-  `revision`
-- `order` - `asc` or `desc`
+- `sort` - `sessions`, `studies_imported`, or `revision`; default `sessions`
+- `order` - `asc` or `desc`; default `desc`
+
+Example `/api/stats/summary` response:
+
+```json
+{
+  "installs": { "total": 12 },
+  "sessions": { "total": 84 },
+  "studies": { "total": 31 },
+  "new_installs_daily": [
+    { "day": "2026-05-01", "count": 2 }
+  ]
+}
+```
+
+Example `/api/stats/installs` row:
+
+```json
+{
+  "install_id_prefix": "00000000",
+  "revision": 4,
+  "sessions": 12,
+  "studies_imported": 8,
+  "version": 1
+}
+```
 
 ## Security Notes
 
@@ -168,8 +194,12 @@ you want meaningful dashboard output.
 
    ```bash
    npx wrangler d1 execute myradone-stats --local --config workers/dashboard/wrangler.toml \
-     --command "INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen) VALUES ('00000000-0000-4000-8000-000000000000', 1, '{\"sessions\":1,\"studiesImported\":2}', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z');"
+     --command "INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen, version, created_at) VALUES ('00000000-0000-4000-8000-000000000000', 1, '{\"sessions\":1,\"studiesImported\":2}', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', 1, '2026-05-01T00:00:00.000Z');"
    ```
+
+   The stats schema still requires timestamp columns for ingestion, but the
+   dashboard APIs only use `created_at` for daily install counts and do not
+   return or sort by the ingestion timestamp fields.
 
 7. Run the worker:
 

--- a/workers/dashboard/README.md
+++ b/workers/dashboard/README.md
@@ -194,12 +194,11 @@ you want meaningful dashboard output.
 
    ```bash
    npx wrangler d1 execute myradone-stats --local --config workers/dashboard/wrangler.toml \
-     --command "INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen, version, created_at) VALUES ('00000000-0000-4000-8000-000000000000', 1, '{\"sessions\":1,\"studiesImported\":2}', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', 1, '2026-05-01T00:00:00.000Z');"
+     --command "INSERT INTO installs (install_id, revision, stats_json, version, created_at) VALUES ('00000000-0000-4000-8000-000000000000', 1, '{\"sessions\":1,\"studiesImported\":2}', 1, '2026-05-01T00:00:00.000Z');"
    ```
 
-   The stats schema still requires timestamp columns for ingestion, but the
-   dashboard APIs only use `created_at` for daily install counts and do not
-   return or sort by the ingestion timestamp fields.
+   The dashboard APIs use `created_at` for daily install counts and do not
+   return or sort by client-side timestamp fields.
 
 7. Run the worker:
 

--- a/workers/dashboard/src/dashboard.html
+++ b/workers/dashboard/src/dashboard.html
@@ -558,21 +558,6 @@
           <p id="statsTotalInstalls" class="card-value">—</p>
         </article>
         <article class="card">
-          <p class="card-label">Active 24h</p>
-          <p id="statsActive24h" class="card-value">—</p>
-        </article>
-        <article class="card">
-          <p class="card-label">Active 7d</p>
-          <p id="statsActive7d" class="card-value">—</p>
-        </article>
-        <article class="card">
-          <p class="card-label">Active 30d</p>
-          <p id="statsActive30d" class="card-value">—</p>
-        </article>
-      </section>
-
-      <section class="cards">
-        <article class="card">
           <p class="card-label">Total Sessions</p>
           <p id="statsTotalSessions" class="card-value">—</p>
         </article>
@@ -604,12 +589,11 @@
           <table>
             <thead>
               <tr>
-                <th>Install (prefix)</th>
-                <th><button class="sort-button stats-sort-button" data-stats-sort="first_seen" type="button">First seen</button></th>
-                <th><button class="sort-button stats-sort-button" data-stats-sort="last_seen" type="button">Last seen</button></th>
+                <th>Install</th>
                 <th><button class="sort-button stats-sort-button" data-stats-sort="sessions" type="button">Sessions</button></th>
                 <th><button class="sort-button stats-sort-button" data-stats-sort="studies_imported" type="button">Studies</button></th>
                 <th><button class="sort-button stats-sort-button" data-stats-sort="revision" type="button">Revision</button></th>
+                <th>Version</th>
               </tr>
             </thead>
             <tbody id="statsInstallsBody"></tbody>
@@ -641,7 +625,7 @@
         statsLoaded: false,
         statsPage: 1,
         statsPerPage: 50,
-        statsSort: 'last_seen',
+        statsSort: 'sessions',
         statsOrder: 'desc',
         statsTotalPages: 1,
         subscribersRefreshPromise: null,
@@ -664,9 +648,6 @@
         refreshButton: document.getElementById('refreshButton'),
         sourceBreakdown: document.getElementById('sourceBreakdown'),
         sourceFilter: document.getElementById('sourceFilter'),
-        statsActive24h: document.getElementById('statsActive24h'),
-        statsActive7d: document.getElementById('statsActive7d'),
-        statsActive30d: document.getElementById('statsActive30d'),
         statsDailyList: document.getElementById('statsDailyList'),
         statsInstallsBody: document.getElementById('statsInstallsBody'),
         statsNextPageButton: document.getElementById('statsNextPageButton'),
@@ -989,7 +970,7 @@
 
         if (isLoading && !state.statsLoaded) {
           elements.statsInstallsBody.replaceChildren();
-          appendEmptyRow(elements.statsInstallsBody, 6, 'Loading install stats...');
+          appendEmptyRow(elements.statsInstallsBody, 5, 'Loading install stats...');
         }
       }
 
@@ -1000,9 +981,6 @@
         const daily = payload.new_installs_daily || [];
 
         elements.statsTotalInstalls.textContent = formatNumber(installs.total);
-        elements.statsActive24h.textContent = formatNumber(installs.active_24h);
-        elements.statsActive7d.textContent = formatNumber(installs.active_7d);
-        elements.statsActive30d.textContent = formatNumber(installs.active_30d);
         elements.statsTotalSessions.textContent = formatNumber(sessions.total);
         elements.statsTotalStudies.textContent = formatNumber(studies.total);
         elements.statsDailyList.replaceChildren();
@@ -1037,18 +1015,15 @@
         const tr = document.createElement('tr');
         const columns = [
           'install_id_prefix',
-          'first_seen',
-          'last_seen',
           'sessions',
           'studies_imported',
-          'revision'
+          'revision',
+          'version'
         ];
 
         columns.forEach(function (column) {
           const td = document.createElement('td');
-          if (column === 'first_seen' || column === 'last_seen') {
-            td.textContent = formatDateTime(install[column]);
-          } else if (column === 'sessions' || column === 'studies_imported' || column === 'revision') {
+          if (column === 'sessions' || column === 'studies_imported' || column === 'revision' || column === 'version') {
             td.textContent = formatNumber(install[column]);
           } else {
             td.textContent = install[column] || '—';
@@ -1070,7 +1045,7 @@
         elements.statsNextPageButton.disabled = state.statsPage >= state.statsTotalPages;
 
         if (!payload.installs.length) {
-          appendEmptyRow(elements.statsInstallsBody, 6, 'No installs reporting yet.');
+          appendEmptyRow(elements.statsInstallsBody, 5, 'No installs reporting yet.');
           return;
         }
 
@@ -1220,7 +1195,7 @@
             state.statsOrder = state.statsOrder === 'asc' ? 'desc' : 'asc';
           } else {
             state.statsSort = field;
-            state.statsOrder = field === 'last_seen' ? 'desc' : 'asc';
+            state.statsOrder = field === 'sessions' ? 'desc' : 'asc';
           }
           state.statsPage = 1;
           refreshStats({ force: true });

--- a/workers/dashboard/src/lib.mjs
+++ b/workers/dashboard/src/lib.mjs
@@ -20,8 +20,6 @@ const SORT_COLUMNS = new Map([
     ['status', 'status']
 ]);
 const INSTALLS_SORT_COLUMNS = new Map([
-    ['last_seen', 'last_seen'],
-    ['first_seen', 'first_seen'],
     ['sessions', 'sessions'],
     ['studies_imported', 'studies_imported'],
     ['revision', 'revision']
@@ -635,7 +633,7 @@ function parseStatsInstallsQuery(request) {
     const url = new URL(request.url);
     const page = parseStatsIntegerParam(url.searchParams.get('page'), 1, 'page', { min: 1 });
     const perPage = parseStatsIntegerParam(url.searchParams.get('per_page'), 50, 'per_page', { min: 1, max: 100 });
-    const sort = (url.searchParams.get('sort') || 'last_seen').toLowerCase();
+    const sort = (url.searchParams.get('sort') || 'sessions').toLowerCase();
     const order = (url.searchParams.get('order') || 'desc').toLowerCase();
 
     if (!INSTALLS_SORT_COLUMNS.has(sort)) {
@@ -656,11 +654,6 @@ function normalizeCount(value) {
 
 function normalizeInt(value) {
     return normalizeCount(value);
-}
-
-function isoDateString(value) {
-    const timestamp = Date.parse(value);
-    return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : '';
 }
 
 function utcDay(value) {
@@ -872,20 +865,12 @@ export async function handleSubscribers(request, env) {
 
 export async function handleStatsSummary(env, options = {}) {
     const { startDay, todayDay } = statsDayBounds(options.now);
-    const now = options.now ? new Date(options.now) : new Date();
-    const nowMs = now.getTime();
-    const active24hSince = new Date(nowMs - 24 * 60 * 60 * 1000).toISOString();
-    const active7dSince = new Date(nowMs - 7 * 24 * 60 * 60 * 1000).toISOString();
-    const active30dSince = new Date(nowMs - 30 * 24 * 60 * 60 * 1000).toISOString();
 
     const totalsRow =
         (await readonlySelect(
             env.STATS_DB,
             `SELECT
                 COUNT(*) AS installs_total,
-                SUM(CASE WHEN last_seen >= ? THEN 1 ELSE 0 END) AS active_24h,
-                SUM(CASE WHEN last_seen >= ? THEN 1 ELSE 0 END) AS active_7d,
-                SUM(CASE WHEN last_seen >= ? THEN 1 ELSE 0 END) AS active_30d,
                 SUM(CASE
                     WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.sessions') AS INTEGER), 0)
                     ELSE 0
@@ -894,8 +879,7 @@ export async function handleStatsSummary(env, options = {}) {
                     WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.studiesImported') AS INTEGER), 0)
                     ELSE 0
                 END) AS studies_total
-             FROM installs`,
-            [active24hSince, active7dSince, active30dSince]
+             FROM installs`
         ).first()) || {};
 
     const dailyRows =
@@ -925,10 +909,7 @@ export async function handleStatsSummary(env, options = {}) {
 
     return {
         installs: {
-            total: normalizeCount(totalsRow.installs_total),
-            active_24h: normalizeCount(totalsRow.active_24h),
-            active_7d: normalizeCount(totalsRow.active_7d),
-            active_30d: normalizeCount(totalsRow.active_30d)
+            total: normalizeCount(totalsRow.installs_total)
         },
         sessions: {
             total: normalizeCount(totalsRow.sessions_total)
@@ -947,11 +928,10 @@ function normalizeInstallRow(row) {
     const installId = typeof row.install_id === 'string' ? row.install_id : '';
     return {
         install_id_prefix: installId.slice(0, 8),
-        first_seen: isoDateString(row.first_seen),
-        last_seen: isoDateString(row.last_seen),
         revision: normalizeInt(row.revision),
         sessions: normalizeInt(row.sessions),
-        studies_imported: normalizeInt(row.studies_imported)
+        studies_imported: normalizeInt(row.studies_imported),
+        version: normalizeInt(row.version)
     };
 }
 
@@ -970,8 +950,6 @@ export async function handleStatsInstalls(request, env) {
                 env.STATS_DB,
                 `SELECT
                     install_id,
-                    first_seen,
-                    last_seen,
                     revision,
                     CASE
                         WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.sessions') AS INTEGER), 0)
@@ -980,7 +958,8 @@ export async function handleStatsInstalls(request, env) {
                     CASE
                         WHEN json_valid(stats_json) THEN COALESCE(CAST(json_extract(stats_json, '$.studiesImported') AS INTEGER), 0)
                         ELSE 0
-                    END AS studies_imported
+                    END AS studies_imported,
+                    version
                  FROM installs
                  ORDER BY ${sortColumn} ${sortDirection}, install_id ${sortDirection}
                  LIMIT ? OFFSET ?`,

--- a/workers/stats/README.md
+++ b/workers/stats/README.md
@@ -27,6 +27,23 @@ usage stats" checkbox in the Help panel.
   "version": 1,
   "revision": 42,
   "installationId": "a1b2c3d4-e5f6-4789-abcd-ef0123456789",
+  "sessions": 12,
+  "studiesImported": 5
+}
+```
+
+These five fields are required. Unknown fields are rejected with 400 so
+schema drift is a loud failure. Note that `shareEnabled` is client-only
+state and is deliberately NOT part of the wire payload.
+
+For backward compatibility with older clients, `firstSeen` and `lastSeen`
+may also be sent as optional ISO-8601 timestamp strings:
+
+```json
+{
+  "version": 1,
+  "revision": 42,
+  "installationId": "a1b2c3d4-e5f6-4789-abcd-ef0123456789",
   "firstSeen": "2026-04-08T12:00:00.000Z",
   "lastSeen": "2026-04-09T09:30:00.000Z",
   "sessions": 12,
@@ -34,60 +51,54 @@ usage stats" checkbox in the Help panel.
 }
 ```
 
-All fields are required. Unknown fields are rejected with 400 so schema
-drift is a loud failure. Note that `shareEnabled` is client-only state and
-is deliberately NOT part of the wire payload.
+When present, legacy timestamps are validated and then stripped before the
+payload is stored. `stats_json` always contains only `version`, `revision`,
+`installationId`, `sessions`, and `studiesImported`.
 
 Rules:
 
 - `version` must be exactly `1`
 - `installationId` must be a lowercase UUID v4
 - `revision`, `sessions`, `studiesImported` must be non-negative integers
-- `firstSeen`, `lastSeen` must be ISO-8601 timestamp strings
+- Optional legacy `firstSeen`, `lastSeen` values must be ISO-8601 timestamp strings
 
 ## Data model
 
-D1 table (see `migrations/0001_create_installs.sql`):
+D1 table after applying `migrations/0001_create_installs.sql` and
+`migrations/0002_drop_seen_columns.sql`:
 
 ```sql
-CREATE TABLE IF NOT EXISTS installs (
+CREATE TABLE installs (
     install_id TEXT PRIMARY KEY,
     revision INTEGER NOT NULL DEFAULT 0,
     stats_json TEXT NOT NULL,
-    first_seen TEXT NOT NULL,
-    last_seen TEXT NOT NULL,
     version INTEGER NOT NULL DEFAULT 1,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-
-CREATE INDEX IF NOT EXISTS idx_installs_last_seen ON installs(last_seen);
 ```
 
 One row per installation, keyed by the client-generated UUID. The full
 payload is stored as JSON in `stats_json` for future schema flexibility,
-and the frequently-queried fields (`revision`, `first_seen`, `last_seen`,
-`version`) are extracted into columns so common queries do not have to
-parse JSON.
+and the frequently-queried fields (`revision`, `version`, `created_at`,
+`updated_at`) are columns so common queries do not have to parse JSON.
 
 ### Upsert semantics
 
 ```sql
-INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen, version)
-VALUES (?, ?, ?, ?, ?, ?)
+INSERT INTO installs (install_id, revision, stats_json, version)
+VALUES (?, ?, ?, ?)
 ON CONFLICT(install_id) DO UPDATE SET
     revision = excluded.revision,
     stats_json = excluded.stats_json,
-    last_seen = excluded.last_seen,
     version = excluded.version,
     updated_at = datetime('now')
 WHERE excluded.revision > installs.revision;
 ```
 
 The `WHERE excluded.revision > installs.revision` clause causes stale writes
-to be silently ignored. `first_seen` is never updated on conflict, so the
-original install date is preserved even if the client ever reports a
-different value.
+to be silently ignored. `created_at` is left to the table default on insert
+and is never updated on conflict.
 
 ## CORS
 
@@ -131,6 +142,7 @@ trivial abuse.
 
    ```bash
    npx wrangler d1 execute myradone-stats --remote --file=migrations/0001_create_installs.sql
+   npx wrangler d1 execute myradone-stats --remote --file=migrations/0002_drop_seen_columns.sql
    ```
 
 5. Create a rate-limit namespace (via the Cloudflare dashboard, or let
@@ -160,8 +172,6 @@ curl -i -X POST https://api.myradone.com/api/stats \
     "version": 1,
     "revision": 1,
     "installationId": "11111111-2222-4333-8444-555555555555",
-    "firstSeen": "2026-04-08T12:00:00.000Z",
-    "lastSeen": "2026-04-08T12:00:00.000Z",
     "sessions": 1,
     "studiesImported": 0
   }'
@@ -173,7 +183,7 @@ Inspect the most recent rows in D1:
 
 ```bash
 npx wrangler d1 execute myradone-stats --remote --command \
-  "SELECT install_id, revision, stats_json, first_seen, last_seen FROM installs ORDER BY updated_at DESC LIMIT 10;"
+  "SELECT install_id, revision, stats_json, version, created_at, updated_at FROM installs ORDER BY updated_at DESC LIMIT 10;"
 ```
 
 Replay the same request with a lower `revision` and confirm the row is
@@ -191,6 +201,7 @@ the local database with:
 
 ```bash
 npx wrangler d1 execute myradone-stats --local --file=migrations/0001_create_installs.sql
+npx wrangler d1 execute myradone-stats --local --file=migrations/0002_drop_seen_columns.sql
 ```
 
 Then POST to the local worker URL printed by `wrangler dev`.

--- a/workers/stats/migrations/0002_drop_seen_columns.sql
+++ b/workers/stats/migrations/0002_drop_seen_columns.sql
@@ -1,6 +1,13 @@
 -- Remove legacy timestamp storage from the stats worker table.
 -- The worker still accepts firstSeen/lastSeen in old client payloads, but
 -- validates and strips them before persistence.
+--
+-- Destructive D1 migration. Deploy the stats worker and dashboard worker from
+-- this PR before applying it: the new stats worker stops INSERTing seen columns,
+-- and the new dashboard stops SELECTing them. Do not roll back either worker to
+-- a build that references first_seen/last_seen after this migration lands.
+--
+-- Cloudflare D1's SQLite baseline supports native ALTER TABLE ... DROP COLUMN.
 DROP INDEX IF EXISTS idx_installs_last_seen;
 
 ALTER TABLE installs DROP COLUMN first_seen;

--- a/workers/stats/migrations/0002_drop_seen_columns.sql
+++ b/workers/stats/migrations/0002_drop_seen_columns.sql
@@ -1,0 +1,7 @@
+-- Remove legacy timestamp storage from the stats worker table.
+-- The worker still accepts firstSeen/lastSeen in old client payloads, but
+-- validates and strips them before persistence.
+DROP INDEX IF EXISTS idx_installs_last_seen;
+
+ALTER TABLE installs DROP COLUMN first_seen;
+ALTER TABLE installs DROP COLUMN last_seen;

--- a/workers/stats/src/index.mjs
+++ b/workers/stats/src/index.mjs
@@ -25,6 +25,8 @@ const DEFAULT_ALLOWED_ORIGINS = [
 
 // Fields the client is expected to send. Any field outside this set causes
 // the request to be rejected with 400 so schema drift fails loud.
+// TODO(cleanup 2026-08-01): remove firstSeen/lastSeen after v0.3.2 clients
+// are past EOL and all supported clients send the five-field v0.4+ shape.
 const ALLOWED_PAYLOAD_FIELDS = new Set([
     'version',
     'revision',

--- a/workers/stats/src/index.mjs
+++ b/workers/stats/src/index.mjs
@@ -39,6 +39,7 @@ const ALLOWED_PAYLOAD_FIELDS = new Set([
 // starts with 8/9/a/b. Lowercase only because crypto.randomUUID() emits
 // lowercase in every runtime we support.
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const ISO_8601_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 const LOCALHOST_ORIGIN_PATTERN = /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/;
 const TAURI_ORIGIN_PATTERN = /^(?:tauri:\/\/localhost(?::\d+)?|https?:\/\/tauri\.localhost(?::\d+)?)$/;
@@ -114,8 +115,13 @@ function isNonNegativeInteger(value) {
 
 function isParseableIsoDate(value) {
     if (typeof value !== 'string' || !value) return false;
+    if (!ISO_8601_TIMESTAMP_PATTERN.test(value)) return false;
     const timestamp = Date.parse(value);
     return Number.isFinite(timestamp);
+}
+
+function hasOwn(raw, key) {
+    return Object.prototype.hasOwnProperty.call(raw, key);
 }
 
 /**
@@ -164,10 +170,10 @@ export function validateStatsPayload(raw) {
         };
     }
 
-    if (!isParseableIsoDate(raw.firstSeen)) {
+    if (hasOwn(raw, 'firstSeen') && !isParseableIsoDate(raw.firstSeen)) {
         return { ok: false, error: 'firstSeen must be an ISO-8601 timestamp', field: 'firstSeen' };
     }
-    if (!isParseableIsoDate(raw.lastSeen)) {
+    if (hasOwn(raw, 'lastSeen') && !isParseableIsoDate(raw.lastSeen)) {
         return { ok: false, error: 'lastSeen must be an ISO-8601 timestamp', field: 'lastSeen' };
     }
 
@@ -177,8 +183,6 @@ export function validateStatsPayload(raw) {
         version: raw.version,
         revision: raw.revision,
         installationId: raw.installationId,
-        firstSeen: raw.firstSeen,
-        lastSeen: raw.lastSeen,
         sessions: raw.sessions,
         studiesImported: raw.studiesImported
     };
@@ -190,39 +194,92 @@ export function validateStatsPayload(raw) {
 // PERSISTENCE
 // =====================================================================
 
+function normalizeStatsPayload(payload) {
+    return {
+        version: payload.version,
+        revision: payload.revision,
+        installationId: payload.installationId,
+        sessions: payload.sessions,
+        studiesImported: payload.studiesImported
+    };
+}
+
+function isLegacySeenColumnConstraintError(error) {
+    const message = String(error?.message || error || '');
+    return (
+        message.includes('NOT NULL constraint failed: installs.first_seen') ||
+        message.includes('NOT NULL constraint failed: installs.last_seen')
+    );
+}
+
+async function runModernUpsert(db, statsPayload, statsJson) {
+    await db
+        .prepare(
+            `INSERT INTO installs (install_id, revision, stats_json, version)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(install_id) DO UPDATE SET
+                 revision = excluded.revision,
+                 stats_json = excluded.stats_json,
+                 version = excluded.version,
+                 updated_at = datetime('now')
+             WHERE excluded.revision > installs.revision`
+        )
+        .bind(
+            statsPayload.installationId,
+            statsPayload.revision,
+            statsJson,
+            statsPayload.version
+        )
+        .run();
+}
+
+async function runLegacySchemaCompatUpsert(db, statsPayload, statsJson) {
+    await db
+        .prepare(
+            `INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen, version)
+             VALUES (?, ?, ?, datetime('now'), datetime('now'), ?)
+             ON CONFLICT(install_id) DO UPDATE SET
+                 revision = excluded.revision,
+                 stats_json = excluded.stats_json,
+                 last_seen = datetime('now'),
+                 version = excluded.version,
+                 updated_at = datetime('now')
+             WHERE excluded.revision > installs.revision`
+        )
+        .bind(
+            statsPayload.installationId,
+            statsPayload.revision,
+            statsJson,
+            statsPayload.version
+        )
+        .run();
+}
+
 /**
  * Upsert the install row. Returns a short status string used only for
  * logging (never leaked to the client).
  *
  * The WHERE clause on the ON CONFLICT target ensures that a stale write
  * (one whose revision is not strictly greater than what is already stored)
- * is silently ignored. `first_seen` is intentionally never updated on
- * conflict so the original install date is preserved.
+ * is silently ignored.
  */
 export async function upsertInstall(db, payload) {
-    const statsJson = JSON.stringify(payload);
+    const statsPayload = normalizeStatsPayload(payload);
+    const statsJson = JSON.stringify(statsPayload);
 
-    await db
-        .prepare(
-            `INSERT INTO installs (install_id, revision, stats_json, first_seen, last_seen, version)
-             VALUES (?, ?, ?, ?, ?, ?)
-             ON CONFLICT(install_id) DO UPDATE SET
-                 revision = excluded.revision,
-                 stats_json = excluded.stats_json,
-                 last_seen = excluded.last_seen,
-                 version = excluded.version,
-                 updated_at = datetime('now')
-             WHERE excluded.revision > installs.revision`
-        )
-        .bind(
-            payload.installationId,
-            payload.revision,
-            statsJson,
-            payload.firstSeen,
-            payload.lastSeen,
-            payload.version
-        )
-        .run();
+    try {
+        await runModernUpsert(db, statsPayload, statsJson);
+    } catch (error) {
+        // The production deploy sequence updates the worker before the
+        // destructive D1 migration. During that short window, the old table
+        // still has NOT NULL first_seen/last_seen columns with no defaults.
+        // Retry with server-generated compatibility values, while keeping
+        // stats_json clean and payload timestamps ignored.
+        if (!isLegacySeenColumnConstraintError(error)) {
+            throw error;
+        }
+        await runLegacySchemaCompatUpsert(db, statsPayload, statsJson);
+    }
 }
 
 // =====================================================================


### PR DESCRIPTION
## Summary
- add an up-front usage stats consent modal with atomic consent recording and effective-consent phone-home gating
- remove client, worker, and dashboard exposure of first/last seen timestamps from the stats payload and UI
- add D1 and desktop SQLite migrations to drop last_seen/seen columns while preserving local firstSeen for the user stats panel
- keep legacy v0.3.2 payloads accepted, validate optional timestamps, and strip them before worker persistence

## Validation
- npx playwright test
- node --test tests/stats-worker.test.mjs tests/dashboard-worker.test.mjs
- npx wrangler deploy --dry-run --config workers/stats/wrangler.toml
- npx wrangler deploy --dry-run --config workers/dashboard/wrangler.toml
- node --check docs/js/instrumentation.js docs/js/app/main.js tests/mock-tauri-sql-init.js
- git diff --check

## Deploy Notes
Server deploy order remains important: deploy stats worker, deploy dashboard worker, then apply workers/stats/migrations/0002_drop_seen_columns.sql. Client release follows separately after server-side health checks.