### PR TITLE
[codex] Add isolated dev desktop identity

### DIFF
--- a/desktop/scripts/dev-desktop.sh
+++ b/desktop/scripts/dev-desktop.sh
@@ -8,6 +8,7 @@ DOCS_DIR="$(cd "${DESKTOP_DIR}/../docs" && pwd)"
 DEV_HOST="${DICOM_DESKTOP_DEV_HOST:-127.0.0.1}"
 DEV_PORT="${DICOM_DESKTOP_DEV_PORT:-1420}"
 DEV_URL="http://${DEV_HOST}:${DEV_PORT}/"
+PROD_APP_SUPPORT_DIR="${HOME}/Library/Application Support/health.divergent.dicomviewer"
 WEB_SERVER_PID=""
 
 require_command() {
@@ -42,6 +43,22 @@ PY
 
 desktop_binary_running() {
     pgrep -f "${DESKTOP_DIR}/src-tauri/target[^/]*/debug/dicom-viewer-desktop" >/dev/null 2>&1
+}
+
+warn_about_shared_prod_state() {
+    if [[ ! -d "$PROD_APP_SUPPORT_DIR" ]]; then
+        return 0
+    fi
+
+    cat >&2 <<EOF
+Note: existing production app data is present at:
+  ${PROD_APP_SUPPORT_DIR}
+
+Dev builds now use health.divergent.dicomviewer.dev instead. Treat the
+production directory above as shared production state; back it up before
+manual repair, and only clean up old dev experiments after identifying exactly
+which files belong to that experiment.
+EOF
 }
 
 listener_command() {
@@ -124,6 +141,9 @@ require_command pgrep
 
 clear_stale_dev_server_if_needed
 
+TAURI_CONFIG_VALUE="$(dev_tauri_config)"
+warn_about_shared_prod_state
+
 cd "$DESKTOP_DIR"
 python3 -m http.server "$DEV_PORT" --bind "$DEV_HOST" --directory "$DOCS_DIR" &
 WEB_SERVER_PID="$!"
@@ -133,5 +153,5 @@ wait_for_dev_server
 
 echo "Launching desktop app..."
 CARGO_TARGET_DIR="${DESKTOP_DIR}/src-tauri/target-dev" \
-TAURI_CONFIG="$(dev_tauri_config)" \
+TAURI_CONFIG="$TAURI_CONFIG_VALUE" \
     cargo run --manifest-path src-tauri/Cargo.toml --no-default-features --color always -- "$@"

--- a/desktop/scripts/dev-desktop.sh
+++ b/desktop/scripts/dev-desktop.sh
@@ -22,7 +22,8 @@ listener_pid_for_dev_port() {
 }
 
 dev_tauri_config() {
-    python3 - "$DESKTOP_DIR/src-tauri/tauri.conf.dev.json" "$DEV_URL" <<'PY'
+    local config
+    if ! config="$(python3 - "$DESKTOP_DIR/src-tauri/tauri.conf.dev.json" "$DEV_URL" <<'PY'
 import json
 import sys
 
@@ -32,10 +33,15 @@ with open(sys.argv[1], encoding="utf-8") as config_file:
 config.setdefault("build", {})["devUrl"] = sys.argv[2].rstrip("/")
 print(json.dumps(config, separators=(",", ":")))
 PY
+    )"; then
+        echo "Failed to build TAURI_CONFIG overlay from src-tauri/tauri.conf.dev.json." >&2
+        return 1
+    fi
+    printf '%s\n' "$config"
 }
 
 desktop_binary_running() {
-    pgrep -f "${DESKTOP_DIR}/src-tauri/target.*/debug/dicom-viewer-desktop" >/dev/null 2>&1
+    pgrep -f "${DESKTOP_DIR}/src-tauri/target[^/]*/debug/dicom-viewer-desktop" >/dev/null 2>&1
 }
 
 listener_command() {

--- a/desktop/scripts/dev-desktop.sh
+++ b/desktop/scripts/dev-desktop.sh
@@ -21,8 +21,21 @@ listener_pid_for_dev_port() {
     lsof -tiTCP:"${DEV_PORT}" -sTCP:LISTEN -n -P 2>/dev/null | head -n 1
 }
 
+dev_tauri_config() {
+    python3 - "$DESKTOP_DIR/src-tauri/tauri.conf.dev.json" "$DEV_URL" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as config_file:
+    config = json.load(config_file)
+
+config.setdefault("build", {})["devUrl"] = sys.argv[2].rstrip("/")
+print(json.dumps(config, separators=(",", ":")))
+PY
+}
+
 desktop_binary_running() {
-    pgrep -f "${DESKTOP_DIR}/src-tauri/target/debug/dicom-viewer-desktop" >/dev/null 2>&1
+    pgrep -f "${DESKTOP_DIR}/src-tauri/target.*/debug/dicom-viewer-desktop" >/dev/null 2>&1
 }
 
 listener_command() {
@@ -113,4 +126,6 @@ echo "Serving docs/ at ${DEV_URL}"
 wait_for_dev_server
 
 echo "Launching desktop app..."
-cargo run --manifest-path src-tauri/Cargo.toml --no-default-features --color always -- "$@"
+CARGO_TARGET_DIR="${DESKTOP_DIR}/src-tauri/target-dev" \
+TAURI_CONFIG="$(dev_tauri_config)" \
+    cargo run --manifest-path src-tauri/Cargo.toml --no-default-features --color always -- "$@"

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -498,14 +498,22 @@ fn main() {
             let menu = build_menu(app)?;
             app.set_menu(menu)?;
 
+            let bundle_identifier = app.config().identifier.clone();
+            app.manage(secure_store::SecureStoreConfig::new(
+                bundle_identifier.clone(),
+            ));
+
             #[cfg(debug_assertions)]
-            eprintln!("[startup] bundle identifier: {}", app.config().identifier);
+            eprintln!("[startup] bundle identifier: {bundle_identifier}");
 
             // Register $APPDATA as an always-allowed root so desktop
             // persistence (decode cache, database, etc.) works without
             // the user explicitly selecting it via a file dialog.
             let allowed = app.state::<path_util::AllowedPaths>();
             if let Ok(app_data) = app.path().app_data_dir() {
+                #[cfg(debug_assertions)]
+                eprintln!("[startup] app data dir: {}", app_data.display());
+
                 if let Ok(canonical) = app_data.canonicalize() {
                     allowed.add_root(canonical);
                 } else {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -498,6 +498,9 @@ fn main() {
             let menu = build_menu(app)?;
             app.set_menu(menu)?;
 
+            #[cfg(debug_assertions)]
+            eprintln!("[startup] bundle identifier: {}", app.config().identifier);
+
             // Register $APPDATA as an always-allowed root so desktop
             // persistence (decode cache, database, etc.) works without
             // the user explicitly selecting it via a file dialog.

--- a/desktop/src-tauri/src/secure_store.rs
+++ b/desktop/src-tauri/src/secure_store.rs
@@ -1,11 +1,28 @@
 use keyring::{Entry, Error as KeyringError};
 use serde::{Deserialize, Serialize};
+use tauri::State;
 
-const SERVICE_NAME: &str = "health.divergent.dicomviewer";
 const ACCESS_TOKEN_KEY: &str = "access_token";
 const REFRESH_TOKEN_KEY: &str = "refresh_token";
 const USER_EMAIL_KEY: &str = "user_email";
 const USER_NAME_KEY: &str = "user_name";
+
+#[derive(Debug, Clone)]
+pub struct SecureStoreConfig {
+    service_name: String,
+}
+
+impl SecureStoreConfig {
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+        }
+    }
+
+    fn service_name(&self) -> &str {
+        &self.service_name
+    }
+}
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct SecureAuthState {
@@ -15,12 +32,12 @@ pub struct SecureAuthState {
     pub user_name: Option<String>,
 }
 
-fn entry_for(key: &str) -> Result<Entry, String> {
-    Entry::new(SERVICE_NAME, key).map_err(|error| error.to_string())
+fn entry_for(service_name: &str, key: &str) -> Result<Entry, String> {
+    Entry::new(service_name, key).map_err(|error| error.to_string())
 }
 
-fn read_value(key: &str) -> Result<Option<String>, String> {
-    let entry = entry_for(key)?;
+fn read_value(service_name: &str, key: &str) -> Result<Option<String>, String> {
+    let entry = entry_for(service_name, key)?;
     match entry.get_password() {
         Ok(value) => Ok(Some(value)),
         Err(KeyringError::NoEntry) => Ok(None),
@@ -28,8 +45,8 @@ fn read_value(key: &str) -> Result<Option<String>, String> {
     }
 }
 
-fn write_value(key: &str, value: Option<&str>) -> Result<(), String> {
-    let entry = entry_for(key)?;
+fn write_value(service_name: &str, key: &str, value: Option<&str>) -> Result<(), String> {
+    let entry = entry_for(service_name, key)?;
     match value {
         Some(raw) if !raw.is_empty() => entry.set_password(raw).map_err(|error| error.to_string()),
         _ => match entry.delete_credential() {
@@ -40,29 +57,45 @@ fn write_value(key: &str, value: Option<&str>) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn load_secure_auth_state() -> Result<SecureAuthState, String> {
+pub fn load_secure_auth_state(
+    config: State<'_, SecureStoreConfig>,
+) -> Result<SecureAuthState, String> {
+    let service_name = config.service_name();
     Ok(SecureAuthState {
-        access_token: read_value(ACCESS_TOKEN_KEY)?,
-        refresh_token: read_value(REFRESH_TOKEN_KEY)?,
-        user_email: read_value(USER_EMAIL_KEY)?,
-        user_name: read_value(USER_NAME_KEY)?,
+        access_token: read_value(service_name, ACCESS_TOKEN_KEY)?,
+        refresh_token: read_value(service_name, REFRESH_TOKEN_KEY)?,
+        user_email: read_value(service_name, USER_EMAIL_KEY)?,
+        user_name: read_value(service_name, USER_NAME_KEY)?,
     })
 }
 
 #[tauri::command]
-pub fn store_secure_auth_state(state: SecureAuthState) -> Result<bool, String> {
-    write_value(ACCESS_TOKEN_KEY, state.access_token.as_deref())?;
-    write_value(REFRESH_TOKEN_KEY, state.refresh_token.as_deref())?;
-    write_value(USER_EMAIL_KEY, state.user_email.as_deref())?;
-    write_value(USER_NAME_KEY, state.user_name.as_deref())?;
+pub fn store_secure_auth_state(
+    config: State<'_, SecureStoreConfig>,
+    state: SecureAuthState,
+) -> Result<bool, String> {
+    let service_name = config.service_name();
+    write_value(
+        service_name,
+        ACCESS_TOKEN_KEY,
+        state.access_token.as_deref(),
+    )?;
+    write_value(
+        service_name,
+        REFRESH_TOKEN_KEY,
+        state.refresh_token.as_deref(),
+    )?;
+    write_value(service_name, USER_EMAIL_KEY, state.user_email.as_deref())?;
+    write_value(service_name, USER_NAME_KEY, state.user_name.as_deref())?;
     Ok(true)
 }
 
 #[tauri::command]
-pub fn clear_secure_auth_state() -> Result<bool, String> {
-    write_value(ACCESS_TOKEN_KEY, None)?;
-    write_value(REFRESH_TOKEN_KEY, None)?;
-    write_value(USER_EMAIL_KEY, None)?;
-    write_value(USER_NAME_KEY, None)?;
+pub fn clear_secure_auth_state(config: State<'_, SecureStoreConfig>) -> Result<bool, String> {
+    let service_name = config.service_name();
+    write_value(service_name, ACCESS_TOKEN_KEY, None)?;
+    write_value(service_name, REFRESH_TOKEN_KEY, None)?;
+    write_value(service_name, USER_EMAIL_KEY, None)?;
+    write_value(service_name, USER_NAME_KEY, None)?;
     Ok(true)
 }

--- a/desktop/src-tauri/tauri.conf.dev.json
+++ b/desktop/src-tauri/tauri.conf.dev.json
@@ -1,0 +1,22 @@
+{
+  "productName": "myradone Dev",
+  "identifier": "health.divergent.dicomviewer.dev",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "myradone Dev",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600
+      }
+    ]
+  },
+  "bundle": {
+    "createUpdaterArtifacts": false
+  },
+  "plugins": {
+    "updater": null
+  }
+}

--- a/docs/decisions/014-per-channel-bundle-identity.md
+++ b/docs/decisions/014-per-channel-bundle-identity.md
@@ -1,0 +1,148 @@
+# ADR 014: Per-Channel Bundle Identity for Desktop Builds
+
+## Status
+
+Implemented
+
+## Context
+
+The Tauri dev and release builds historically shared the same bundle identifier,
+`health.divergent.dicomviewer`. On macOS, Tauri derives the app data directory
+from that identifier, so both builds used:
+
+```text
+~/Library/Application Support/health.divergent.dicomviewer/
+```
+
+That meant a dev launch could read or mutate the same `viewer.db`, managed
+library folder, notes, comments, reports, and persisted file-scope grants used
+by the installed release app. During the 2026-05-15 BUG-014 investigation, a
+dev-side attempt to repair migration state for the consent popup touched the
+installed app's database because both channels shared this identity.
+
+The shared display name created a second problem: both builds appeared as
+`myradone` in the macOS menu bar and Dock, which made it easy to mistake the
+dev shell for the installed app. A runtime title/menu workaround was not enough
+because macOS bundle metadata such as `CFBundleName` is derived from the Tauri
+build config.
+
+## Decision
+
+Each desktop build channel gets a distinct Tauri bundle identifier:
+
+```text
+health.divergent.dicomviewer[.<channel>]
+```
+
+The empty channel is reserved for production to preserve continuity with the
+existing installed app and its data directory. The initial channels are:
+
+- Production: `health.divergent.dicomviewer`
+- Development: `health.divergent.dicomviewer.dev`
+
+The development channel also uses `productName = "myradone Dev"` and an initial
+window title of `myradone Dev`, so it is visually distinct before and after the
+webview loads.
+
+The existing managed launcher, `desktop/scripts/dev-desktop.sh`, remains the
+entry point for desktop development. It injects the dev identity and current
+dev server URL with Tauri 2.5.6's `TAURI_CONFIG` inline JSON merge overlay
+before invoking `cargo run`. This preserves the launcher's port cleanup and
+static docs server behavior without adding `tauri-cli` as a new required tool.
+
+## Alternatives Considered
+
+### `tauri dev --config`
+
+Rejected for now. It is the most recognizable Tauri CLI pattern for config
+overlays, but this repository already has a managed launcher that handles stale
+port cleanup and serves `docs/` directly. Replacing that orchestration solely
+to set the dev bundle identity would create more moving parts than this change
+requires.
+
+### Custom `build.rs` config selection
+
+Rejected. The pinned Tauri build and codegen crates already read the
+`TAURI_CONFIG` environment variable and merge it into the compile-time config.
+Adding custom `build.rs` selection would duplicate a supported hook and make the
+configuration path harder to inspect.
+
+### Runtime app-data path redirection
+
+Rejected. Redirecting `app_data_dir()` consumers in application code would
+invert the responsibility: every filesystem, SQL, persisted-scope, and future
+desktop feature would need to remember which channel it was running in. Bundle
+identity is the platform-level source of truth and keeps data isolation below
+the app feature layer.
+
+### Runtime display-name patch only
+
+Rejected. Renaming menu items or windows at runtime can reduce visual confusion
+but does not isolate data. It also cannot reliably replace bundle-derived macOS
+metadata such as the app menu label.
+
+## Design Details
+
+- `desktop/src-tauri/tauri.conf.json` remains the production config and keeps
+  `identifier = "health.divergent.dicomviewer"`.
+- `desktop/src-tauri/tauri.conf.dev.json` contains only the dev-channel overlay:
+  dev product name, dev identifier, full window block, updater artifact
+  suppression, and removal of updater endpoint config.
+- The dev launcher reads `tauri.conf.dev.json`, injects the active
+  `build.devUrl` derived from `DICOM_DESKTOP_DEV_HOST` /
+  `DICOM_DESKTOP_DEV_PORT`, then sets:
+
+  ```bash
+  CARGO_TARGET_DIR="${DESKTOP_DIR}/src-tauri/target-dev"
+  TAURI_CONFIG="$(dev_tauri_config)"
+  ```
+
+  before running Cargo.
+
+- `target-dev/` keeps debug artifacts for the dev channel separate from the
+  normal `target/` tree so generated Tauri context code cannot be reused across
+  channel flips.
+- The stale-server guard in `dev-desktop.sh` checks both `target/debug` and
+  `target-dev/debug` so a second dev launch cannot accidentally tear down the
+  server used by an already-running dev app.
+- The dev overlay sets `"plugins": { "updater": null }`, which removes the dev
+  channel's updater endpoint config from the merged Tauri config. The Rust
+  updater plugin is still registered, but the dev channel has no production
+  update endpoint configured.
+- The full `windows[0]` block is repeated in the overlay because JSON merge
+  behavior for arrays replaces the window entry rather than merging individual
+  fields.
+
+## Consequences
+
+Positive:
+
+- Dev and production data are isolated by macOS bundle identity.
+- The installed app keeps its existing data directory unchanged.
+- The dev app creates and uses
+  `~/Library/Application Support/health.divergent.dicomviewer.dev/`.
+- The menu bar, Dock label, and initial window title distinguish the dev build.
+- BUG-014 first-launch and migration scenarios can be reproduced against a
+  disposable dev database.
+- Future beta or nightly channels can follow the same identifier convention
+  with one additional overlay file per channel.
+
+Tradeoffs:
+
+- The dev channel creates an additional `target-dev/` build directory.
+- The dev app starts with an empty library and no persisted file-scope grants.
+  That is intentional isolation, but developers must re-grant folders or import
+  test data in the dev channel.
+- Keychain and secure-store entries are channel-specific because the bundle
+  identifier changes. This is desirable for isolation but should not surprise
+  anyone testing credentials.
+- If the dev channel is ever bundled for distribution, signing and provisioning
+  must be configured explicitly for the `.dev` identifier. The current workflow
+  launches dev with `cargo run`, so this ADR does not introduce a dev release
+  channel.
+
+## Rollback
+
+Delete `desktop/src-tauri/tauri.conf.dev.json` and remove the `TAURI_CONFIG` /
+`CARGO_TARGET_DIR` prefixes from `desktop/scripts/dev-desktop.sh`. That returns
+dev and production builds to a shared identifier and shared app data directory.

--- a/docs/decisions/014-per-channel-bundle-identity.md
+++ b/docs/decisions/014-per-channel-bundle-identity.md
@@ -109,6 +109,9 @@ metadata such as the app menu label.
   channel's updater endpoint config from the merged Tauri config. The Rust
   updater plugin is still registered, but the dev channel has no production
   update endpoint configured.
+- The secure auth store uses the compiled bundle identifier as its Keychain
+  service name. Production continues to use `health.divergent.dicomviewer`; dev
+  uses `health.divergent.dicomviewer.dev`.
 - The full `windows[0]` block is repeated in the overlay because JSON merge
   behavior for arrays replaces the window entry rather than merging individual
   fields.
@@ -136,6 +139,11 @@ Tradeoffs:
 - Keychain and secure-store entries are channel-specific because the bundle
   identifier changes. This is desirable for isolation but should not surprise
   anyone testing credentials.
+- Any developer who previously launched dev builds before this ADR should treat
+  `~/Library/Application Support/health.divergent.dicomviewer/` as shared
+  production state. Back up that directory before manual repair, and clean up
+  old dev experiments only after identifying exactly which files belong to the
+  experiment.
 - If the dev channel is ever bundled for distribution, signing and provisioning
   must be configured explicitly for the `.dev` identifier. The current workflow
   launches dev with `cargo run`, so this ADR does not introduce a dev release


### PR DESCRIPTION
## Summary

- Adds a dev-only Tauri config overlay with `productName = "myradone Dev"` and `identifier = "health.divergent.dicomviewer.dev"`.
- Updates the managed desktop launcher to inject the dev overlay via `TAURI_CONFIG`, use a separate `target-dev` build directory, and keep `DICOM_DESKTOP_DEV_PORT` reflected in the compiled dev URL.
- Documents the per-channel bundle identity decision in ADR 014.

## Why

The dev and installed release builds shared `health.divergent.dicomviewer`, so they also shared the same macOS Application Support directory. That made dev database and migration experiments capable of touching the installed app's `viewer.db`. The dev channel now gets its own bundle identity and app-data directory.

## Validation

- `python3 -m json.tool desktop/src-tauri/tauri.conf.dev.json`
- `bash -n desktop/scripts/dev-desktop.sh`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- `git diff --check`
- Confirmed during verification that a compiled dev binary embedded `health.divergent.dicomviewer.dev` / `myradone Dev`, while a base build embedded the production identifier and updater endpoint.

Could not complete a live `npm run desktop:launch` verification because the machine hit `No space left on device` during linking. Generated target dirs were cleaned afterward.
