### PR TITLE
[codex] Reduce duplicated desktop runtime helpers

### DIFF
--- a/docs/js/app/library.js
+++ b/docs/js/app/library.js
@@ -556,7 +556,7 @@
                                         <div class="series-main-row">
                                             <span class="series-icon">&#128196;</span>
                                             ${warningIcon}
-                                            <span class="series-name">${escapeHtml(series.seriesDescription || 'Series ' + (series.seriesNumber || '?'))}</span>
+                                            <span class="series-name">${escapeHtml(series.seriesDescription || `Series ${series.seriesNumber || '?'}`)}</span>
                                             <span class="series-count">${series.slices.length} slices</span>
                                             <button class="comment-toggle series-comment-toggle" data-study-uid="${escapeHtml(study.studyInstanceUid)}" data-series-uid="${escapeHtml(series.seriesInstanceUid)}">
                                                 ${seriesCommentCount > 0 ? `${seriesCommentCount} comment${seriesCommentCount > 1 ? 's' : ''}` : 'Add comment'}
@@ -1033,7 +1033,7 @@
             messageParts.push(`${errors} error${errors !== 1 ? 's' : ''}`);
         }
 
-        let message = messageParts.join('. ') + '.';
+        let message = `${messageParts.join('. ')}.`;
         if (duration != null) {
             const seconds = (duration / 1000).toFixed(1);
             message += ` (${seconds}s)`;

--- a/docs/js/app/main.js
+++ b/docs/js/app/main.js
@@ -304,29 +304,10 @@
     }
 
     async function waitForDesktopRuntime() {
-        const runtime = window.__TAURI__;
-        if (runtime?.fs?.readFile && runtime?.path?.appDataDir && runtime?.path?.join) {
-            return runtime;
-        }
-
-        const ready = window.__DICOM_VIEWER_TAURI_STORAGE_READY__ || window.__DICOM_VIEWER_TAURI_READY__;
-        if (ready && typeof ready.then === 'function') {
-            const resolved = await ready;
-            if (resolved?.fs?.readFile && resolved?.path?.appDataDir && resolved?.path?.join) {
-                return resolved;
-            }
-        }
-
-        const deadline = performance.now() + 5000;
-        while (performance.now() < deadline) {
-            const current = window.__TAURI__;
-            if (current?.fs?.readFile && current?.path?.appDataDir && current?.path?.join) {
-                return current;
-            }
-            await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-
-        return window.__TAURI__ || null;
+        return await window.DicomViewerTauriCompat.waitForRuntime({
+            validator: (runtime) => !!(runtime?.fs?.readFile && runtime?.path?.appDataDir && runtime?.path?.join),
+            ready: [window.__DICOM_VIEWER_TAURI_STORAGE_READY__, window.__DICOM_VIEWER_TAURI_READY__],
+        });
     }
 
     async function initializeDesktopLibrary() {

--- a/docs/js/app/rendering.js
+++ b/docs/js/app/rendering.js
@@ -224,7 +224,7 @@
         if (typeof value === 'string') {
             // Redact absolute paths to filename only (may contain patient names in directory structure)
             if ((value.startsWith('/') && value.includes('/', 1)) || /^[A-Z]:\\/.test(value)) {
-                return '.../' + value.split(/[\\/]/).pop();
+                return `.../${value.split(/[\\/]/).pop()}`;
             }
             return value;
         }

--- a/docs/js/app/reports-ui.js
+++ b/docs/js/app/reports-ui.js
@@ -250,20 +250,9 @@
     if (!app.desktopBridge) {
         app.desktopBridge = {
             async getRuntime() {
-                const runtime = window.__TAURI__;
-                if (typeof runtime?.core?.invoke === 'function') {
-                    return runtime;
-                }
-
-                const ready = window.__DICOM_VIEWER_TAURI_READY__;
-                if (ready && typeof ready.then === 'function') {
-                    const resolved = await ready;
-                    if (typeof resolved?.core?.invoke === 'function') {
-                        return resolved;
-                    }
-                }
-
-                return window.__TAURI__ || null;
+                return await window.DicomViewerTauriCompat.waitForRuntime({
+                    validator: (runtime) => typeof runtime?.core?.invoke === 'function',
+                });
             },
             async revealInFinder(path) {
                 if (!path) return false;

--- a/docs/js/app/reports-ui.js
+++ b/docs/js/app/reports-ui.js
@@ -251,6 +251,7 @@
         app.desktopBridge = {
             async getRuntime() {
                 return await window.DicomViewerTauriCompat.waitForRuntime({
+                    ready: window.__DICOM_VIEWER_TAURI_READY__,
                     validator: (runtime) => typeof runtime?.core?.invoke === 'function',
                 });
             },

--- a/docs/js/app/sync-status-ui.js
+++ b/docs/js/app/sync-status-ui.js
@@ -51,7 +51,7 @@ const _SyncStatusUI = (() => {
         if (initialized) return;
 
         const config = window.CONFIG;
-        if (!config || !config.features || !config.features.cloudSync) {
+        if (!config?.features?.cloudSync) {
             return;
         }
 
@@ -177,14 +177,14 @@ const _SyncStatusUI = (() => {
         if (!iconEl || !textEl || !statusEl) return;
 
         // Update the CSS class for color/animation
-        statusEl.className = 'sync-status sync-status--' + status;
+        statusEl.className = `sync-status sync-status--${status}`;
 
         // Update the label
         textEl.textContent = STATE_LABELS[status] || status;
 
         // Build tooltip with relative time for synced state
         if (status === 'synced' && lastSyncTimestamp) {
-            statusEl.title = 'Last synced: ' + formatRelativeTime(lastSyncTimestamp);
+            statusEl.title = `Last synced: ${formatRelativeTime(lastSyncTimestamp)}`;
         } else if (status === 'error') {
             statusEl.title = 'Sync failed. Will retry automatically.';
         } else if (status === 'offline') {
@@ -239,7 +239,7 @@ const _SyncStatusUI = (() => {
 
         const statusEl = document.getElementById('syncStatus');
         if (statusEl) {
-            statusEl.title = 'Last synced: ' + formatRelativeTime(lastSyncTimestamp);
+            statusEl.title = `Last synced: ${formatRelativeTime(lastSyncTimestamp)}`;
         }
     }
 
@@ -253,15 +253,15 @@ const _SyncStatusUI = (() => {
         const deltaSec = Math.floor(deltaMs / 1000);
 
         if (deltaSec < 10) return 'just now';
-        if (deltaSec < 60) return deltaSec + ' seconds ago';
+        if (deltaSec < 60) return `${deltaSec} seconds ago`;
 
         const deltaMin = Math.floor(deltaSec / 60);
         if (deltaMin === 1) return '1 minute ago';
-        if (deltaMin < 60) return deltaMin + ' minutes ago';
+        if (deltaMin < 60) return `${deltaMin} minutes ago`;
 
         const deltaHour = Math.floor(deltaMin / 60);
         if (deltaHour === 1) return '1 hour ago';
-        return deltaHour + ' hours ago';
+        return `${deltaHour} hours ago`;
     }
 
     /**

--- a/docs/js/app/tools.js
+++ b/docs/js/app/tools.js
@@ -66,11 +66,11 @@
     function formatDistance(distanceMm, distancePixels) {
         if (distanceMm !== null) {
             if (distanceMm >= 100) {
-                return (distanceMm / 10).toFixed(2) + ' cm';
+                return `${(distanceMm / 10).toFixed(2)} cm`;
             }
-            return distanceMm.toFixed(2) + ' mm';
+            return `${distanceMm.toFixed(2)} mm`;
         }
-        return distancePixels.toFixed(1) + ' px';
+        return `${distancePixels.toFixed(1)} px`;
     }
 
     function createMeasurement(start, end) {

--- a/docs/js/app/update-ui.js
+++ b/docs/js/app/update-ui.js
@@ -29,10 +29,6 @@ const _UpdateUI = (() => {
     // Brief message display time for "up to date" on manual check
     const UP_TO_DATE_DISPLAY_MS = 4000;
 
-    // Max time to wait for Tauri runtime APIs to become available
-    const RUNTIME_WAIT_TIMEOUT_MS = 5000;
-    const RUNTIME_POLL_INTERVAL_MS = 50;
-
     let initialized = false;
     let pendingUpdate = null;
     let installing = false;
@@ -85,28 +81,10 @@ const _UpdateUI = (() => {
     }
 
     async function waitForUpdaterRuntime() {
-        // Check if already available
-        if (hasUpdaterApis(window.__TAURI__)) {
-            return window.__TAURI__;
-        }
-
-        // Wait for the ready promise if available
-        const ready = window.__DICOM_VIEWER_TAURI_READY__;
-        if (ready && typeof ready.then === 'function') {
-            const resolved = await ready;
-            if (hasUpdaterApis(resolved)) return resolved;
-        }
-
-        // Poll for late-arriving runtime
-        const deadline = performance.now() + RUNTIME_WAIT_TIMEOUT_MS;
-        while (performance.now() < deadline) {
-            if (hasUpdaterApis(window.__TAURI__)) {
-                return window.__TAURI__;
-            }
-            await new Promise((resolve) => setTimeout(resolve, RUNTIME_POLL_INTERVAL_MS));
-        }
-
-        return null;
+        return await window.DicomViewerTauriCompat.waitForRuntime({
+            validator: hasUpdaterApis,
+            fallbackRuntime: false,
+        });
     }
 
     function hasUpdaterApis(runtime) {
@@ -142,7 +120,7 @@ const _UpdateUI = (() => {
 
             if (update) {
                 pendingUpdate = update;
-                showBanner('Version ' + update.version + ' is available.', 'Download and Install');
+                showBanner(`Version ${update.version} is available.`, 'Download and Install');
             } else if (manual) {
                 showBanner('You are on the latest version.', null);
                 setTimeout(hideBanner, UP_TO_DATE_DISPLAY_MS);

--- a/docs/js/app/viewer.js
+++ b/docs/js/app/viewer.js
@@ -665,7 +665,7 @@
             .map(
                 (series) => `
             <div class="series-item" data-uid="${escapeHtml(series.seriesInstanceUid)}">
-                <div class="series-name">${escapeHtml(series.seriesDescription || 'Series ' + (series.seriesNumber || '?'))}</div>
+                <div class="series-name">${escapeHtml(series.seriesDescription || `Series ${series.seriesNumber || '?'}`)}</div>
                 <div class="series-info">${series.slices.length} slices</div>
             </div>
         `,

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -117,62 +117,6 @@ const CONFIG = {
             instrumentation: mode === 'desktop' || mode === 'personal',
         };
     },
-
-    /**
-     * Check if notes should persist
-     * Always true; storage backend depends on deployment mode
-     * @returns {boolean}
-     */
-    shouldPersistNotes() {
-        return this.features.notesPersistence;
-    },
-
-    /**
-     * Check if running on the cloud platform
-     * @returns {boolean}
-     */
-    isCloudPlatform() {
-        return this.deploymentMode === 'cloud';
-    },
-
-    /**
-     * Check if running in demo mode (GitHub Pages)
-     * @returns {boolean}
-     */
-    isDemo() {
-        return this.deploymentMode === 'demo';
-    },
-
-    /**
-     * Check if running in a preview environment (Vercel)
-     * @returns {boolean}
-     */
-    isPreview() {
-        return this.deploymentMode === 'preview';
-    },
-
-    /**
-     * Check if running locally or self-hosted
-     * @returns {boolean}
-     */
-    isPersonal() {
-        return this.deploymentMode === 'personal';
-    },
-
-    /**
-     * Get human-readable deployment mode name
-     * @returns {string}
-     */
-    getModeName() {
-        const names = {
-            demo: 'Demo',
-            preview: 'Preview',
-            cloud: 'Cloud',
-            desktop: 'Desktop',
-            personal: 'Personal',
-        };
-        return names[this.deploymentMode] || 'Unknown';
-    },
 };
 
 // Freeze to prevent modification

--- a/docs/js/instrumentation.js
+++ b/docs/js/instrumentation.js
@@ -15,7 +15,6 @@ const Instrumentation = (() => {
     const PHONE_HOME_DEBOUNCE_MS = 5_000;
     const PHONE_HOME_URL = 'https://api.myradone.com/api/stats';
     const SCHEMA_VERSION = 1;
-    const DESKTOP_RUNTIME_TIMEOUT_MS = 5_000;
 
     // Desktop SQL table and DB
     const DESKTOP_DB_URL = 'sqlite:viewer.db';
@@ -27,7 +26,6 @@ const Instrumentation = (() => {
 
     let stats = null;
     let dirty = false;
-    let flushTimer = null;
     let phoneHomeTimer = null;
     let desktopDbPromise = null;
     let useDesktopSql = false;
@@ -129,19 +127,10 @@ const Instrumentation = (() => {
     }
 
     async function waitForDesktopRuntime() {
-        const ready = window.__DICOM_VIEWER_TAURI_STORAGE_READY__ || window.__DICOM_VIEWER_TAURI_READY__;
-        if (ready && typeof ready.then === 'function') {
-            await ready;
-        }
-        if (window.__TAURI__?.sql?.load) return window.__TAURI__;
-
-        const deadline = performance.now() + DESKTOP_RUNTIME_TIMEOUT_MS;
-        while (performance.now() < deadline) {
-            if (window.__TAURI__?.sql?.load) return window.__TAURI__;
-            await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-
-        return window.__TAURI__ || null;
+        return await window.DicomViewerTauriCompat.waitForRuntime({
+            validator: (runtime) => typeof runtime?.sql?.load === 'function',
+            ready: [window.__DICOM_VIEWER_TAURI_STORAGE_READY__, window.__DICOM_VIEWER_TAURI_READY__],
+        });
     }
 
     async function getDesktopDb() {
@@ -170,7 +159,7 @@ const Instrumentation = (() => {
         try {
             const db = await getDesktopDb();
             const rows = await db.select(`SELECT * FROM ${DESKTOP_TABLE} WHERE id = 1 LIMIT 1`);
-            if (!rows || !rows.length) return null;
+            if (!rows?.length) return null;
             const row = rows[0];
             return {
                 version: row.version,
@@ -473,7 +462,7 @@ const Instrumentation = (() => {
         stats = await loadStats();
 
         // Start periodic flush
-        flushTimer = setInterval(() => {
+        setInterval(() => {
             if (dirty) {
                 void flush();
             }

--- a/docs/js/persistence/desktop.js
+++ b/docs/js/persistence/desktop.js
@@ -145,18 +145,10 @@ const _NotesDesktop = (() => {
     }
 
     async function waitForDesktopRuntime() {
-        const ready = window.__DICOM_VIEWER_TAURI_STORAGE_READY__ || window.__DICOM_VIEWER_TAURI_READY__;
-        if (ready && typeof ready.then === 'function') {
-            await ready;
-        }
-        if (window.__TAURI__?.sql?.load) return window.__TAURI__;
-
-        const deadline = performance.now() + 5000;
-        while (performance.now() < deadline) {
-            if (window.__TAURI__?.sql?.load) return window.__TAURI__;
-            await new Promise((r) => setTimeout(r, 50));
-        }
-        return window.__TAURI__ || null;
+        return await window.DicomViewerTauriCompat.waitForRuntime({
+            validator: (runtime) => typeof runtime?.sql?.load === 'function',
+            ready: [window.__DICOM_VIEWER_TAURI_STORAGE_READY__, window.__DICOM_VIEWER_TAURI_READY__],
+        });
     }
 
     async function getDesktopDb() {

--- a/docs/js/persistence/dispatcher.js
+++ b/docs/js/persistence/dispatcher.js
@@ -48,10 +48,6 @@ const NotesAPI = (() => {
     }
 
     function isEnabled() {
-        const config = getConfig();
-        if (config?.shouldPersistNotes) {
-            return config.shouldPersistNotes();
-        }
         return true;
     }
 
@@ -131,7 +127,6 @@ const NotesAPI = (() => {
     }
 
     async function loadNotes(studyUids) {
-        if (!isEnabled()) return { studies: {} };
         return await withFallback(
             () => ServerBackend.loadNotes(studyUids),
             () => LocalBackend.loadNotes(studyUids),
@@ -140,7 +135,6 @@ const NotesAPI = (() => {
     }
 
     async function saveStudyDescription(studyUid, description) {
-        if (!isEnabled()) return null;
         const baseSyncVersion = getBaseSyncVersion(getStudyState(studyUid));
         const result = await withFallback(
             () => ServerBackend.saveStudyDescription(studyUid, description),
@@ -154,7 +148,6 @@ const NotesAPI = (() => {
     }
 
     async function saveSeriesDescription(studyUid, seriesUid, description) {
-        if (!isEnabled()) return null;
         const studyEntry = getStudyState(studyUid);
         const seriesEntry = studyEntry?.series?.[seriesUid] || null;
         const baseSyncVersion = getBaseSyncVersion(seriesEntry);
@@ -170,7 +163,6 @@ const NotesAPI = (() => {
     }
 
     async function addComment(studyUid, payload) {
-        if (!isEnabled()) return null;
         const result = await withFallback(
             () => ServerBackend.addComment(studyUid, payload),
             () => LocalBackend.addComment(studyUid, payload),
@@ -184,7 +176,6 @@ const NotesAPI = (() => {
     }
 
     async function updateComment(studyUid, commentId, payload) {
-        if (!isEnabled()) return null;
         const comment = findCommentRecord(studyUid, commentId);
         const baseSyncVersion = getBaseSyncVersion(comment);
         const result = await withFallback(
@@ -200,7 +191,6 @@ const NotesAPI = (() => {
     }
 
     async function deleteComment(studyUid, commentId) {
-        if (!isEnabled()) return false;
         const comment = findCommentRecord(studyUid, commentId);
         const baseSyncVersion = getBaseSyncVersion(comment);
         const result = await withFallback(
@@ -216,7 +206,6 @@ const NotesAPI = (() => {
     }
 
     async function uploadReport(studyUid, file, meta) {
-        if (!isEnabled()) return null;
         const result = await withFallback(
             () => ServerBackend.uploadReport(studyUid, file, meta),
             () => LocalBackend.uploadReport(studyUid, file, meta),
@@ -230,7 +219,6 @@ const NotesAPI = (() => {
     }
 
     async function deleteReport(studyUid, reportId) {
-        if (!isEnabled()) return false;
         const report = findReportRecord(studyUid, reportId);
         const baseSyncVersion = getBaseSyncVersion(report);
         const result = await withFallback(
@@ -246,7 +234,6 @@ const NotesAPI = (() => {
     }
 
     async function migrate(payload) {
-        if (!isEnabled()) return null;
         return await withFallback(
             () => ServerBackend.migrate(payload),
             () => LocalBackend.migrate(payload),
@@ -255,7 +242,6 @@ const NotesAPI = (() => {
     }
 
     function getReportFileUrl(reportId) {
-        if (!isEnabled()) return '';
         const backend = getBackend();
         if (backend === 'server') {
             return ServerBackend.getReportFileUrl(reportId);
@@ -267,7 +253,7 @@ const NotesAPI = (() => {
     }
 
     function getReportFilePath(reportId) {
-        if (!isEnabled() || getBackend() !== 'desktop') return '';
+        if (getBackend() !== 'desktop') return '';
         return DesktopBackend.getReportFilePath(reportId);
     }
 

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -10,6 +10,8 @@
     };
     const MAX_ATTEMPTS = 1200;
     const RETRY_DELAY_MS = 25;
+    const DEFAULT_RUNTIME_WAIT_MS = 5000;
+    const DEFAULT_RUNTIME_POLL_MS = 50;
 
     function hasReadyDesktopStorageApis(runtime) {
         return !!(
@@ -349,10 +351,53 @@
         });
     }
 
+    async function waitForRuntime(options = {}) {
+        const {
+            validator = hasReadyDesktopApis,
+            ready = window.__DICOM_VIEWER_TAURI_READY__,
+            timeoutMs = DEFAULT_RUNTIME_WAIT_MS,
+            pollMs = DEFAULT_RUNTIME_POLL_MS,
+            fallbackRuntime = true,
+        } = options;
+
+        const current = resolveDesktopRuntime(validator);
+        if (current) return current;
+
+        let readyRuntime = null;
+        const readyPromises = Array.isArray(ready) ? ready : [ready];
+        for (const promise of readyPromises) {
+            if (!promise || typeof promise.then !== 'function') continue;
+            promise
+                .then((resolved) => {
+                    if (validator(resolved)) {
+                        readyRuntime = resolved;
+                        return;
+                    }
+                    readyRuntime = resolveDesktopRuntime(validator);
+                })
+                .catch(() => {});
+        }
+
+        const deadline = performance.now() + timeoutMs;
+        while (performance.now() < deadline) {
+            if (readyRuntime) return readyRuntime;
+            const runtime = resolveDesktopRuntime(validator);
+            if (runtime) return runtime;
+            await new Promise((resolve) => setTimeout(resolve, pollMs));
+        }
+
+        return fallbackRuntime ? window.__TAURI__ || null : null;
+    }
+
     window.__DICOM_VIEWER_TAURI_STORAGE_READY__ =
         window.__DICOM_VIEWER_TAURI_STORAGE_READY__ || createReadyPromise(hasReadyDesktopStorageApis);
 
     window.__DICOM_VIEWER_TAURI_READY__ =
         window.__DICOM_VIEWER_TAURI_READY__ || createReadyPromise(hasReadyDesktopApis);
+    window.DicomViewerTauriCompat = Object.freeze({
+        waitForRuntime,
+        hasReadyDesktopApis,
+        hasReadyDesktopStorageApis,
+    });
     resolveDesktopRuntime(hasReadyDesktopStorageApis) || resolveDesktopRuntime();
 })();

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -369,11 +369,8 @@
             if (!promise || typeof promise.then !== 'function') continue;
             promise
                 .then((resolved) => {
-                    if (validator(resolved)) {
-                        readyRuntime = resolved;
-                        return;
-                    }
-                    readyRuntime = resolveDesktopRuntime(validator);
+                    const runtime = validator(resolved) ? resolved : resolveDesktopRuntime(validator);
+                    if (runtime) readyRuntime = runtime;
                 })
                 .catch(() => {});
         }

--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -374,6 +374,10 @@
                 })
                 .catch(() => {});
         }
+        if (readyPromises.some((promise) => promise && typeof promise.then === 'function')) {
+            await Promise.resolve();
+            if (readyRuntime) return readyRuntime;
+        }
 
         const deadline = performance.now() + timeoutMs;
         while (performance.now() < deadline) {

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -740,6 +740,30 @@ test('desktop scan uses read_scan_manifest and read_scan_header through producti
     expect(result.headerPaths).toContain('/library/IMG001.dcm');
 });
 
+test('waitForRuntime returns an already-settled ready runtime before the first poll delay', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5001/?nolib');
+
+    const result = await page.evaluate(async () => {
+        const runtime = { core: { invoke() {} } };
+        const startedAt = performance.now();
+        const resolved = await window.DicomViewerTauriCompat.waitForRuntime({
+            ready: Promise.resolve(runtime),
+            validator: (candidate) => candidate === runtime,
+            timeoutMs: 1200,
+            pollMs: 1000,
+            fallbackRuntime: false,
+        });
+
+        return {
+            matched: resolved === runtime,
+            elapsedMs: performance.now() - startedAt,
+        };
+    });
+
+    expect(result.matched).toBe(true);
+    expect(result.elapsedMs).toBeLessThan(250);
+});
+
 // Regression: waitForDesktopRuntime() did a one-shot check for window.__TAURI__.sql.load
 // and returned null immediately if it wasn't there yet. On cold start the SQL plugin is
 // injected asynchronously, so getDesktopDb() would throw before the plugin was ready.

--- a/tests/instrumentation.spec.js
+++ b/tests/instrumentation.spec.js
@@ -38,7 +38,7 @@
 // is off by default on fresh install.
 //
 const { test, expect } = require('@playwright/test');
-const path = require('path');
+const path = require('node:path');
 
 const APP_URL = 'http://127.0.0.1:5001/?nolib';
 const TEST_URL = 'http://127.0.0.1:5001/?test';


### PR DESCRIPTION
## Summary
- add a shared Tauri runtime wait helper and route desktop/update/report callers through it
- remove unused deployment-mode convenience helpers from config
- simplify NotesAPI dispatcher guards now that persistence is always enabled

## Verification
- npm run format:js:check
- npm run lint:js (passes with existing warnings/infos outside this cleanup)
- git diff --check
- npx playwright test tests/config-hostname-matching.spec.js tests/desktop-runtime-compat.spec.js tests/instrumentation.spec.js --reporter=line
- npm test -- --reporter=line (559 passed, 4 skipped)