### PR TITLE
[codex] Harden desktop copy-on-import invariant

### DIFF
--- a/docs/decisions/007-multi-source-library.md
+++ b/docs/decisions/007-multi-source-library.md
@@ -137,7 +137,7 @@ Migration from v1 requires care. A user with a large library folder could face a
 
 1. On first launch with a v1 config, the app detects the old `folder` value and shows a migration prompt -- not an auto-import.
 2. **Preflight check**: Calculate total size of DICOM files in the old folder. Show the user: "Your library at [path] contains N files (X GB). Importing will copy these into the app's managed folder, using approximately X GB of additional disk space. Available disk: Y GB."
-3. **User confirms** before any copying begins. If they decline, the app continues with the old reference-in-place behavior until they're ready.
+3. **User confirms** before any copying begins. If they decline, the app does not import that source. Reference-in-place mode is not a supported long-term desktop library state.
 4. **Resumable import**: If the import is interrupted (crash, quit, power loss), it picks up where it left off on next launch. Files already copied are detected by the dedup check.
 5. After successful import, the v2 config is persisted. The old folder is untouched -- the user can delete it manually if they want to reclaim space.
 
@@ -249,3 +249,5 @@ Negative:
 4. **[P2] "Indexed in SQLite" was vague.** `addSliceToStudies()` is an in-memory assembler, not a persistent index. Fixed: added Metadata Index section clarifying the flow (SQLite scan cache -> in-memory assembly -> UI display) and confirming `desktop_scan_cache` is sufficient for v1.
 
 5. **[P3] "No offline drive problems" overstated.** If `libraryPath` is configured to an external drive, that drive must be mounted. Fixed: qualified the claim in Consequences.
+
+**BUG-013 hardening (2026-05-12):** Stale `managedLibrary: false` desktop config values are normalized back to managed mode, Tauri folder drops prefer the import pipeline whenever it is available, and cached library snapshots are rejected if any slice source points outside the snapshot folder. This closes the copy-on-import bypass and adds a startup cache invariant check.

--- a/docs/js/app/desktop-library.js
+++ b/docs/js/app/desktop-library.js
@@ -3,23 +3,62 @@
     window.DicomViewerApp = app;
     const notesApi = window.NotesAPI;
     const LEGACY_LIBRARY_CONFIG_KEY = 'dicom-viewer-library-config';
+    const normalizeDesktopConfig = window._NotesDesktop?.normalizeDesktopLibraryConfig;
 
