### PR TITLE
[codex] Add real Tauri desktop launch smoke

### DIFF
--- a/.github/workflows/real-tauri-nightly.yml
+++ b/.github/workflows/real-tauri-nightly.yml
@@ -47,6 +47,7 @@ jobs:
         run: npm run test:real-tauri
         env:
           CI: true
+          DICOM_REAL_TAURI_PORT: '15320'
 
       - name: Upload real Tauri diagnostics
         uses: actions/upload-artifact@v4

--- a/.github/workflows/real-tauri-nightly.yml
+++ b/.github/workflows/real-tauri-nightly.yml
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Divergent Health Technologies
+# Nightly real-Tauri smoke workflow.
+
+name: Real Tauri Nightly Smoke
+
+on:
+  schedule:
+    - cron: '23 9 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: real-tauri-nightly-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: macOS Real Tauri Launch Smoke
+    runs-on: macos-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install desktop dependencies
+        working-directory: desktop
+        run: npm ci
+
+      - name: Run real Tauri smoke
+        run: npm run test:real-tauri
+        env:
+          CI: true
+
+      - name: Upload real Tauri diagnostics
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: real-tauri-diagnostics
+          path: tests/real-tauri/diagnostics/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ data/
 dist/
 build/
 desktop/src-tauri/target/
+desktop/src-tauri/target-dev/
 desktop/src-tauri/gen/
 .wrangler/
 
@@ -57,6 +58,8 @@ test-data/
 # Playwright test results
 test-results/
 .playwright-mcp/
+tests/real-tauri/diagnostics/*
+!tests/real-tauri/diagnostics/.gitkeep
 
 # Session logs (contain local paths)
 docs/planning/SESSION-*.md

--- a/desktop/src-tauri/tauri.conf.dev.json
+++ b/desktop/src-tauri/tauri.conf.dev.json
@@ -15,8 +15,5 @@
   },
   "bundle": {
     "createUpdaterArtifacts": false
-  },
-  "plugins": {
-    "updater": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:py:fix": "./scripts/run-ruff.sh check --fix app.py server/",
     "lint:rust": "cargo clippy --locked --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings",
     "test": "npx playwright test",
+    "test:real-tauri": "DICOM_ENABLE_REAL_TAURI=1 npx playwright test --project=real-tauri",
     "worktree:new": "./scripts/agent-worktree-new.sh",
     "worktree:list": "./scripts/agent-worktree-list.sh",
     "worktree:list:all": "./scripts/agent-worktree-list.sh --all",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 Divergent Health Technologies
 const { defineConfig, devices } = require('@playwright/test');
 
+const enableRealTauri = process.env.DICOM_ENABLE_REAL_TAURI === '1';
+
 /**
  * Playwright configuration for DICOM Viewer tests
  *
@@ -58,12 +60,21 @@ module.exports = defineConfig({
   },
 
   /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-  ],
+  projects: enableRealTauri
+    ? [
+        {
+          name: 'real-tauri',
+          testMatch: /real-tauri\/.*\.spec\.js/,
+          retries: 1,
+        },
+      ]
+    : [
+        {
+          name: 'chromium',
+          testIgnore: /real-tauri\/.*\.spec\.js/,
+          use: { ...devices['Desktop Chrome'] },
+        },
+      ],
 
   /* Timeout settings */
   timeout: 60000, // 60 seconds per test - DICOM rendering can be slow with large files
@@ -87,10 +98,12 @@ module.exports = defineConfig({
    *   often has server running in another terminal)
    * - CI environment: Always start fresh to ensure clean, reproducible state
    */
-  webServer: {
-    command: 'FLASK_ENV=test ./venv/bin/flask run --host=127.0.0.1 --port=5001',
-    url: 'http://127.0.0.1:5001/api/test-data/info',
-    reuseExistingServer: !process.env.CI,
-    timeout: 60000,
-  },
+  webServer: enableRealTauri
+    ? undefined
+    : {
+        command: 'FLASK_ENV=test ./venv/bin/flask run --host=127.0.0.1 --port=5001',
+        url: 'http://127.0.0.1:5001/api/test-data/info',
+        reuseExistingServer: !process.env.CI,
+        timeout: 60000,
+      },
 });

