### PR TITLE
[codex] Fix DX placeholder window level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Copyright 2026 Divergent Health Technologies
 
 ## [Unreleased]
 
+### Fixed
+- DX/CR radiographs with full-range placeholder W/L now use pixel-statistics auto W/L instead of rendering washed out (BUG-012)
+
 ## [2026-04-10]
 
 ### Added

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -12,6 +12,82 @@ Known issues, bugs, and their resolution status.
 
 ## Resolved Bugs
 
+### BUG-012: DX images render washed out when stored W/L is the full 16-bit range placeholder
+
+| Field | Value |
+|-------|-------|
+| **Status** | Resolved |
+| **Priority** | High |
+| **Found** | 2026-05-11 |
+| **Resolved** | 2026-05-11 |
+| **Scope** | Image rendering, window/level resolution path |
+| **Tracked at** | [#109](https://github.com/elgabrielc/dicom-viewer/issues/109) |
+| **PR** | Pending (`codex/bug-012-window-level`) |
+
+**How Encountered:**
+An EOS full-body DX scoliosis study rendered with almost no visible contrast in the
+desktop viewer. The body silhouette was visible against black, but bone and
+soft-tissue detail were compressed into a very narrow gray band. The toolbar and
+metadata panel reported `C: 32767 W: 65536`.
+
+The source files are two 16-bit unsigned JPEG Lossless SV1 DX slices from the
+`3-26-26_XR NYU` study folder:
+- `1.2.250.1.118.8.2104.1033.142.1774535757.dcm`
+- `1.2.250.1.118.8.2104.1033.143.1774535757.dcm`
+
+Both files store `WindowCenter=32767` and `WindowWidth=65536` with
+`RescaleSlope=1` and `RescaleIntercept=0`. That W/L covers the full 16-bit stored
+range, so the real anatomy values occupy only a small fraction of the display ramp.
+
+**Root Cause:**
+`resolveWindowLevel()` treated any present `WindowCenter` and `WindowWidth` tags as
+authoritative. Because the BUG-012 files include a full-range placeholder W/L, the
+viewer skipped its existing pixel-statistics auto window/level path and rendered the
+entire storable range across black-to-white.
+
+The auto-W/L fallback was also limited to MR/PT/NM when no W/L was present, leaving
+DX/CR/MG/XA/RF images with placeholder W/L stuck on the producer's no-op values.
+
+**Solution:**
+Added `isPlaceholderWindowLevel()` to detect raw stored-space windows that cover the
+entire storable pixel range. The helper only fires when `RescaleSlope=1` and
+`RescaleIntercept=0`, so CT and other rescaled modality-unit windows keep their
+explicit DICOM W/L values.
+
+`resolveWindowLevel()` now treats detected placeholder stored W/L as absent. If the
+native decoder's preferred W/L merely echoes the stored placeholder, that preferred
+value is also treated as absent so the existing auto-W/L fallback can run. A native
+preferred W/L that differs from the stored tags still wins.
+
+The auto-W/L modality list now includes `DX`, `CR`, `MG`, `XA`, and `RF` in addition
+to the existing `MR`, `PT`, and `NM`.
+
+**Why This Solution:**
+Alternatives considered:
+- *Always auto-window DX/CR/MG/XA/RF even when stored W/L is present* - Rejected.
+  Some producers provide useful W/L values; those should remain authoritative.
+- *Use modality defaults for placeholder DX values* - Rejected. The existing
+  DX/CR defaults are generic fallbacks and can still be full-range no-ops for
+  12-bit data. Pixel statistics are closer to the actual image content.
+- *Apply placeholder detection to rescaled CT* - Rejected. CT W/L values live in
+  Hounsfield units after slope/intercept; comparing them directly to stored bit
+  depth is unsafe.
+
+**Prevention Controls:**
+- Added Playwright coverage for the full-range placeholder truth table, including
+  unsigned, signed, rescaled, and invalid-input cases.
+- Added synthetic DX decode coverage for the JS path to prove stored placeholder
+  W/L routes to `calculateAutoWindowLevel()`.
+- Added synthetic native decode coverage where the native bridge echoes the stored
+  placeholder W/L, matching the current desktop failure mode.
+
+**Files Changed:**
+- `docs/js/app/dicom.js`
+- `docs/js/app/rendering.js`
+- `tests/dicom-window-level.spec.js`
+- `docs/BUGS.md`
+- `CHANGELOG.md`
+
 ### BUG-011: Desktop release build blocked by missing signing key and stale DMG mounts
 
 | Field | Value |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -22,7 +22,7 @@ Known issues, bugs, and their resolution status.
 | **Resolved** | 2026-05-11 |
 | **Scope** | Image rendering, window/level resolution path |
 | **Tracked at** | [#109](https://github.com/elgabrielc/dicom-viewer/issues/109) |
-| **PR** | Pending (`codex/bug-012-window-level`) |
+| **PR** | #110 |
 
 **How Encountered:**
 An EOS full-body DX scoliosis study rendered with almost no visible contrast in the

--- a/docs/js/app/dicom.js
+++ b/docs/js/app/dicom.js
@@ -396,6 +396,49 @@
     }
 
     /**
+     * Detect stored full-range window/level values that act as a no-op placeholder.
+     * Only raw stored-space windows are considered; rescaled modalities keep their
+     * explicit W/L because the comparison would otherwise need modality-unit math.
+     * @param {number} windowCenter - Stored Window Center
+     * @param {number} windowWidth - Stored Window Width
+     * @param {number} bitsStored - DICOM Bits Stored
+     * @param {number} pixelRepresentation - 0=unsigned, 1=signed
+     * @param {number} rescaleSlope - Rescale slope
+     * @param {number} rescaleIntercept - Rescale intercept
+     * @returns {boolean} True when the window covers the full storable pixel range
+     */
+    function isPlaceholderWindowLevel(
+        windowCenter,
+        windowWidth,
+        bitsStored,
+        pixelRepresentation = 0,
+        rescaleSlope = 1,
+        rescaleIntercept = 0,
+    ) {
+        if (rescaleSlope !== 1 || rescaleIntercept !== 0) {
+            return false;
+        }
+        if (!Number.isInteger(bitsStored) || bitsStored < 1 || bitsStored > 32) {
+            return false;
+        }
+        if (!Number.isFinite(windowCenter) || !Number.isFinite(windowWidth)) {
+            return false;
+        }
+
+        const storableRange = 2 ** bitsStored;
+        const isSigned = Number(pixelRepresentation) === 1;
+        const minStorable = isSigned ? -(storableRange / 2) : 0;
+        const maxStorable = isSigned ? storableRange / 2 - 1 : storableRange - 1;
+
+        if (windowWidth < storableRange - 1) {
+            return false;
+        }
+
+        const halfWidth = windowWidth / 2;
+        return windowCenter - halfWidth <= minStorable + 1 && windowCenter + halfWidth >= maxStorable - 1;
+    }
+
+    /**
      * Calculate auto window/level from pixel data statistics
      * Useful for MRI and other modalities without standard units
      * @param {TypedArray} pixelData - Raw pixel values
@@ -946,6 +989,7 @@
         isJpeg2000,
         getTransferSyntaxInfo,
         getModalityDefaults,
+        isPlaceholderWindowLevel,
         calculateAutoWindowLevel,
         isBlankSlice,
         displayBlankSlice,

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -27,6 +27,7 @@
         ['1.2.840.10008.1.2.4.90', new Set(['RF', 'XA'])],
         ['1.2.840.10008.1.2.4.91', new Set(['RF', 'XA'])],
     ]);
+    // MG only auto-WLs when no explicit producer W/L survives; MQSA compliance depends on producer-supplied values.
     const AUTO_WL_MODALITIES = new Set(['MR', 'PT', 'NM', 'DX', 'CR', 'MG', 'XA', 'RF']);
     const DEBUG_DECODE_MODE_STORAGE_KEY = 'dicom-viewer-debug-decode-mode';
     const DEBUG_PRELOAD_MODE_STORAGE_KEY = 'dicom-viewer-debug-preload-mode';

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -13,6 +13,7 @@
         getNumberOfFrames,
         getTransferSyntaxInfo,
         getModalityDefaults,
+        isPlaceholderWindowLevel,
         calculateAutoWindowLevel,
         isBlankSlice,
         displayBlankSlice,
@@ -26,6 +27,7 @@
         ['1.2.840.10008.1.2.4.90', new Set(['RF', 'XA'])],
         ['1.2.840.10008.1.2.4.91', new Set(['RF', 'XA'])],
     ]);
+    const AUTO_WL_MODALITIES = new Set(['MR', 'PT', 'NM', 'DX', 'CR', 'MG', 'XA', 'RF']);
     const DEBUG_DECODE_MODE_STORAGE_KEY = 'dicom-viewer-debug-decode-mode';
     const DEBUG_PRELOAD_MODE_STORAGE_KEY = 'dicom-viewer-debug-preload-mode';
     let desktopDebugSettings = {
@@ -482,12 +484,45 @@
         };
     }
 
-    function resolveWindowLevel(dataSet, modality, preferredWindowCenter = null, preferredWindowWidth = null) {
+    function resolveWindowLevel(
+        dataSet,
+        modality,
+        preferredWindowCenter = null,
+        preferredWindowWidth = null,
+        bitsStored = null,
+        pixelRepresentation = 0,
+        rescaleSlope = 1,
+        rescaleIntercept = 0,
+    ) {
         const modalityDefaults = getModalityDefaults(modality);
         const storedWindowCenter = getOptionalNumber(dataSet, 'x00281050'); // (0028,1050)
         const storedWindowWidth = getOptionalNumber(dataSet, 'x00281051'); // (0028,1051)
-        const hasPreferredWindowLevel = Number.isFinite(preferredWindowCenter) && Number.isFinite(preferredWindowWidth);
-        const hasStoredWindowLevel = Number.isFinite(storedWindowCenter) && Number.isFinite(storedWindowWidth);
+        let hasPreferredWindowLevel = Number.isFinite(preferredWindowCenter) && Number.isFinite(preferredWindowWidth);
+        let hasStoredWindowLevel = Number.isFinite(storedWindowCenter) && Number.isFinite(storedWindowWidth);
+        const preferredEchoesStored =
+            hasPreferredWindowLevel &&
+            hasStoredWindowLevel &&
+            preferredWindowCenter === storedWindowCenter &&
+            preferredWindowWidth === storedWindowWidth;
+
+        if (
+            hasStoredWindowLevel &&
+            (!hasPreferredWindowLevel || preferredEchoesStored) &&
+            isPlaceholderWindowLevel(
+                storedWindowCenter,
+                storedWindowWidth,
+                bitsStored,
+                pixelRepresentation,
+                rescaleSlope,
+                rescaleIntercept,
+            )
+        ) {
+            hasStoredWindowLevel = false;
+            if (preferredEchoesStored) {
+                hasPreferredWindowLevel = false;
+            }
+        }
+
         const hasWindowLevel = hasPreferredWindowLevel || hasStoredWindowLevel;
 
         let windowCenter = hasPreferredWindowLevel ? preferredWindowCenter : storedWindowCenter;
@@ -549,7 +584,7 @@
         if (
             !hasWindowLevel &&
             decoded.samplesPerPixel === 1 &&
-            (decoded.modality === 'MR' || decoded.modality === 'PT' || decoded.modality === 'NM')
+            AUTO_WL_MODALITIES.has(decoded.modality)
         ) {
             const autoWL = calculateAutoWindowLevel(decoded.pixelData, decoded.rescaleSlope, decoded.rescaleIntercept);
             windowCenter = autoWL.windowCenter;
@@ -703,7 +738,16 @@
         const rescaleIntercept = getNumber(dataSet, 'x00281052', 0); // (0028,1052)
 
         // Window/level for display - use modality-appropriate defaults
-        const { windowCenter, windowWidth, hasWindowLevel } = resolveWindowLevel(dataSet, modality);
+        const { windowCenter, windowWidth, hasWindowLevel } = resolveWindowLevel(
+            dataSet,
+            modality,
+            null,
+            null,
+            bitsStored,
+            pixelRepresentation,
+            rescaleSlope,
+            rescaleIntercept,
+        );
 
         // Extract pixel spacing for measurement calibration
         const pixelSpacing = app.tools.extractPixelSpacing(dataSet);
@@ -873,18 +917,22 @@
         const pixelRepresentation = Number(nativeDecoded.pixelRepresentation);
         const samplesPerPixel = Number(nativeDecoded.samplesPerPixel || 1);
         const planarConfiguration = Number(nativeDecoded.planarConfiguration || 0);
-        const { windowCenter, windowWidth, hasWindowLevel } = resolveWindowLevel(
-            dataSet,
-            modality,
-            nativeDecoded.windowCenter,
-            nativeDecoded.windowWidth,
-        );
         const rescaleSlope = Number.isFinite(nativeDecoded.rescaleSlope)
             ? nativeDecoded.rescaleSlope
             : getNumber(dataSet, 'x00281053', 1);
         const rescaleIntercept = Number.isFinite(nativeDecoded.rescaleIntercept)
             ? nativeDecoded.rescaleIntercept
             : getNumber(dataSet, 'x00281052', 0);
+        const { windowCenter, windowWidth, hasWindowLevel } = resolveWindowLevel(
+            dataSet,
+            modality,
+            nativeDecoded.windowCenter,
+            nativeDecoded.windowWidth,
+            bitsStored,
+            pixelRepresentation,
+            rescaleSlope,
+            rescaleIntercept,
+        );
         const decoded = {
             pixelData: nativeDecoded.pixelData,
             rows,

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -581,11 +581,7 @@
         }
 
         let { windowCenter, windowWidth } = decoded;
-        if (
-            !hasWindowLevel &&
-            decoded.samplesPerPixel === 1 &&
-            AUTO_WL_MODALITIES.has(decoded.modality)
-        ) {
+        if (!hasWindowLevel && decoded.samplesPerPixel === 1 && AUTO_WL_MODALITIES.has(decoded.modality)) {
             const autoWL = calculateAutoWindowLevel(decoded.pixelData, decoded.rescaleSlope, decoded.rescaleIntercept);
             windowCenter = autoWL.windowCenter;
             windowWidth = autoWL.windowWidth;

--- a/tests/dicom-window-level.spec.js
+++ b/tests/dicom-window-level.spec.js
@@ -199,3 +199,59 @@ test('decodeNative auto-windows DX images when native W/L only echoes the stored
     expect(result.windowWidth).not.toBe(65536);
     expect(result.windowWidth).toBeLessThan(10000);
 });
+
+test('decodeNative keeps meaningful native W/L when stored W/L is a placeholder', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate((pixelValues) => {
+        const app = window.DicomViewerApp;
+        const pixels = Uint16Array.from(pixelValues);
+
+        app.desktopDecode.decodeFrameWithPixels = async () => ({
+            pixelData: pixels.slice(),
+            rows: 10,
+            cols: 10,
+            bitsAllocated: 16,
+            bitsStored: 16,
+            pixelRepresentation: 0,
+            samplesPerPixel: 1,
+            planarConfiguration: 0,
+            photometricInterpretation: 'MONOCHROME2',
+            windowCenter: 1500,
+            windowWidth: 2000,
+            rescaleSlope: 1,
+            rescaleIntercept: 0,
+        });
+
+        const dataSet = {
+            string(tag) {
+                const values = {
+                    x00020010: '1.2.840.10008.1.2.1',
+                    x00080060: 'DX',
+                    x00280004: 'MONOCHROME2',
+                    x00281050: '32767',
+                    x00281051: '65536',
+                    x00281052: '0',
+                    x00281053: '1',
+                };
+                return values[tag] || '';
+            },
+            uint16(tag) {
+                const values = {
+                    x00280101: 16,
+                };
+                return values[tag];
+            },
+        };
+
+        return app.rendering.decodeNative(dataSet, '/mock/native-window-dx.dcm', 0).then((decoded) => ({
+            windowCenter: decoded.windowCenter,
+            windowWidth: decoded.windowWidth,
+            isBlank: decoded.isBlank,
+        }));
+    }, DX_PIXEL_VALUES);
+
+    expect(result.isBlank).toBe(false);
+    expect(result.windowCenter).toBe(1500);
+    expect(result.windowWidth).toBe(2000);
+});

--- a/tests/dicom-window-level.spec.js
+++ b/tests/dicom-window-level.spec.js
@@ -1,0 +1,201 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+const { test, expect } = require('@playwright/test');
+
+const TEST_BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:5001';
+const HOME_URL = `${TEST_BASE_URL}/?nolib`;
+
+function placeholderDxValues(index) {
+    return 1000 + ((index * 37) % 2000);
+}
+
+const DX_PIXEL_VALUES = Array.from({ length: 100 }, (_, index) => placeholderDxValues(index));
+
+test('isPlaceholderWindowLevel detects full-range no-op windows', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const results = await page.evaluate(() => {
+        const { isPlaceholderWindowLevel } = window.DicomViewerApp.dicom;
+        const cases = [
+            {
+                name: '16-bit unsigned BUG-012 placeholder',
+                args: [32767, 65536, 16, 0, 1, 0],
+                expected: true,
+            },
+            {
+                name: '12-bit signed placeholder',
+                args: [0, 4096, 12, 1, 1, 0],
+                expected: true,
+            },
+            {
+                name: '8-bit unsigned placeholder',
+                args: [128, 256, 8, 0, 1, 0],
+                expected: true,
+            },
+            {
+                name: '12-bit unsigned full-range window',
+                args: [2048, 4096, 12, 0, 1, 0],
+                expected: true,
+            },
+            {
+                name: 'CT soft-tissue window with rescale intercept',
+                args: [40, 400, 12, 0, 1, -1024],
+                expected: false,
+            },
+            {
+                name: 'narrow raw window',
+                args: [40, 400, 12, 0, 1, 0],
+                expected: false,
+            },
+            {
+                name: 'missing bits stored',
+                args: [32767, 65536, undefined, 0, 1, 0],
+                expected: false,
+            },
+            {
+                name: 'invalid center',
+                args: [Number.NaN, 65536, 16, 0, 1, 0],
+                expected: false,
+            },
+            {
+                name: 'invalid width',
+                args: [32767, Number.NaN, 16, 0, 1, 0],
+                expected: false,
+            },
+        ];
+
+        return cases.map((testCase) => ({
+            name: testCase.name,
+            actual: isPlaceholderWindowLevel(...testCase.args),
+            expected: testCase.expected,
+        }));
+    });
+
+    for (const result of results) {
+        expect(result.actual, result.name).toBe(result.expected);
+    }
+});
+
+test('decodeDicom auto-windows DX images with stored full-range placeholder W/L', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate((pixelValues) => {
+        const pixels = Uint16Array.from(pixelValues);
+
+        const dataSet = {
+            byteArray: new Uint8Array(pixels.buffer),
+            elements: {
+                x7fe00010: {
+                    dataOffset: 0,
+                    length: pixels.byteLength,
+                },
+            },
+            string(tag) {
+                const values = {
+                    x00020010: '1.2.840.10008.1.2.1',
+                    x00080060: 'DX',
+                    x00280004: 'MONOCHROME2',
+                    x00281050: '32767',
+                    x00281051: '65536',
+                    x00281052: '0',
+                    x00281053: '1',
+                };
+                return values[tag] || '';
+            },
+            uint16(tag) {
+                const values = {
+                    x00280010: 10,
+                    x00280011: 10,
+                    x00280100: 16,
+                    x00280101: 16,
+                    x00280103: 0,
+                    x00280002: 1,
+                    x00280008: 1,
+                };
+                return values[tag];
+            },
+        };
+
+        return window.DicomViewerApp.rendering.decodeDicom(dataSet, 0).then((decoded) => {
+            const expected = window.DicomViewerApp.dicom.calculateAutoWindowLevel(pixels, 1, 0);
+            return {
+                windowCenter: decoded.windowCenter,
+                windowWidth: decoded.windowWidth,
+                expectedCenter: expected.windowCenter,
+                expectedWidth: expected.windowWidth,
+                isBlank: decoded.isBlank,
+            };
+        });
+    }, DX_PIXEL_VALUES);
+
+    expect(result.isBlank).toBe(false);
+    expect(result.windowCenter).toBe(result.expectedCenter);
+    expect(result.windowWidth).toBe(result.expectedWidth);
+    expect(result.windowCenter).not.toBe(32767);
+    expect(result.windowWidth).not.toBe(65536);
+    expect(result.windowWidth).toBeLessThan(10000);
+});
+
+test('decodeNative auto-windows DX images when native W/L only echoes the stored placeholder', async ({ page }) => {
+    await page.goto(HOME_URL);
+
+    const result = await page.evaluate((pixelValues) => {
+        const app = window.DicomViewerApp;
+        const pixels = Uint16Array.from(pixelValues);
+
+        app.desktopDecode.decodeFrameWithPixels = async () => ({
+            pixelData: pixels.slice(),
+            rows: 10,
+            cols: 10,
+            bitsAllocated: 16,
+            bitsStored: 16,
+            pixelRepresentation: 0,
+            samplesPerPixel: 1,
+            planarConfiguration: 0,
+            photometricInterpretation: 'MONOCHROME2',
+            windowCenter: 32767,
+            windowWidth: 65536,
+            rescaleSlope: 1,
+            rescaleIntercept: 0,
+        });
+
+        const dataSet = {
+            string(tag) {
+                const values = {
+                    x00020010: '1.2.840.10008.1.2.1',
+                    x00080060: 'DX',
+                    x00280004: 'MONOCHROME2',
+                    x00281050: '32767',
+                    x00281051: '65536',
+                    x00281052: '0',
+                    x00281053: '1',
+                };
+                return values[tag] || '';
+            },
+            uint16(tag) {
+                const values = {
+                    x00280101: 16,
+                };
+                return values[tag];
+            },
+        };
+
+        return app.rendering.decodeNative(dataSet, '/mock/full-range-dx.dcm', 0).then((decoded) => {
+            const expected = app.dicom.calculateAutoWindowLevel(pixels, 1, 0);
+            return {
+                windowCenter: decoded.windowCenter,
+                windowWidth: decoded.windowWidth,
+                expectedCenter: expected.windowCenter,
+                expectedWidth: expected.windowWidth,
+                isBlank: decoded.isBlank,
+            };
+        });
+    }, DX_PIXEL_VALUES);
+
+    expect(result.isBlank).toBe(false);
+    expect(result.windowCenter).toBe(result.expectedCenter);
+    expect(result.windowWidth).toBe(result.expectedWidth);
+    expect(result.windowCenter).not.toBe(32767);
+    expect(result.windowWidth).not.toBe(65536);
+    expect(result.windowWidth).toBeLessThan(10000);
+});


### PR DESCRIPTION
## Summary
- Detect full-range stored window/level values that act as no-op placeholders.
- Treat placeholder stored W/L, and native W/L that only echoes it, as absent so pixel-statistics auto W/L can run.
- Extend auto W/L fallback to DX, CR, MG, XA, and RF while preserving rescaled CT W/L behavior.
- Add regression coverage for helper truth table, JS decode, and native decode paths.

## Root Cause
DX files in BUG-012 ship `WindowCenter=32767` and `WindowWidth=65536`, which covers the full 16-bit stored range. The viewer treated any stored W/L as authoritative, so it skipped auto W/L and rendered real anatomy values across only a tiny fraction of the grayscale ramp.

## Impact
DX/CR radiographs with full-range placeholder W/L now render with usable contrast from pixel statistics instead of appearing washed out. Native decoder-provided W/L still wins when it differs from the stored placeholder.

Fixes #109

## Validation
- `npx playwright test tests/dicom-window-level.spec.js`
- `npx playwright test`
- `git diff --check`
- `npx biome lint docs/js/app/dicom.js docs/js/app/rendering.js tests/dicom-window-level.spec.js` (exited 0; reported one existing unrelated style info at `rendering.js:226`)

## Manual Testing
- Not run: desktop app against the private BUG-012 source folder.