-    function normalizeDesktopConfig(config) {
+    if (typeof normalizeDesktopConfig !== 'function') {
+        throw new Error('Desktop library config normalizer is unavailable.');
+    }
+
+    function normalizeComparablePath(path) {
+        return String(path || '')
+            .replace(/\\/g, '/')
+            .replace(/\/+$/g, '');
+    }
+
+    function isPathInsideRoot(path, rootPath) {
+        const normalizedPath = normalizeComparablePath(path);
+        const normalizedRoot = normalizeComparablePath(rootPath);
+        return !!(
+            normalizedPath &&
+            normalizedRoot &&
+            (normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`))
+        );
+    }
+
+    function findOutOfRootStudySources(studies, rootPath) {
+        const violations = [];
+        for (const [studyUid, study] of Object.entries(studies || {})) {
+            for (const series of Object.values(study?.series || {})) {
+                for (const slice of series?.slices || []) {
+                    const source = slice?.source;
+                    if (source?.kind !== 'path' || !isPathInsideRoot(source.path, rootPath)) {
+                        return [
+                            {
+                                studyUid,
+                                sourceKind: source?.kind || '',
+                                path: source?.path || '',
+                            },
+                        ];
+                    }
+                }
+            }
+        }
+        return violations;
+    }
+
+    function canImportToManagedLibrary() {
+        return !!(
+            typeof app.desktopLibrary?.runImport === 'function' &&
+            typeof app.importPipeline?.getLibraryPath === 'function' &&
+            typeof app.importPipeline?.importFromPaths === 'function'
+        );
+    }
+
+    function createCacheRepairNotice(reason, details = {}) {
         return {
-            folder: typeof config?.folder === 'string' && config.folder ? config.folder : null,
-            lastScan: typeof config?.lastScan === 'string' && config.lastScan ? config.lastScan : null,
-            managedLibrary: config?.managedLibrary !== false,
-            importHistory: Array.isArray(config?.importHistory)
-                ? config.importHistory.filter(
-                      (entry) =>
-                          entry &&
-                          typeof entry === 'object' &&
-                          typeof entry.sourcePath === 'string' &&
-                          typeof entry.importedAt === 'string' &&
-                          typeof entry.fileCount === 'number' &&
-                          typeof entry.studyCount === 'number',
-                  )
-                : [],
+            reason,
+            message: 'Library cache repaired. Re-scanning managed library...',
+            ...details,
         };
     }
 
@@ -42,6 +81,15 @@
         SCAN_TIMING_KEY: 'dicom-viewer-debug-scan-timing',
         SNAPSHOT_VERSION: 1,
         SNAPSHOT_FILENAME: 'desktop-library-cache.json',
+        _lastCacheRepairNotice: null,
+
+        canImportToManagedLibrary,
+
+        consumeCacheRepairNotice() {
+            const notice = this._lastCacheRepairNotice;
+            this._lastCacheRepairNotice = null;
+            return notice;
+        },
 
         getRuntime() {
             const tauri = window.__TAURI__;
@@ -128,6 +176,7 @@
         },
 
         async loadCachedStudies(folderPath) {
+            this._lastCacheRepairNotice = null;
             if (!folderPath) {
                 return null;
             }
@@ -153,6 +202,20 @@
                 if (!payload?.studies || typeof payload.studies !== 'object') {
                     return null;
                 }
+                const outOfRootSources = findOutOfRootStudySources(payload.studies, folderPath);
+                if (outOfRootSources.length > 0) {
+                    this._lastCacheRepairNotice = createCacheRepairNotice('out-of-root-sources', {
+                        folderPath,
+                        count: outOfRootSources.length,
+                        sample: outOfRootSources,
+                    });
+                    console.warn('DesktopLibrary: cached library snapshot references files outside its folder:', {
+                        folderPath,
+                        count: outOfRootSources.length,
+                        sample: outOfRootSources,
+                    });
+                    return null;
+                }
                 return payload.studies;
             } catch (error) {
                 console.warn('DesktopLibrary: failed to read cached library snapshot:', error);
@@ -162,7 +225,16 @@
 
         async saveCachedStudies(folderPath, studies) {
             if (!folderPath) {
-                return;
+                return false;
+            }
+
+            const outOfRootSources = findOutOfRootStudySources(studies, folderPath);
+            if (outOfRootSources.length > 0) {
+                console.warn('DesktopLibrary: refusing to cache studies outside the library folder:', {
+                    folderPath,
+                    sample: outOfRootSources,
+                });
+                return false;
             }
 
             const tauri = this.getRuntime();
@@ -175,6 +247,7 @@
             };
             const bytes = new TextEncoder().encode(`${JSON.stringify(payload)}\n`);
             await tauri.fs.writeFile(snapshotPath, bytes);
+            return true;
         },
 
         async writeScanTimingReport(report) {
@@ -260,8 +333,8 @@
             const tauri = this.getRuntime();
             const state = app.state;
 
-            if (state.managedLibrary) {
-                // In managed library mode, picking a folder triggers an import
+            if (this.canImportToManagedLibrary()) {
+                // Picking a folder in the desktop app imports it into the managed library.
                 const selected = await tauri.dialog.open({
                     directory: true,
                     recursive: true,
@@ -283,7 +356,7 @@
                 return folder;
             }
 
-            // Direct scan mode: existing behavior
+            // Browser-only/test fallback for environments without the import pipeline.
             const selected = await tauri.dialog.open({
                 directory: true,
                 recursive: true,

--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -295,7 +295,7 @@
                     return;
                 }
 
-                if (state.managedLibrary) {
+                if (app.desktopLibrary?.canImportToManagedLibrary?.()) {
                     // Import already ran inside pickAndSetFolder; now rescan the managed library
                     const libraryPath = await app.importPipeline.getLibraryPath();
                     const studies = await app.desktopLibrary.loadStudies(libraryPath, {

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -139,7 +139,7 @@
         setDragActive(false);
         abortLibraryLoad();
 
-        if (state.managedLibrary) {
+        if (app.desktopLibrary?.canImportToManagedLibrary?.()) {
             state.libraryAbort = new AbortController();
             try {
                 const importResult = await app.desktopLibrary.runImport(paths, {
@@ -347,9 +347,12 @@
                 const libraryPath = await app.importPipeline.getLibraryPath();
 
                 const cachedStudies = await app.desktopLibrary.loadCachedStudies(libraryPath);
+                const cacheRepairNotice = app.desktopLibrary.consumeCacheRepairNotice?.();
                 if (cachedStudies && Object.keys(cachedStudies).length > 0) {
                     await applyDesktopLibrarySnapshot(libraryPath, cachedStudies);
                     setLibraryFolderMessage('Showing cached library while refreshing...', 'info');
+                } else if (cacheRepairNotice?.message) {
+                    setLibraryFolderMessage(cacheRepairNotice.message, 'info');
                 } else {
                     setLibraryFolderMessage('Loading managed library...', 'info');
                 }
@@ -366,7 +369,7 @@
                 });
                 await applyDesktopLibraryScan(libraryPath, studies);
             } else {
-                // Direct scan mode: existing behavior
+                // Legacy fallback for environments without the managed import pipeline.
                 if (!state.libraryFolder) {
                     await displayStudies();
                     return;

--- a/docs/js/app/state.js
+++ b/docs/js/app/state.js
@@ -72,7 +72,7 @@
         importInProgress: false,
         importProgress: null, // {phase, discovered, processed, copied, skipped, invalid, errors, collisions, currentPath}
         importResult: null, // {imported, skipped, invalid, errors, collisions, duration}
-        managedLibrary: false, // mirrors config.managedLibrary
+        managedLibrary: false, // desktop managed-library mode once config loads
         studySort: { column: 'date', direction: 'desc' },
         currentTool: 'wl',
         viewTransform: { panX: 0, panY: 0, zoom: 1 },

--- a/docs/js/persistence/desktop.js
+++ b/docs/js/persistence/desktop.js
@@ -53,7 +53,7 @@ const _NotesDesktop = (() => {
         return {
             folder: typeof config?.folder === 'string' && config.folder ? config.folder : null,
             lastScan: typeof config?.lastScan === 'string' && config.lastScan ? config.lastScan : null,
-            managedLibrary: config?.managedLibrary !== false,
+            managedLibrary: true,
             importHistory: Array.isArray(config?.importHistory)
                 ? config.importHistory.filter(
                       (entry) =>
@@ -1119,6 +1119,7 @@ const _NotesDesktop = (() => {
     return {
         DesktopBackend,
         initializeDesktopStorage,
+        normalizeDesktopLibraryConfig,
         loadDesktopLibraryConfig,
         saveDesktopLibraryConfig,
         loadDesktopScanCache,

--- a/tests/desktop-import.spec.js
+++ b/tests/desktop-import.spec.js
@@ -1417,10 +1417,10 @@ test.describe('Desktop import integration', () => {
     });
 
     // -----------------------------------------------------------------------
-    // Test 2: Drop does NOT trigger import when managedLibrary is false
+    // Test 2: stale managedLibrary=false config is upgraded to managed imports
     // -----------------------------------------------------------------------
 
-    test('standard scan path does not write to managed library when managedLibrary is false', async ({ page }) => {
+    test('stale managedLibrary false config still routes Tauri drops through managed import', async ({ page }) => {
         const dicomBytes = buildSyntheticDicomBytes({
             studyInstanceUid: '1.2.study.scan.1',
             seriesInstanceUid: '1.2.series.scan.1',
@@ -1435,8 +1435,8 @@ test.describe('Desktop import integration', () => {
                 managedLibrary: false,
                 importHistory: [],
             },
-            // Supply the same file as both a manifest entry (for importFromPaths)
-            // and as readFileBytes so the standard scan path can read it
+            // Supply the same file as both a manifest entry and readFileBytes
+            // so the stale false config can still flow through managed import.
             manifestEntries: [
                 {
                     path: '/source/scan1.dcm',
@@ -1449,39 +1449,63 @@ test.describe('Desktop import integration', () => {
             readFileBytes: {
                 '/source/scan1.dcm': dicomBytes,
             },
+            dirs: {
+                [LIBRARY_ROOT]: [
+                    {
+                        name: '1.2.study.scan.1',
+                        isFile: false,
+                        isDirectory: true,
+                        children: [
+                            {
+                                name: '1.2.series.scan.1',
+                                isFile: false,
+                                isDirectory: true,
+                                children: [
+                                    {
+                                        name: '1.2.sop.scan.1.dcm',
+                                        isFile: true,
+                                        isDirectory: false,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
         });
 
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
+        await page.waitForFunction(() => typeof window.__capturedDragDropHandler === 'function');
 
-        // Verify managedLibrary is false
         const configCheck = await page.evaluate(async () => {
             const config = await window.DicomViewerApp.desktopLibrary.getConfig();
             return config.managedLibrary;
         });
-        expect(configCheck).toBe(false);
+        expect(configCheck).toBe(true);
 
-        // When managedLibrary is false, the app should NOT call importFromPaths.
-        // Verify that calling importFromPaths is what writes to the library path,
-        // and that simply reading the manifest without importing does not.
-        const result = await page.evaluate(async () => {
-            // Read the manifest entries (what read_scan_manifest returns) to
-            // confirm they exist, but do NOT call importFromPaths. This simulates
-            // the non-managed-library flow where files are scanned in place.
-            const invoke = window.__TAURI__.core.invoke;
-            const manifest = await invoke('read_scan_manifest', { roots: ['/source'], maxDepth: 20 });
-            const state = window.__importMockState;
-            return {
-                manifestCount: manifest.length,
-                writeFileCalls: state.writeFileCalls.filter((call) => call.path.startsWith('/mock-app-data/library')),
-            };
+        await page.evaluate(() => {
+            window.__capturedDragDropHandler({
+                payload: {
+                    type: 'drop',
+                    paths: ['/source'],
+                },
+            });
         });
 
-        // Files exist in the source folder
-        expect(result.manifestCount).toBe(1);
+        await page.waitForFunction(
+            (libraryRoot) => window.__importMockState.writeFileCalls.some((call) => call.path.startsWith(libraryRoot)),
+            LIBRARY_ROOT,
+        );
 
-        // No files should have been written to the managed library path
-        expect(result.writeFileCalls).toHaveLength(0);
+        const result = await page.evaluate((libraryRoot) => {
+            const state = window.__importMockState;
+            return {
+                writeFileCalls: state.writeFileCalls.filter((call) => call.path.startsWith(libraryRoot)),
+            };
+        }, LIBRARY_ROOT);
+
+        expect(result.writeFileCalls).toHaveLength(1);
     });
 
     // -----------------------------------------------------------------------

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -3123,14 +3123,15 @@ test.describe('Desktop library scanning', () => {
             },
             dirs: {
                 '/slow-library': [],
+                '/appdata/library': [],
             },
             readDirDelayMs: 500,
         });
 
         await page.goto(AUTOLOAD_URL);
-        await expect(page.locator('#libraryFolderConfig')).toBeVisible();
+        await expect(page.locator('#libraryFolderConfig')).toBeHidden();
         await expect(page.locator('#libraryFolderInput')).toHaveValue('/slow-library');
-        await expect(page.locator('#libraryFolderMessage')).toContainText('Loading saved library folder...');
+        await expect(page.locator('#libraryFolderMessage')).toContainText('Loading managed library...');
     });
 
     test('desktop library config falls back to the mirrored local config when native storage is unavailable', async ({
@@ -3144,15 +3145,16 @@ test.describe('Desktop library scanning', () => {
             },
             dirs: {
                 '/slow-library': [],
+                '/appdata/library': [],
             },
             readDirDelayMs: 500,
             sqlLoadError: 'mock desktop sqlite unavailable',
         });
 
         await page.goto(AUTOLOAD_URL);
-        await expect(page.locator('#libraryFolderConfig')).toBeVisible();
+        await expect(page.locator('#libraryFolderConfig')).toBeHidden();
         await expect(page.locator('#libraryFolderInput')).toHaveValue('/slow-library');
-        await expect(page.locator('#libraryFolderMessage')).toContainText('Loading saved library folder...');
+        await expect(page.locator('#libraryFolderMessage')).toContainText('Loading managed library...');
     });
 
     test('desktop auto-load shows a cached library snapshot while refresh is in flight', async ({ page }) => {
@@ -3178,7 +3180,7 @@ test.describe('Desktop library scanning', () => {
                             {
                                 instanceNumber: 1,
                                 sliceLocation: 0,
-                                source: { kind: 'path', path: '/slow-library/image.dcm' },
+                                source: { kind: 'path', path: '/appdata/library/image.dcm' },
                             },
                         ],
                     },
@@ -3188,7 +3190,7 @@ test.describe('Desktop library scanning', () => {
         const snapshotBytes = new TextEncoder().encode(
             JSON.stringify({
                 version: 1,
-                folder: '/slow-library',
+                folder: '/appdata/library',
                 savedAt: '2026-03-22T00:00:00.000Z',
                 studies: cachedStudies,
             }),
@@ -3202,6 +3204,7 @@ test.describe('Desktop library scanning', () => {
             },
             dirs: {
                 '/slow-library': [],
+                '/appdata/library': [],
             },
             readDirDelayMs: 3000,
             storedFiles: {
@@ -3210,12 +3213,158 @@ test.describe('Desktop library scanning', () => {
         });
 
         await page.goto(AUTOLOAD_URL);
-        await expect(page.locator('#libraryFolderConfig')).toBeVisible();
-        await expect(page.locator('#libraryFolderInput')).toHaveValue('/slow-library');
+        await expect(page.locator('#libraryFolderConfig')).toBeHidden();
+        await expect(page.locator('#libraryFolderInput')).toHaveValue('/appdata/library');
         await expect(page.locator('#studiesBody')).toContainText('Cached Patient');
     });
 
-    test('desktop library cache round-trips through app data', async ({ page }) => {
+    test('desktop library cache reports repair message for out-of-root cached snapshot', async ({ page }) => {
+        const cachedStudies = {
+            '1.2.840.cached.study': {
+                patientName: 'Cached Patient',
+                studyDate: '20260322',
+                studyDescription: 'Cached Study',
+                studyInstanceUid: '1.2.840.cached.study',
+                modality: 'MR',
+                seriesCount: 1,
+                imageCount: 1,
+                comments: [],
+                reports: [],
+                series: {
+                    '1.2.840.cached.series': {
+                        seriesInstanceUid: '1.2.840.cached.series',
+                        seriesDescription: 'Cached Series',
+                        seriesNumber: 1,
+                        modality: 'MR',
+                        comments: [],
+                        slices: [
+                            {
+                                instanceNumber: 1,
+                                sliceLocation: 0,
+                                source: { kind: 'path', path: '/external/image.dcm' },
+                            },
+                        ],
+                    },
+                },
+            },
+        };
+        const snapshotBytes = new TextEncoder().encode(
+            JSON.stringify({
+                version: 1,
+                folder: '/appdata/library',
+                savedAt: '2026-03-22T00:00:00.000Z',
+                studies: cachedStudies,
+            }),
+        );
+
+        await installMockDesktop(page, {
+            initialConfig: {
+                folder: '/slow-library',
+                lastScan: '2026-03-07T12:00:00.000Z',
+                managedLibrary: false,
+            },
+            dirs: {
+                '/slow-library': [],
+                '/appdata/library': [],
+            },
+            readDirDelayMs: 15000,
+            storedFiles: {
+                '/appdata/desktop-library-cache.json': snapshotBytes,
+            },
+        });
+
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const loaded = await window.DicomViewerApp.desktopLibrary.loadCachedStudies('/appdata/library');
+            const notice = window.DicomViewerApp.desktopLibrary.consumeCacheRepairNotice?.();
+            return {
+                loaded,
+                notice,
+            };
+        });
+
+        expect(result.loaded).toBeNull();
+        expect(result.notice).toEqual(
+            expect.objectContaining({
+                reason: 'out-of-root-sources',
+                message: 'Library cache repaired. Re-scanning managed library...',
+                folderPath: '/appdata/library',
+                count: 1,
+            }),
+        );
+    });
+
+    test('desktop library cache refuses out-of-root source paths on save', async ({ page }) => {
+        await installMockDesktop(page);
+        await page.goto(HOME_URL);
+        await expect(page.locator('#libraryView')).toBeVisible();
+
+        const result = await page.evaluate(async () => {
+            const studies = {
+                '1.2.840.cached.study': {
+                    patientName: 'Roundtrip Patient',
+                    studyDate: '20260322',
+                    studyDescription: 'Roundtrip Study',
+                    studyInstanceUid: '1.2.840.cached.study',
+                    modality: 'MR',
+                    seriesCount: 1,
+                    imageCount: 1,
+                    comments: [],
+                    reports: [],
+                    series: {
+                        '1.2.840.cached.series': {
+                            seriesInstanceUid: '1.2.840.cached.series',
+                            seriesDescription: 'Roundtrip Series',
+                            seriesNumber: 1,
+                            modality: 'MR',
+                            comments: [],
+                            slices: [
+                                {
+                                    instanceNumber: 1,
+                                    sliceLocation: 0,
+                                    source: { kind: 'path', path: '/library/image.dcm' },
+                                },
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const saved = await window.DicomViewerApp.desktopLibrary.saveCachedStudies('/library', studies);
+            const rawBefore = localStorage.getItem('mock-desktop-fs:/appdata/desktop-library-cache.json');
+            const externalStudies = structuredClone(studies);
+            externalStudies['1.2.840.cached.study'].series['1.2.840.cached.series'].slices[0].source.path =
+                '/external/image.dcm';
+            const rejectedWrite = await window.DicomViewerApp.desktopLibrary.saveCachedStudies(
+                '/library',
+                externalStudies,
+            );
+            const rawAfter = localStorage.getItem('mock-desktop-fs:/appdata/desktop-library-cache.json');
+            return {
+                saved,
+                rejectedWrite,
+                loaded: await window.DicomViewerApp.desktopLibrary.loadCachedStudies('/library'),
+                rawUnchanged: rawAfter === rawBefore,
+                rawText: rawAfter ? new TextDecoder().decode(Uint8Array.from(JSON.parse(rawAfter))) : '',
+            };
+        });
+
+        expect(result.saved).toBe(true);
+        expect(result.rejectedWrite).toBe(false);
+        expect(result.loaded).toEqual(
+            expect.objectContaining({
+                '1.2.840.cached.study': expect.objectContaining({
+                    patientName: 'Roundtrip Patient',
+                }),
+            }),
+        );
+        expect(result.rawUnchanged).toBe(true);
+        expect(result.rawText).toContain('"folder":"/library"');
+    });
+
+    test('desktop library cache round-trips compliant source paths through app data', async ({ page }) => {
         await installMockDesktop(page);
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();


### PR DESCRIPTION
## Summary

- normalize stale desktop `managedLibrary: false` config values back to managed mode
- route Tauri drops/folder picks through copy-on-import whenever the import pipeline is available
- reject cached desktop library snapshots whose slice sources point outside the managed library folder
- update ADR 007 and regression coverage for BUG-013

## Why

BUG-013 exposed that a study could be visible/renderable while still depending on its original drop folder, bypassing ADR 007's copy-on-import invariant. The current filesystem audit showed the observed scoped folders have since been imported into the managed library, but the bypass path still existed through stale config/state and unchecked cached snapshots.

This hardens both sides: new desktop imports prefer the managed pipeline, and startup cache reuse refuses snapshots that would rehydrate external source paths.

## Validation

- `npx biome lint docs/js/app/main.js docs/js/app/state.js docs/js/app/desktop-library.js docs/js/app/library.js docs/js/persistence/desktop.js tests/desktop-import.spec.js tests/desktop-library.spec.js`
  - passes with two pre-existing style infos in `docs/js/app/library.js`
- `npx playwright test tests/desktop-import.spec.js tests/desktop-library.spec.js --grep "stale managedLibrary|cache round-trips|cached library snapshot|saved desktop library config|mirrored local config|managedLibrary loads"`
  - 7 passed