--- a/tests/real-tauri/README.md
+++ b/tests/real-tauri/README.md
@@ -1,0 +1,41 @@
+# Real Tauri Smoke Suite
+
+This suite launches the actual debug Tauri desktop binary through the managed desktop launcher. It is a fidelity floor for desktop startup and channel isolation, not a replacement for browser-level Playwright tests.
+
+## Why This Is A Launch Smoke
+
+Tauri's official WebDriver support does not cover desktop macOS because WKWebView has no native WebDriver server. This repository's active desktop surface is macOS, so the first real-Tauri suite verifies what can be checked reliably without a WebDriver bridge:
+
+- the managed desktop launcher starts the docs server
+- the actual Rust/Tauri binary reaches startup
+- the dev overlay compiles into the binary as `health.divergent.dicomviewer.dev`
+- the app data directory resolves to the dev channel, not production
+- bundled sample data is served by the desktop docs server
+
+The dev overlay disables updater artifact creation, but it does not set `plugins.updater` to `null`: Tauri 2 rejects `null` plugin config during startup. The frontend update UI already skips updater checks in non-packaged dev builds, so leaving the base updater plugin config valid does not make this smoke hit the production update endpoint.
+
+Full in-window interaction and rendered-slice assertions remain future work. They require either a supported WebDriver platform, app-side test instrumentation, or a separate automation strategy.
+
+## Running Locally
+
+```bash
+npm run test:real-tauri
+```
+
+The test is macOS-only and uses the same `desktop/scripts/dev-desktop.sh` launcher that developers use. It writes diagnostics to `tests/real-tauri/diagnostics/`.
+
+## Diagnostics Policy
+
+Every run writes:
+
+- `app-stdout.log`
+- `app-stderr.log`
+- `versions.txt`
+- `startup.png` when `screencapture` is available
+- `failure.png` when the test fails and `screencapture` is available
+
+The Playwright project allows one runner-level retry. Do not add retry loops inside the test itself; startup hangs and launch failures should remain visible.
+
+## Stability Policy
+
+The GitHub workflow is nightly-only at first. Do not promote it to per-PR until it has five consecutive green scheduled runs across at least seven calendar days.

--- a/tests/real-tauri/README.md
+++ b/tests/real-tauri/README.md
@@ -24,6 +24,8 @@ npm run test:real-tauri
 
 The test is macOS-only and uses the same `desktop/scripts/dev-desktop.sh` launcher that developers use. It writes diagnostics to `tests/real-tauri/diagnostics/`.
 
+By default the smoke uses port `15320`, not the launcher's normal `1420`, so it does not collide with a manually running dev desktop session. Override that with `DICOM_REAL_TAURI_PORT=<port>` if you need a different isolated port.
+
 ## Diagnostics Policy
 
 Every run writes:
@@ -31,10 +33,10 @@ Every run writes:
 - `app-stdout.log`
 - `app-stderr.log`
 - `versions.txt`
-- `startup.png` when `screencapture` is available
+- `startup.png` after startup is confirmed, when `screencapture` is available
 - `failure.png` when the test fails and `screencapture` is available
 
-The Playwright project allows one runner-level retry. Do not add retry loops inside the test itself; startup hangs and launch failures should remain visible.
+The Playwright project allows one runner-level retry to absorb OS scheduling jitter on macOS runners. Do not add retry loops inside the test itself; startup hangs and launch failures should remain visible.
 
 ## Stability Policy
 

--- a/tests/real-tauri/smoke.spec.js
+++ b/tests/real-tauri/smoke.spec.js
@@ -48,7 +48,7 @@ function recordVersions() {
             `macos=${runVersionCommand('sw_vers', ['-productVersion'])}`,
             `rustc=${runVersionCommand('rustc', ['--version'])}`,
             `cargo=${runVersionCommand('cargo', ['--version'])}`,
-            `tauri=${runVersionCommand('npm', ['run', 'tauri', '--', '--version'], DESKTOP_DIR)}`,
+            `tauri=${runVersionCommand('npx', ['tauri', '--version'], DESKTOP_DIR)}`,
         ].join('\n'),
     );
 }
@@ -71,6 +71,7 @@ function terminateProcessTree(child) {
     try {
         process.kill(-child.pid, 'SIGTERM');
     } catch (_error) {
+        // detached: true makes the child a process-group leader on Unix; fall back if the platform refuses group signaling.
         try {
             child.kill('SIGTERM');
         } catch {}
@@ -136,10 +137,9 @@ test.describe('real Tauri desktop launch smoke', () => {
             appendDiagnostic('app-stderr.log', text);
         });
 
-        captureScreenshot('startup.png');
-
         try {
             const startupOutput = await waitForStartup(child, () => `${stdout}\n${stderr}`);
+            captureScreenshot('startup.png');
             expect(startupOutput).toContain(`[startup] bundle identifier: ${DEV_IDENTIFIER}`);
             expect(startupOutput).toContain(`Application Support/${DEV_IDENTIFIER}`);
 

--- a/tests/real-tauri/smoke.spec.js
+++ b/tests/real-tauri/smoke.spec.js
@@ -1,0 +1,160 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+const { test, expect } = require('@playwright/test');
+const { execFileSync, spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+const DESKTOP_DIR = path.join(ROOT_DIR, 'desktop');
+const DIAGNOSTICS_DIR = process.env.DICOM_REAL_TAURI_DIAGNOSTICS_DIR || path.join(__dirname, 'diagnostics');
+const STARTUP_TIMEOUT_MS = 120_000;
+const DEV_IDENTIFIER = 'health.divergent.dicomviewer.dev';
+const DEV_PORT = process.env.DICOM_REAL_TAURI_PORT || '15320';
+
+function resetDiagnostics() {
+    fs.rmSync(DIAGNOSTICS_DIR, { recursive: true, force: true });
+    fs.mkdirSync(DIAGNOSTICS_DIR, { recursive: true });
+    fs.writeFileSync(path.join(DIAGNOSTICS_DIR, '.gitkeep'), '');
+}
+
+function writeDiagnostic(name, text) {
+    fs.writeFileSync(path.join(DIAGNOSTICS_DIR, name), `${text.replace(/\s+$/u, '')}\n`);
+}
+
+function appendDiagnostic(name, text) {
+    fs.appendFileSync(path.join(DIAGNOSTICS_DIR, name), text);
+}
+
+function runVersionCommand(command, args = [], cwd = ROOT_DIR) {
+    try {
+        return execFileSync(command, args, {
+            cwd,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        }).trim();
+    } catch (error) {
+        return `unavailable: ${error.message}`;
+    }
+}
+
+function recordVersions() {
+    writeDiagnostic(
+        'versions.txt',
+        [
+            `node=${process.version}`,
+            `platform=${process.platform}`,
+            `arch=${process.arch}`,
+            `macos=${runVersionCommand('sw_vers', ['-productVersion'])}`,
+            `rustc=${runVersionCommand('rustc', ['--version'])}`,
+            `cargo=${runVersionCommand('cargo', ['--version'])}`,
+            `tauri=${runVersionCommand('npm', ['run', 'tauri', '--', '--version'], DESKTOP_DIR)}`,
+        ].join('\n'),
+    );
+}
+
+function captureScreenshot(name) {
+    if (process.platform !== 'darwin') return;
+
+    try {
+        execFileSync('screencapture', ['-x', path.join(DIAGNOSTICS_DIR, name)], {
+            stdio: ['ignore', 'ignore', 'ignore'],
+        });
+    } catch (error) {
+        writeDiagnostic(`${name}.txt`, `screencapture unavailable: ${error.message}`);
+    }
+}
+
+function terminateProcessTree(child) {
+    if (!child.pid || child.exitCode !== null) return;
+
+    try {
+        process.kill(-child.pid, 'SIGTERM');
+    } catch (_error) {
+        try {
+            child.kill('SIGTERM');
+        } catch {}
+    }
+}
+
+async function waitForStartup(child, getCombinedOutput) {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < STARTUP_TIMEOUT_MS) {
+        const output = getCombinedOutput();
+        if (
+            output.includes(`[startup] bundle identifier: ${DEV_IDENTIFIER}`) &&
+            output.includes('[startup] app data dir:') &&
+            output.includes(DEV_IDENTIFIER)
+        ) {
+            return output;
+        }
+
+        if (child.exitCode !== null) {
+            throw new Error(`desktop launcher exited early with code ${child.exitCode}\n${output}`);
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+
+    throw new Error(`timed out waiting for desktop startup logs\n${getCombinedOutput()}`);
+}
+
+test.describe('real Tauri desktop launch smoke', () => {
+    test.skip(process.platform !== 'darwin', 'real Tauri smoke currently targets the active macOS desktop surface');
+
+    test('launches the dev desktop binary with isolated app identity and serves sample data', async () => {
+        test.setTimeout(STARTUP_TIMEOUT_MS + 30_000);
+        resetDiagnostics();
+        recordVersions();
+
+        const env = {
+            ...process.env,
+            DICOM_DESKTOP_DEV_HOST: '127.0.0.1',
+            DICOM_DESKTOP_DEV_PORT: DEV_PORT,
+            FORCE_COLOR: '0',
+            NO_COLOR: '1',
+            RUST_BACKTRACE: '1',
+        };
+        const child = spawn('npm', ['run', 'dev:desktop'], {
+            cwd: DESKTOP_DIR,
+            detached: true,
+            env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => {
+            const text = chunk.toString();
+            stdout += text;
+            appendDiagnostic('app-stdout.log', text);
+        });
+        child.stderr.on('data', (chunk) => {
+            const text = chunk.toString();
+            stderr += text;
+            appendDiagnostic('app-stderr.log', text);
+        });
+
+        captureScreenshot('startup.png');
+
+        try {
+            const startupOutput = await waitForStartup(child, () => `${stdout}\n${stderr}`);
+            expect(startupOutput).toContain(`[startup] bundle identifier: ${DEV_IDENTIFIER}`);
+            expect(startupOutput).toContain(`Application Support/${DEV_IDENTIFIER}`);
+
+            const manifestUrl = `http://127.0.0.1:${DEV_PORT}/sample/manifest.json`;
+            const response = await fetch(manifestUrl);
+            expect(response.ok).toBe(true);
+            const manifest = await response.json();
+            expect(Array.isArray(manifest)).toBe(true);
+            expect(manifest.length).toBeGreaterThan(0);
+            expect(manifest[0]).toMatch(/\.dcm$/u);
+        } catch (error) {
+            captureScreenshot('failure.png');
+            throw error;
+        } finally {
+            terminateProcessTree(child);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Adds an opt-in `real-tauri` Playwright project and `npm run test:real-tauri` for a macOS real desktop launch smoke.
- Adds a nightly/manual GitHub Actions workflow that runs the smoke and uploads launch diagnostics.
- Verifies the managed desktop launcher starts the actual Tauri binary with the dev bundle identifier/app data directory and serves bundled sample data.
- Fixes the dev overlay startup panic by removing `plugins.updater: null`; Tauri 2 rejects null plugin config at startup, while updater artifact creation remains disabled for dev builds.

## Notes

This intentionally adapts PR #1 of the larger desktop-test-harness plan. Tauri's desktop WebDriver path does not support macOS WKWebView, so this first fidelity floor is a real Tauri launch smoke rather than an in-window rendered-slice test. Rendered-slice automation remains future work via a supported platform, app-side instrumentation, or another automation strategy.

## Verification

- `npm run format:js:check && npm run lint:js && git diff --check`
- `npm run test:real-tauri`
- `npx playwright test tests/auth-rate-limit-edge-cases.spec.js --reporter=line`
- `npm test -- --reporter=line` (`560 passed, 4 skipped`)
