### PR TITLE
[codex] Add shared desktop Tauri test harness

### DIFF
--- a/docs/decisions/015-shared-desktop-test-harness.md
+++ b/docs/decisions/015-shared-desktop-test-harness.md
@@ -1,0 +1,125 @@
+# ADR 015: Shared Desktop Test Harness
+
+## Status
+
+Implemented
+
+## Context
+
+The desktop Playwright specs have to run browser code that normally expects a
+Tauri desktop shell. Before this ADR, each spec hand-rolled enough of that
+runtime to make its own scenarios pass. That repeated setup covered the same
+basic surfaces in slightly different ways: `window.__TAURI__`, filesystem
+commands, path helpers, SQL loading, secure auth commands, drag/drop stubs, and
+runtime-ready promises.
+
+The duplication created two risks:
+
+- Specs could disagree about what "desktop Tauri" means.
+- A test could pass because its local mock was more forgiving than the real
+  runtime or another spec's mock.
+
+PR 115 added a real-Tauri launch smoke suite as a fidelity floor. That suite is
+intentionally small and slow-running. The regular Playwright desktop specs still
+need a shared browser-side mock so they can be fast while staying consistent.
+
+## Decision
+
+Create a shared desktop runtime harness at
+`tests/helpers/mock-desktop-tauri.js`.
+
+Desktop specs install it with one Node-side helper:
+
+```js
+await installMockDesktopTauri(page, options);
+```
+
+The harness owns desktop plumbing: Tauri globals, runtime-ready promises,
+`core.invoke`, filesystem commands, path commands, SQL plugin loading, secure
+auth commands, webview drag/drop stubs, and event plugin stubs. Specs continue
+to own domain fixtures such as DICOM bytes, scan manifests, report payloads,
+study notes, sync data, and scenario-specific edge cases.
+
+The first migration moves `tests/desktop-report-persistence.spec.js` onto the
+shared harness and adds helper smoke/contract coverage.
+
+## Alternatives Considered
+
+### Keep per-spec mocks
+
+Rejected. Per-spec mocks are easy to tune locally, but they accumulate drift and
+make desktop test failures harder to trust.
+
+### Variant-based helper
+
+Rejected for now. An API such as `installMockTauri({ variant: 'import' })`
+would make early migrations short, but it would bake spec names into the helper
+and encourage a growing switch statement.
+
+### Multiple named installers
+
+Rejected for now. Separate helpers such as `installLibraryTauri` and
+`installImportTauri` would be discoverable, but they would duplicate internal
+setup and make mixed concerns awkward.
+
+### Playwright fixtures
+
+Rejected for this phase. The existing test suite uses imperative setup rather
+than `test.extend`. Keeping the harness imperative minimizes migration churn.
+
+## Design Details
+
+- `installMockDesktopTauri(page, options)` must be called before navigation.
+- Options are grouped by runtime subsystem: `fs`, `invoke`, `sql`, plus
+  top-level runtime identity options such as `appDataDir` and
+  `secureAuthState`.
+- The helper exports `READY_PROMISE_NAMES`, currently
+  `__DICOM_VIEWER_TAURI_STORAGE_READY__` and `__DICOM_VIEWER_TAURI_READY__`.
+- The harness pre-injects both ready promises and resolves them to the
+  installed mock runtime.
+- The SQL mock is reused through `tests/mock-tauri-sql-init.js`; this ADR does
+  not replace the existing SQL helper.
+- Unknown `core.invoke` commands throw with the command name.
+- Missing files follow Tauri-like defaults: `fs.exists` returns `false`, while
+  `fs.readFile` and `fs.stat` throw.
+- Every install creates fresh browser-side state at
+  `window.__mockDesktopTauriState`. The Node module keeps no mutable per-test
+  state.
+- The helper uses JSON-serializable options only. Highly custom behavior should
+  be layered on with `page.evaluate()` after installing the default harness.
+- Contract tests cover loud unknown invokes, missing-file defaults, and ready
+  promise resolution. A normalized real-Tauri golden recorder remains a future
+  hardening step once the launch smoke suite is stable enough to support it.
+
+## Consequences
+
+Positive:
+
+- Desktop specs share one canonical mock for the Tauri shell.
+- Report-persistence tests lose duplicated setup while preserving their
+  negative-path coverage.
+- Future migrations can make smaller diffs by reusing the same runtime surface.
+- Browser-side call tracking is available through
+  `window.__mockDesktopTauriState` without per-spec global arrays.
+
+Tradeoffs:
+
+- The helper becomes a shared dependency for multiple desktop specs, so changes
+  need focused contract tests and careful review.
+- A shared mock can become too permissive if every test-specific quirk is
+  promoted. New options should be added only when they model desktop runtime
+  behavior rather than domain behavior.
+- The current contract tests are intentionally lightweight. They guard the most
+  important defaults, but they do not replace the real-Tauri smoke suite or a
+  future normalized golden recording.
+
+## Extension Rules
+
+- Keep subsystem options grouped. Do not add new flat option flags.
+- Preserve loud defaults. Forgiving behavior must be opt-in.
+- Promote behavior into the harness only when it appears in at least three
+  specs or represents a shared Tauri contract.
+- Keep domain fixtures in specs.
+- When migrating a spec, its focused Playwright test count must remain the same
+  and all negative-path assertions must still run.
+

--- a/tests/desktop-report-persistence.spec.js
+++ b/tests/desktop-report-persistence.spec.js
@@ -1,159 +1,16 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
-const path = require('node:path');
 const { test, expect } = require('@playwright/test');
+const { installMockDesktopTauri } = require('./helpers/mock-desktop-tauri');
 
 const HOME_URL = 'http://127.0.0.1:5001/?nolib';
-const MOCK_SQL_INIT_PATH = path.join(__dirname, 'mock-tauri-sql-init.js');
-
-async function installMockTauri(page, options = {}) {
-    await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
-    await page.addInitScript((options) => {
-        const FILE_STORAGE_PREFIX = 'mock-tauri-fs:';
-        const SECURE_AUTH_STORAGE_KEY = 'mock-tauri-secure-auth-state';
-        const failRemoveAll = !!options.failRemoveAll;
-        const failWritePatterns = Array.isArray(options.failWritePatterns) ? options.failWritePatterns : [];
-        const selectDelayMs = Number.isFinite(Number(options.selectDelayMs)) ? Number(options.selectDelayMs) : 0;
-        const selectDelayPatterns = Array.isArray(options.selectDelayPatterns)
-            ? options.selectDelayPatterns.map((pattern) => String(pattern).toLowerCase())
-            : [];
-        const sqlPlugin = window.__createMockTauriSql(options);
-
-        if (selectDelayMs > 0) {
-            const originalLoad = sqlPlugin.load.bind(sqlPlugin);
-            sqlPlugin.load = async (db) => {
-                const connection = await originalLoad(db);
-                const originalSelect = connection.select.bind(connection);
-                connection.select = async (query, values) => {
-                    const normalizedQuery = String(query || '').toLowerCase();
-                    const shouldDelay =
-                        !selectDelayPatterns.length ||
-                        selectDelayPatterns.some((pattern) => normalizedQuery.includes(pattern));
-
-                    if (shouldDelay) {
-                        await new Promise((resolve) => setTimeout(resolve, selectDelayMs));
-                    }
-
-                    return originalSelect(query, values);
-                };
-                return connection;
-            };
-        }
-
-        if (options.initialSecureAuthState) {
-            localStorage.setItem(SECURE_AUTH_STORAGE_KEY, JSON.stringify(options.initialSecureAuthState));
-        }
-
-        function joinPaths(...parts) {
-            const cleaned = parts
-                .filter((part) => part !== null && part !== undefined && part !== '')
-                .map((part, index) => {
-                    const text = String(part);
-                    if (index === 0) {
-                        return text.replace(/\/+$/g, '') || '/';
-                    }
-                    return text.replace(/^\/+/g, '').replace(/\/+$/g, '');
-                })
-                .filter(Boolean);
-
-            if (!cleaned.length) return '';
-            const joined = cleaned.join('/');
-            return joined.startsWith('/') ? joined : `/${joined}`;
-        }
-
-        window.__TAURI__ = {
-            core: {
-                convertFileSrc(filePath) {
-                    return `asset://local/${encodeURIComponent(filePath)}`;
-                },
-                async invoke(cmd, args) {
-                    if (cmd === 'apply_desktop_migration') {
-                        return window.__applyMockDesktopMigration(args.db, args.batch, options);
-                    }
-                    if (cmd === 'load_legacy_desktop_browser_stores') {
-                        return options.legacyDesktopStores || [];
-                    }
-                    if (cmd === 'load_secure_auth_state') {
-                        const raw = localStorage.getItem(SECURE_AUTH_STORAGE_KEY);
-                        return raw
-                            ? JSON.parse(raw)
-                            : {
-                                  access_token: null,
-                                  refresh_token: null,
-                                  user_email: null,
-                                  user_name: null,
-                              };
-                    }
-                    if (cmd === 'store_secure_auth_state') {
-                        localStorage.setItem(SECURE_AUTH_STORAGE_KEY, JSON.stringify(args.state || {}));
-                        return true;
-                    }
-                    if (cmd === 'clear_secure_auth_state') {
-                        localStorage.removeItem(SECURE_AUTH_STORAGE_KEY);
-                        return true;
-                    }
-                    throw new Error(`Unhandled core invoke: ${cmd}`);
-                },
-            },
-            fs: {
-                async exists(filePath) {
-                    return localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`) !== null;
-                },
-                async mkdir() {
-                    return undefined;
-                },
-                async remove(filePath) {
-                    if (failRemoveAll) {
-                        throw new Error(`Mock remove failure for ${filePath}`);
-                    }
-                    localStorage.removeItem(`${FILE_STORAGE_PREFIX}${filePath}`);
-                },
-                async rename(fromPath, toPath) {
-                    const raw = localStorage.getItem(`${FILE_STORAGE_PREFIX}${fromPath}`);
-                    if (raw === null) {
-                        throw new Error(`Mock rename missing source ${fromPath}`);
-                    }
-                    localStorage.setItem(`${FILE_STORAGE_PREFIX}${toPath}`, raw);
-                    localStorage.removeItem(`${FILE_STORAGE_PREFIX}${fromPath}`);
-                },
-                async writeFile(filePath, bytes) {
-                    if (failWritePatterns.some((pattern) => String(filePath).includes(String(pattern)))) {
-                        throw new Error(`Mock write failure for ${filePath}`);
-                    }
-                    localStorage.setItem(`${FILE_STORAGE_PREFIX}${filePath}`, JSON.stringify(Array.from(bytes)));
-                },
-            },
-            path: {
-                async appDataDir() {
-                    return '/mock/appdata';
-                },
-                async join(...parts) {
-                    return joinPaths(...parts);
-                },
-                async normalize(path) {
-                    return joinPaths(path);
-                },
-            },
-            sql: sqlPlugin,
-            webview: {
-                getCurrentWebview() {
-                    return {
-                        onDragDropEvent() {
-                            return Promise.resolve(() => {});
-                        },
-                    };
-                },
-            },
-        };
-    }, options);
-}
 
 test.describe('Desktop report persistence', () => {
     test('desktop comment writes use canonical UUID ids for update and delete', async ({ page }) => {
         const studyUid = '1.2.840.desktop.comment-uuid.study';
         const seriesUid = '1.2.840.desktop.comment-uuid.series';
 
-        await installMockTauri(page);
+        await installMockDesktopTauri(page);
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
 
@@ -207,7 +64,7 @@ test.describe('Desktop report persistence', () => {
         const studyUid = '1.2.840.desktop.manual-migrate.study';
         const seriesUid = '1.2.840.desktop.manual-migrate.series';
 
-        await installMockTauri(page);
+        await installMockDesktopTauri(page);
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
 
@@ -268,7 +125,7 @@ test.describe('Desktop report persistence', () => {
             lastScan: '2026-03-21T18:00:00.000Z',
         };
 
-        await installMockTauri(page);
+        await installMockDesktopTauri(page);
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
 
@@ -381,46 +238,51 @@ test.describe('Desktop report persistence', () => {
             lastScan: '2026-03-20T14:51:37.855Z',
         };
 
-        await installMockTauri(page, {
-            initialState: {
-                'sqlite:viewer.db': {
-                    study_notes: [],
-                    series_notes: [],
-                    comments: [],
-                    reports: [],
-                    app_config: [
-                        { key: 'desktop_library_config', value: JSON.stringify(libraryConfig), updated_at: 1 },
-                        { key: 'localstorage_migrated', value: '1', updated_at: 1 },
-                    ],
-                    meta: { lastCommentId: 0 },
+        await installMockDesktopTauri(page, {
+            sql: {
+                initialState: {
+                    'sqlite:viewer.db': {
+                        study_notes: [],
+                        series_notes: [],
+                        comments: [],
+                        reports: [],
+                        app_config: [
+                            { key: 'desktop_library_config', value: JSON.stringify(libraryConfig), updated_at: 1 },
+                            { key: 'localstorage_migrated', value: '1', updated_at: 1 },
+                        ],
+                        meta: { lastCommentId: 0 },
+                    },
                 },
             },
-            legacyDesktopStores: [
-                {
-                    sourcePath: '/Users/gabriel/Library/WebKit/health.divergent.dicomviewer/.../localstorage.sqlite3',
-                    notesJson: JSON.stringify({
-                        studies: {
-                            [studyUid]: {
-                                description: '',
-                                comments: [],
-                                series: {},
-                                reports: [
-                                    {
-                                        id: reportId,
-                                        name: 'Migrated report.pdf',
-                                        type: 'pdf',
-                                        size: 123,
-                                        filePath: reportPath,
-                                        addedAt: 303,
-                                        updatedAt: 404,
-                                    },
-                                ],
+            invoke: {
+                legacyDesktopStores: [
+                    {
+                        sourcePath:
+                            '/Users/gabriel/Library/WebKit/health.divergent.dicomviewer/.../localstorage.sqlite3',
+                        notesJson: JSON.stringify({
+                            studies: {
+                                [studyUid]: {
+                                    description: '',
+                                    comments: [],
+                                    series: {},
+                                    reports: [
+                                        {
+                                            id: reportId,
+                                            name: 'Migrated report.pdf',
+                                            type: 'pdf',
+                                            size: 123,
+                                            filePath: reportPath,
+                                            addedAt: 303,
+                                            updatedAt: 404,
+                                        },
+                                    ],
+                                },
                             },
-                        },
-                    }),
-                    libraryConfigJson: JSON.stringify(libraryConfig),
-                },
-            ],
+                        }),
+                        libraryConfigJson: JSON.stringify(libraryConfig),
+                    },
+                ],
+            },
         });
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
@@ -461,8 +323,10 @@ test.describe('Desktop report persistence', () => {
         const failedReportId = 'desktop-legacy-report-fail';
         const goodReportId = 'desktop-legacy-report-good';
 
-        await installMockTauri(page, {
-            failWritePatterns: [failedReportId],
+        await installMockDesktopTauri(page, {
+            fs: {
+                failWritePatterns: [failedReportId],
+            },
         });
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
@@ -536,21 +400,23 @@ test.describe('Desktop report persistence', () => {
             lastScan: '2026-03-22T10:00:00.000Z',
         };
 
-        await installMockTauri(page, {
-            legacyDesktopStores: [
-                {
-                    sourcePath: '/Users/gabriel/Library/WebKit/zzz/localstorage.sqlite3',
-                    modifiedMs: 10,
-                    notesJson: JSON.stringify({ studies: {} }),
-                    libraryConfigJson: JSON.stringify(olderConfig),
-                },
-                {
-                    sourcePath: '/Users/gabriel/Library/WebKit/aaa/localstorage.sqlite3',
-                    modifiedMs: 20,
-                    notesJson: JSON.stringify({ studies: {} }),
-                    libraryConfigJson: JSON.stringify(newerConfig),
-                },
-            ],
+        await installMockDesktopTauri(page, {
+            invoke: {
+                legacyDesktopStores: [
+                    {
+                        sourcePath: '/Users/gabriel/Library/WebKit/zzz/localstorage.sqlite3',
+                        modifiedMs: 10,
+                        notesJson: JSON.stringify({ studies: {} }),
+                        libraryConfigJson: JSON.stringify(olderConfig),
+                    },
+                    {
+                        sourcePath: '/Users/gabriel/Library/WebKit/aaa/localstorage.sqlite3',
+                        modifiedMs: 20,
+                        notesJson: JSON.stringify({ studies: {} }),
+                        libraryConfigJson: JSON.stringify(newerConfig),
+                    },
+                ],
+            },
         });
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
@@ -564,8 +430,10 @@ test.describe('Desktop report persistence', () => {
     });
 
     test('desktop sqlite init backs off repeated failures before retrying', async ({ page }) => {
-        await installMockTauri(page, {
-            sqlLoadError: 'mock desktop sqlite unavailable',
+        await installMockDesktopTauri(page, {
+            sql: {
+                loadError: 'mock desktop sqlite unavailable',
+            },
         });
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
@@ -604,7 +472,7 @@ test.describe('Desktop report persistence', () => {
     test('desktop auth store migrates legacy browser tokens into secure storage and clears localStorage', async ({
         page,
     }) => {
-        await installMockTauri(page);
+        await installMockDesktopTauri(page);
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
 
@@ -668,7 +536,7 @@ test.describe('Desktop report persistence', () => {
     test('desktop sync state and outbox persist via sqlite across reload without legacy localStorage', async ({
         page,
     }) => {
-        await installMockTauri(page);
+        await installMockDesktopTauri(page);
         await page.addInitScript(() => {
             if (sessionStorage.getItem('desktop-sync-migration-seeded') === '1') {
                 return;
@@ -804,33 +672,35 @@ test.describe('Desktop report persistence', () => {
     });
 
     test('desktop hydration merges pre-hydration sync writes instead of clobbering them', async ({ page }) => {
-        await installMockTauri(page, {
-            selectDelayMs: 150,
-            selectDelayPatterns: ['sync_state', 'sync_outbox'],
-            initialState: {
-                'sqlite:viewer.db': {
-                    sync_state: [
-                        { key: 'delta_cursor', value: 'legacy-cursor', updated_at: 1000 },
-                        { key: 'device_id', value: 'legacy-device', updated_at: 1001 },
-                    ],
-                    sync_outbox: [
-                        {
-                            id: 1,
-                            operation_uuid: 'legacy-op-1',
-                            table_name: 'comments',
-                            record_key: 'legacy-comment-1',
-                            operation: 'insert',
-                            base_sync_version: 0,
-                            created_at: 1000,
-                            synced_at: null,
-                            attempts: 0,
-                            last_error: null,
+        await installMockDesktopTauri(page, {
+            sql: {
+                selectDelayMs: 150,
+                selectDelayPatterns: ['sync_state', 'sync_outbox'],
+                initialState: {
+                    'sqlite:viewer.db': {
+                        sync_state: [
+                            { key: 'delta_cursor', value: 'legacy-cursor', updated_at: 1000 },
+                            { key: 'device_id', value: 'legacy-device', updated_at: 1001 },
+                        ],
+                        sync_outbox: [
+                            {
+                                id: 1,
+                                operation_uuid: 'legacy-op-1',
+                                table_name: 'comments',
+                                record_key: 'legacy-comment-1',
+                                operation: 'insert',
+                                base_sync_version: 0,
+                                created_at: 1000,
+                                synced_at: null,
+                                attempts: 0,
+                                last_error: null,
+                            },
+                        ],
+                        meta: {
+                            lastCommentId: 0,
+                            lastOutboxId: 1,
+                            loadCalls: 0,
                         },
-                    ],
-                    meta: {
-                        lastCommentId: 0,
-                        lastOutboxId: 1,
-                        loadCalls: 0,
                     },
                 },
             },
@@ -876,7 +746,7 @@ test.describe('Desktop report persistence', () => {
         const studyUid = '1.2.840.desktop.test.study';
         const reportId = 'desktop-report-001';
 
-        await installMockTauri(page);
+        await installMockDesktopTauri(page);
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
 
@@ -970,7 +840,7 @@ test.describe('Desktop report persistence', () => {
         const secondStudyUid = '1.2.840.desktop.cross.study.b';
         const reportId = 'desktop-cross-study-report';
 
-        await installMockTauri(page);
+        await installMockDesktopTauri(page);
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
 
@@ -1033,7 +903,7 @@ test.describe('Desktop report persistence', () => {
         const studyUid = '1.2.840.desktop.test.study';
         const reportId = 'desktop-report-delete-failure';
 
-        await installMockTauri(page, { failRemoveAll: true });
+        await installMockDesktopTauri(page, { fs: { failRemoveAll: true } });
         await page.goto(HOME_URL);
         await expect(page.locator('#libraryView')).toBeVisible();
 

--- a/tests/helpers/mock-desktop-tauri.README.md
+++ b/tests/helpers/mock-desktop-tauri.README.md
@@ -81,7 +81,8 @@ Options are grouped by runtime subsystem:
 - `invoke.legacyDesktopStores`: returned by
   `load_legacy_desktop_browser_stores`.
 - `sql.initialState`: initial mock SQLite state.
-- `sql.loadError` / `sql.sqlLoadError`: make SQL load fail.
+- `sql.loadError`: make SQL load fail. Prefer this spelling in new tests.
+- `sql.sqlLoadError`: migration alias for older mock-SQL option naming.
 - `sql.selectDelayMs`: delay matching `select` calls.
 - `sql.selectDelayPatterns`: lower-case query substrings that receive the
   delay.
@@ -123,4 +124,3 @@ Start with per-spec setup when a behavior is unique. Promote it into the
 harness only when it models desktop runtime behavior and appears in at least
 three specs, or when keeping it local would make tests disagree about the same
 Tauri contract.
-

--- a/tests/helpers/mock-desktop-tauri.README.md
+++ b/tests/helpers/mock-desktop-tauri.README.md
@@ -1,0 +1,126 @@
+# Mock Desktop Tauri Harness
+
+`mock-desktop-tauri.js` installs the shared Playwright test double for the
+desktop shell. It models the browser-visible Tauri runtime so desktop specs can
+focus on application scenarios instead of rebuilding `window.__TAURI__`,
+runtime-ready promises, filesystem behavior, SQL loading, and secure auth
+commands in every file.
+
+## Boundary
+
+The harness owns desktop plumbing:
+
+- `window.__TAURI__`
+- runtime-ready promises
+- `core.invoke`
+- `core.convertFileSrc`
+- filesystem commands
+- path commands
+- the SQL plugin bridge via `mock-tauri-sql-init.js`
+- secure auth commands
+- webview drag/drop stubs
+- event plugin stubs
+
+Specs still own domain fixtures:
+
+- synthetic DICOM bytes
+- DICOMDIR records
+- scan manifests
+- report payloads
+- study, series, slice, note, and sync scenarios
+- import-specific edge cases
+- decode behavior
+
+Keep the harness boring. If an option describes radiology behavior instead of
+desktop runtime behavior, it belongs in the spec.
+
+## Usage
+
+Install the harness before navigation:
+
+```js
+const { installMockDesktopTauri } = require('./helpers/mock-desktop-tauri');
+
+await installMockDesktopTauri(page, {
+    appDataDir: '/mock/appdata',
+    fs: {
+        files: {
+            '/mock/appdata/reports/example.pdf': [37, 80, 68, 70],
+        },
+    },
+    sql: {
+        initialState: {
+            'sqlite:viewer.db': {
+                reports: [],
+            },
+        },
+    },
+});
+
+await page.goto(HOME_URL);
+```
+
+`installMockDesktopTauri()` uses serializable options because Playwright
+`addInitScript` options cross the Node-to-browser boundary. For unusual cases,
+install the default harness first, then patch the runtime in `page.evaluate()`
+inside the test.
+
+## Options
+
+Options are grouped by runtime subsystem:
+
+- `appDataDir`: returned by `window.__TAURI__.path.appDataDir()`.
+- `secureAuthState`: initial secure auth state returned by
+  `load_secure_auth_state`.
+- `fs.files`: seeded filesystem bytes keyed by path.
+- `fs.directories`: seeded directories.
+- `fs.readDirEntries`: path-to-entry arrays returned by `readDir`.
+- `fs.failWritePatterns`: substrings that make `writeFile` throw.
+- `fs.failRemovePatterns`: substrings that make `remove` throw.
+- `fs.failRemoveAll`: makes all `remove` calls throw.
+- `invoke.legacyDesktopStores`: returned by
+  `load_legacy_desktop_browser_stores`.
+- `sql.initialState`: initial mock SQLite state.
+- `sql.loadError` / `sql.sqlLoadError`: make SQL load fail.
+- `sql.selectDelayMs`: delay matching `select` calls.
+- `sql.selectDelayPatterns`: lower-case query substrings that receive the
+  delay.
+
+Do not add flat top-level options for new behavior. Keep subsystem options under
+`fs`, `invoke`, `sql`, or another explicit runtime domain.
+
+## Loud Defaults
+
+The default mock should be at least as strict as the real desktop runtime:
+
+- Unknown `core.invoke` commands throw with the command name.
+- `fs.exists` returns `false` for missing paths.
+- `fs.readFile` and `fs.stat` throw for missing paths.
+- Forgiving behavior must be opt-in through a named option.
+
+When migrating a spec, keep negative-path assertions intact. A shared mock that
+silently accepts everything makes tests easier to port but less useful.
+
+## State Isolation
+
+The helper keeps no mutable Node-side module state. Each browser install creates
+a fresh `window.__mockDesktopTauriState` with:
+
+- `reads`
+- `writes`
+- `invokeCalls`
+- `mkdirCalls`
+- `removeCalls`
+- `renameCalls`
+- `secureAuthState`
+
+Use that browser-side state for assertions instead of adding global arrays in
+the Node test file.
+
+## Promotion Rule
+
+Start with per-spec setup when a behavior is unique. Promote it into the
+harness only when it models desktop runtime behavior and appears in at least
+three specs, or when keeping it local would make tests disagree about the same
+Tauri contract.
+

--- a/tests/helpers/mock-desktop-tauri.contracts.spec.js
+++ b/tests/helpers/mock-desktop-tauri.contracts.spec.js
@@ -1,22 +1,12 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 const { test, expect } = require('@playwright/test');
-const { READY_PROMISE_NAMES, installMockDesktopTauri } = require('./mock-desktop-tauri');
-
-async function gotoMockPage(page) {
-    await page.route('http://mock.local/blank', async (route) => {
-        await route.fulfill({
-            contentType: 'text/html',
-            body: '<html><body>mock</body></html>',
-        });
-    });
-    await page.goto('http://mock.local/blank');
-}
+const { READY_PROMISE_NAMES, gotoMockDesktopPage, installMockDesktopTauri } = require('./mock-desktop-tauri');
 
 test.describe('mock desktop Tauri contract', () => {
     test('unknown invoke commands fail loudly with the command name', async ({ page }) => {
         await installMockDesktopTauri(page);
-        await gotoMockPage(page);
+        await gotoMockDesktopPage(page);
 
         const message = await page.evaluate(async () => {
             try {
@@ -32,34 +22,61 @@ test.describe('mock desktop Tauri contract', () => {
 
     test('filesystem defaults match non-forgiving Tauri-like behavior', async ({ page }) => {
         await installMockDesktopTauri(page);
-        await gotoMockPage(page);
+        await gotoMockDesktopPage(page);
 
         const result = await page.evaluate(async () => {
             const missingPath = '/mock/appdata/missing.pdf';
             const exists = await window.__TAURI__.fs.exists(missingPath);
             let readError = null;
+            let readIsError = null;
             let statError = null;
+            let statIsError = null;
             try {
                 await window.__TAURI__.fs.readFile(missingPath);
             } catch (error) {
                 readError = String(error?.message || error);
+                readIsError = error instanceof Error;
             }
             try {
                 await window.__TAURI__.fs.stat(missingPath);
             } catch (error) {
                 statError = String(error?.message || error);
+                statIsError = error instanceof Error;
             }
-            return { exists, readError, statError };
+            return { exists, readError, readIsError, statError, statIsError };
         });
 
         expect(result.exists).toBe(false);
         expect(result.readError).toContain('No such file or directory');
+        expect(result.readIsError).toBe(true);
         expect(result.statError).toContain('No such file or directory');
+        expect(result.statIsError).toBe(true);
+    });
+
+    test('mkdir accepts and records Tauri options', async ({ page }) => {
+        await installMockDesktopTauri(page);
+        await gotoMockDesktopPage(page);
+
+        const result = await page.evaluate(async () => {
+            await window.__TAURI__.fs.mkdir('/mock/appdata/reports/study-1', { recursive: true });
+            return {
+                exists: await window.__TAURI__.fs.exists('/mock/appdata/reports/study-1'),
+                mkdirCalls: window.__mockDesktopTauriState.mkdirCalls,
+            };
+        });
+
+        expect(result.exists).toBe(true);
+        expect(result.mkdirCalls).toEqual([
+            {
+                dirPath: '/mock/appdata/reports/study-1',
+                options: { recursive: true },
+            },
+        ]);
     });
 
     test('ready promises resolve to the installed runtime', async ({ page }) => {
         await installMockDesktopTauri(page);
-        await gotoMockPage(page);
+        await gotoMockDesktopPage(page);
 
         const result = await page.evaluate(async (readyPromiseNames) => {
             const runtimes = await Promise.all(readyPromiseNames.map((name) => window[name]));

--- a/tests/helpers/mock-desktop-tauri.contracts.spec.js
+++ b/tests/helpers/mock-desktop-tauri.contracts.spec.js
@@ -1,0 +1,79 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+const { test, expect } = require('@playwright/test');
+const { READY_PROMISE_NAMES, installMockDesktopTauri } = require('./mock-desktop-tauri');
+
+async function gotoMockPage(page) {
+    await page.route('http://mock.local/blank', async (route) => {
+        await route.fulfill({
+            contentType: 'text/html',
+            body: '<html><body>mock</body></html>',
+        });
+    });
+    await page.goto('http://mock.local/blank');
+}
+
+test.describe('mock desktop Tauri contract', () => {
+    test('unknown invoke commands fail loudly with the command name', async ({ page }) => {
+        await installMockDesktopTauri(page);
+        await gotoMockPage(page);
+
+        const message = await page.evaluate(async () => {
+            try {
+                await window.__TAURI__.core.invoke('unknown_desktop_command', { example: true });
+                return null;
+            } catch (error) {
+                return String(error?.message || error);
+            }
+        });
+
+        expect(message).toContain('unknown_desktop_command');
+    });
+
+    test('filesystem defaults match non-forgiving Tauri-like behavior', async ({ page }) => {
+        await installMockDesktopTauri(page);
+        await gotoMockPage(page);
+
+        const result = await page.evaluate(async () => {
+            const missingPath = '/mock/appdata/missing.pdf';
+            const exists = await window.__TAURI__.fs.exists(missingPath);
+            let readError = null;
+            let statError = null;
+            try {
+                await window.__TAURI__.fs.readFile(missingPath);
+            } catch (error) {
+                readError = String(error?.message || error);
+            }
+            try {
+                await window.__TAURI__.fs.stat(missingPath);
+            } catch (error) {
+                statError = String(error?.message || error);
+            }
+            return { exists, readError, statError };
+        });
+
+        expect(result.exists).toBe(false);
+        expect(result.readError).toContain('No such file or directory');
+        expect(result.statError).toContain('No such file or directory');
+    });
+
+    test('ready promises resolve to the installed runtime', async ({ page }) => {
+        await installMockDesktopTauri(page);
+        await gotoMockPage(page);
+
+        const result = await page.evaluate(async (readyPromiseNames) => {
+            const runtimes = await Promise.all(readyPromiseNames.map((name) => window[name]));
+            return runtimes.map((runtime) => ({
+                hasInvoke: typeof runtime?.core?.invoke === 'function',
+                hasSql: typeof runtime?.sql?.load === 'function',
+            }));
+        }, READY_PROMISE_NAMES);
+
+        expect(result).toEqual(
+            READY_PROMISE_NAMES.map(() => ({
+                hasInvoke: true,
+                hasSql: true,
+            })),
+        );
+    });
+});

--- a/tests/helpers/mock-desktop-tauri.js
+++ b/tests/helpers/mock-desktop-tauri.js
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Divergent Health Technologies
+//
+// Shared Node-side installer for the browser-side mock Tauri desktop runtime.
+// The harness owns desktop plumbing; specs still own domain fixtures.
+const path = require('node:path');
+
+const MOCK_SQL_INIT_PATH = path.join(__dirname, '..', 'mock-tauri-sql-init.js');
+
+const READY_PROMISE_NAMES = Object.freeze(['__DICOM_VIEWER_TAURI_STORAGE_READY__', '__DICOM_VIEWER_TAURI_READY__']);
+
+async function installMockDesktopTauri(page, options = {}) {
+    await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
+    await page.addInitScript(
+        ({ options, readyPromiseNames }) => {
+            const FILE_STORAGE_PREFIX = 'mock-tauri-fs:';
+            const SECURE_AUTH_STORAGE_KEY = 'mock-tauri-secure-auth-state';
+            const SECURE_AUTH_SEEDED_KEY = 'mock-tauri-secure-auth-state-seeded';
+            const fsOptions = options.fs || {};
+            const invokeOptions = options.invoke || {};
+            const sqlOptions = options.sql || {};
+            const appDataDir = options.appDataDir || '/mock/appdata';
+            const failRemoveAll = !!fsOptions.failRemoveAll;
+            const failWritePatterns = Array.isArray(fsOptions.failWritePatterns) ? fsOptions.failWritePatterns : [];
+            const failRemovePatterns = Array.isArray(fsOptions.failRemovePatterns) ? fsOptions.failRemovePatterns : [];
+            const readDirEntries =
+                fsOptions.readDirEntries && typeof fsOptions.readDirEntries === 'object'
+                    ? fsOptions.readDirEntries
+                    : {};
+            const seedFiles = fsOptions.files && typeof fsOptions.files === 'object' ? fsOptions.files : {};
+            const seedDirectories = Array.isArray(fsOptions.directories) ? fsOptions.directories : [];
+            const selectDelayMs = Number.isFinite(Number(sqlOptions.selectDelayMs))
+                ? Number(sqlOptions.selectDelayMs)
+                : 0;
+            const selectDelayPatterns = Array.isArray(sqlOptions.selectDelayPatterns)
+                ? sqlOptions.selectDelayPatterns.map((pattern) => String(pattern).toLowerCase())
+                : [];
+            const tauriSqlOptions = {
+                initialState: sqlOptions.initialState || {},
+                sqlLoadError: sqlOptions.loadError || sqlOptions.sqlLoadError || null,
+            };
+
+            function joinPaths(...parts) {
+                const cleaned = parts
+                    .filter((part) => part !== null && part !== undefined && part !== '')
+                    .map((part, index) => {
+                        const text = String(part).replace(/\\/g, '/');
+                        if (index === 0) {
+                            return text.replace(/\/+$/g, '') || '/';
+                        }
+                        return text.replace(/^\/+/g, '').replace(/\/+$/g, '');
+                    })
+                    .filter(Boolean);
+
+                if (!cleaned.length) return '';
+                const joined = cleaned.join('/').replace(/\/+/g, '/');
+                return joined.startsWith('/') ? joined : `/${joined}`;
+            }
+
+            function makeMissingFileError(filePath) {
+                return `No such file or directory: ${filePath}`;
+            }
+
+            function serializeBytes(bytes) {
+                if (typeof bytes === 'string') {
+                    return JSON.stringify(Array.from(new TextEncoder().encode(bytes)));
+                }
+                return JSON.stringify(Array.from(bytes || []));
+            }
+
+            function seedFile(filePath, bytes) {
+                localStorage.setItem(`${FILE_STORAGE_PREFIX}${filePath}`, serializeBytes(bytes));
+            }
+
+            window.__mockDesktopTauriState = {
+                files: seedFiles,
+                reads: [],
+                writes: [],
+                invokeCalls: [],
+                mkdirCalls: [],
+                removeCalls: [],
+                renameCalls: [],
+                secureAuthState: options.secureAuthState || null,
+            };
+
+            window.__mockDesktopTauriDirectories = new Set(seedDirectories.map((dir) => joinPaths(dir)));
+            for (const [filePath, bytes] of Object.entries(seedFiles)) {
+                seedFile(filePath, bytes);
+            }
+
+            if (options.secureAuthState && sessionStorage.getItem(SECURE_AUTH_SEEDED_KEY) !== '1') {
+                localStorage.setItem(SECURE_AUTH_STORAGE_KEY, JSON.stringify(options.secureAuthState));
+                sessionStorage.setItem(SECURE_AUTH_SEEDED_KEY, '1');
+            }
+
+            const sqlPlugin = window.__createMockTauriSql(tauriSqlOptions);
+            if (selectDelayMs > 0) {
+                const originalLoad = sqlPlugin.load.bind(sqlPlugin);
+                sqlPlugin.load = async (db) => {
+                    const connection = await originalLoad(db);
+                    const originalSelect = connection.select.bind(connection);
+                    connection.select = async (query, values) => {
+                        const normalizedQuery = String(query || '').toLowerCase();
+                        const shouldDelay =
+                            !selectDelayPatterns.length ||
+                            selectDelayPatterns.some((pattern) => normalizedQuery.includes(pattern));
+
+                        if (shouldDelay) {
+                            await new Promise((resolve) => setTimeout(resolve, selectDelayMs));
+                        }
+
+                        return originalSelect(query, values);
+                    };
+                    return connection;
+                };
+            }
+
+            window.__TAURI__ = {
+                core: {
+                    convertFileSrc(filePath) {
+                        return `asset://local/${encodeURIComponent(filePath)}`;
+                    },
+                    async invoke(cmd, args = {}) {
+                        window.__mockDesktopTauriState.invokeCalls.push({ cmd, args });
+                        if (cmd === 'apply_desktop_migration') {
+                            return window.__applyMockDesktopMigration(args.db, args.batch, tauriSqlOptions);
+                        }
+                        if (cmd === 'load_legacy_desktop_browser_stores') {
+                            return invokeOptions.legacyDesktopStores || [];
+                        }
+                        if (cmd === 'load_secure_auth_state') {
+                            const raw = localStorage.getItem(SECURE_AUTH_STORAGE_KEY);
+                            return raw
+                                ? JSON.parse(raw)
+                                : {
+                                      access_token: null,
+                                      refresh_token: null,
+                                      user_email: null,
+                                      user_name: null,
+                                  };
+                        }
+                        if (cmd === 'store_secure_auth_state') {
+                            const nextState = args.state || {};
+                            localStorage.setItem(SECURE_AUTH_STORAGE_KEY, JSON.stringify(nextState));
+                            window.__mockDesktopTauriState.secureAuthState = nextState;
+                            return true;
+                        }
+                        if (cmd === 'clear_secure_auth_state') {
+                            localStorage.removeItem(SECURE_AUTH_STORAGE_KEY);
+                            window.__mockDesktopTauriState.secureAuthState = null;
+                            return true;
+                        }
+                        throw new Error(`Unhandled core invoke: ${cmd}`);
+                    },
+                },
+                fs: {
+                    async exists(filePath) {
+                        return (
+                            localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`) !== null ||
+                            window.__mockDesktopTauriDirectories.has(joinPaths(filePath)) ||
+                            Object.hasOwn(readDirEntries, filePath)
+                        );
+                    },
+                    async readFile(filePath) {
+                        window.__mockDesktopTauriState.reads.push(filePath);
+                        const raw = localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`);
+                        if (raw === null) {
+                            throw makeMissingFileError(filePath);
+                        }
+                        return Uint8Array.from(JSON.parse(raw));
+                    },
+                    async readDir(dirPath) {
+                        return readDirEntries[dirPath] || [];
+                    },
+                    async stat(filePath) {
+                        const isFile = localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`) !== null;
+                        const isDirectory =
+                            window.__mockDesktopTauriDirectories.has(joinPaths(filePath)) ||
+                            Object.hasOwn(readDirEntries, filePath);
+                        if (!isFile && !isDirectory) {
+                            throw makeMissingFileError(filePath);
+                        }
+                        return {
+                            isFile,
+                            isDirectory,
+                            isSymlink: false,
+                            size: isFile
+                                ? JSON.parse(localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`)).length
+                                : 0,
+                            mtime: null,
+                            atime: null,
+                            birthtime: null,
+                            readonly: false,
+                            fileAttributes: null,
+                            dev: null,
+                            ino: null,
+                            mode: null,
+                            nlink: null,
+                            uid: null,
+                            gid: null,
+                            rdev: null,
+                            blksize: null,
+                            blocks: null,
+                        };
+                    },
+                    async mkdir(dirPath) {
+                        const normalized = joinPaths(dirPath);
+                        window.__mockDesktopTauriState.mkdirCalls.push(normalized);
+                        window.__mockDesktopTauriDirectories.add(normalized);
+                        return undefined;
+                    },
+                    async remove(filePath) {
+                        window.__mockDesktopTauriState.removeCalls.push(filePath);
+                        if (
+                            failRemoveAll ||
+                            failRemovePatterns.some((pattern) => String(filePath).includes(String(pattern)))
+                        ) {
+                            throw new Error(`Mock remove failure for ${filePath}`);
+                        }
+                        localStorage.removeItem(`${FILE_STORAGE_PREFIX}${filePath}`);
+                    },
+                    async rename(fromPath, toPath) {
+                        window.__mockDesktopTauriState.renameCalls.push({ fromPath, toPath });
+                        const raw = localStorage.getItem(`${FILE_STORAGE_PREFIX}${fromPath}`);
+                        if (raw === null) {
+                            throw makeMissingFileError(fromPath);
+                        }
+                        localStorage.setItem(`${FILE_STORAGE_PREFIX}${toPath}`, raw);
+                        localStorage.removeItem(`${FILE_STORAGE_PREFIX}${fromPath}`);
+                    },
+                    async writeFile(filePath, bytes) {
+                        window.__mockDesktopTauriState.writes.push({ filePath, byteLength: bytes?.length || 0 });
+                        if (failWritePatterns.some((pattern) => String(filePath).includes(String(pattern)))) {
+                            throw new Error(`Mock write failure for ${filePath}`);
+                        }
+                        localStorage.setItem(`${FILE_STORAGE_PREFIX}${filePath}`, serializeBytes(bytes));
+                    },
+                },
+                path: {
+                    async appDataDir() {
+                        return appDataDir;
+                    },
+                    async join(...parts) {
+                        return joinPaths(...parts);
+                    },
+                    async normalize(filePath) {
+                        return joinPaths(filePath);
+                    },
+                },
+                sql: sqlPlugin,
+                webview: {
+                    getCurrentWebview() {
+                        return {
+                            onDragDropEvent() {
+                                return Promise.resolve(() => {});
+                            },
+                        };
+                    },
+                },
+            };
+
+            for (const name of readyPromiseNames) {
+                window[name] = Promise.resolve(window.__TAURI__);
+            }
+
+            window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+                unregisterListener() {},
+            };
+        },
+        { options, readyPromiseNames: READY_PROMISE_NAMES },
+    );
+}
+
+module.exports = {
+    READY_PROMISE_NAMES,
+    installMockDesktopTauri,
+};

--- a/tests/helpers/mock-desktop-tauri.js
+++ b/tests/helpers/mock-desktop-tauri.js
@@ -57,7 +57,7 @@ async function installMockDesktopTauri(page, options = {}) {
             }
 
             function makeMissingFileError(filePath) {
-                return `No such file or directory: ${filePath}`;
+                return new Error(`No such file or directory: ${filePath}`);
             }
 
             function serializeBytes(bytes) {
@@ -172,7 +172,8 @@ async function installMockDesktopTauri(page, options = {}) {
                         return readDirEntries[dirPath] || [];
                     },
                     async stat(filePath) {
-                        const isFile = localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`) !== null;
+                        const raw = localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`);
+                        const isFile = raw !== null;
                         const isDirectory =
                             window.__mockDesktopTauriDirectories.has(joinPaths(filePath)) ||
                             Object.hasOwn(readDirEntries, filePath);
@@ -183,9 +184,7 @@ async function installMockDesktopTauri(page, options = {}) {
                             isFile,
                             isDirectory,
                             isSymlink: false,
-                            size: isFile
-                                ? JSON.parse(localStorage.getItem(`${FILE_STORAGE_PREFIX}${filePath}`)).length
-                                : 0,
+                            size: isFile ? JSON.parse(raw).length : 0,
                             mtime: null,
                             atime: null,
                             birthtime: null,
@@ -202,9 +201,9 @@ async function installMockDesktopTauri(page, options = {}) {
                             blocks: null,
                         };
                     },
-                    async mkdir(dirPath) {
+                    async mkdir(dirPath, options = {}) {
                         const normalized = joinPaths(dirPath);
-                        window.__mockDesktopTauriState.mkdirCalls.push(normalized);
+                        window.__mockDesktopTauriState.mkdirCalls.push({ dirPath: normalized, options });
                         window.__mockDesktopTauriDirectories.add(normalized);
                         return undefined;
                     },
@@ -270,7 +269,18 @@ async function installMockDesktopTauri(page, options = {}) {
     );
 }
 
+async function gotoMockDesktopPage(page) {
+    await page.route('http://mock.local/blank', async (route) => {
+        await route.fulfill({
+            contentType: 'text/html',
+            body: '<html><body>mock</body></html>',
+        });
+    });
+    await page.goto('http://mock.local/blank');
+}
+
 module.exports = {
     READY_PROMISE_NAMES,
+    gotoMockDesktopPage,
     installMockDesktopTauri,
 };

--- a/tests/helpers/mock-desktop-tauri.smoke.spec.js
+++ b/tests/helpers/mock-desktop-tauri.smoke.spec.js
@@ -1,0 +1,49 @@
+// @ts-check
+// Copyright (c) 2026 Divergent Health Technologies
+const { test, expect } = require('@playwright/test');
+const { READY_PROMISE_NAMES, installMockDesktopTauri } = require('./mock-desktop-tauri');
+
+async function gotoMockPage(page) {
+    await page.route('http://mock.local/blank', async (route) => {
+        await route.fulfill({
+            contentType: 'text/html',
+            body: '<html><body>mock</body></html>',
+        });
+    });
+    await page.goto('http://mock.local/blank');
+}
+
+test('mock desktop Tauri harness installs the baseline runtime on a blank page', async ({ page }) => {
+    await installMockDesktopTauri(page, {
+        appDataDir: '/mock/appdata',
+        fs: {
+            files: {
+                '/mock/appdata/library/image.dcm': [1, 2, 3],
+            },
+        },
+    });
+    await gotoMockPage(page);
+
+    const result = await page.evaluate(async (readyPromiseNames) => {
+        const ready = await Promise.all(readyPromiseNames.map((name) => window[name]));
+        return {
+            hasTauri: typeof window.__TAURI__ === 'object',
+            hasInvoke: typeof window.__TAURI__?.core?.invoke === 'function',
+            hasSql: typeof window.__TAURI__?.sql?.load === 'function',
+            readyCount: ready.length,
+            fileExists: await window.__TAURI__.fs.exists('/mock/appdata/library/image.dcm'),
+            bytes: Array.from(await window.__TAURI__.fs.readFile('/mock/appdata/library/image.dcm')),
+            appDataDir: await window.__TAURI__.path.appDataDir(),
+        };
+    }, READY_PROMISE_NAMES);
+
+    expect(result).toEqual({
+        hasTauri: true,
+        hasInvoke: true,
+        hasSql: true,
+        readyCount: READY_PROMISE_NAMES.length,
+        fileExists: true,
+        bytes: [1, 2, 3],
+        appDataDir: '/mock/appdata',
+    });
+});

--- a/tests/helpers/mock-desktop-tauri.smoke.spec.js
+++ b/tests/helpers/mock-desktop-tauri.smoke.spec.js
@@ -1,17 +1,7 @@
 // @ts-check
 // Copyright (c) 2026 Divergent Health Technologies
 const { test, expect } = require('@playwright/test');
-const { READY_PROMISE_NAMES, installMockDesktopTauri } = require('./mock-desktop-tauri');
-
-async function gotoMockPage(page) {
-    await page.route('http://mock.local/blank', async (route) => {
-        await route.fulfill({
-            contentType: 'text/html',
-            body: '<html><body>mock</body></html>',
-        });
-    });
-    await page.goto('http://mock.local/blank');
-}
+const { READY_PROMISE_NAMES, gotoMockDesktopPage, installMockDesktopTauri } = require('./mock-desktop-tauri');
 
 test('mock desktop Tauri harness installs the baseline runtime on a blank page', async ({ page }) => {
     await installMockDesktopTauri(page, {
@@ -22,7 +12,7 @@ test('mock desktop Tauri harness installs the baseline runtime on a blank page',
             },
         },
     });
-    await gotoMockPage(page);
+    await gotoMockDesktopPage(page);
 
     const result = await page.evaluate(async (readyPromiseNames) => {
         const ready = await Promise.all(readyPromiseNames.map((name) => window[name]));


### PR DESCRIPTION
## Summary
- add a shared Playwright mock for the desktop Tauri runtime, including ready promises, filesystem/path helpers, SQL bridge reuse, secure auth commands, and browser-side call tracking
- migrate `desktop-report-persistence.spec.js` to the shared harness while preserving negative-path coverage
- add helper smoke/contract tests plus README and ADR 015 documenting the harness boundary and extension rules

## Verification
- `npm run format:js:check && npm run lint:js && git diff --check`
- `npx playwright test tests/helpers/mock-desktop-tauri.smoke.spec.js tests/helpers/mock-desktop-tauri.contracts.spec.js tests/desktop-report-persistence.spec.js --reporter=line`
- `npm test -- --reporter=line` (72 Node TAP subtests, then 564 passed / 4 skipped Playwright tests)

## Notes
- This PR intentionally does not add the normalized real-Tauri golden recorder yet; ADR 015 records that as a future hardening step once the real-Tauri launch smoke has stabilized.
- I left `docs/INDEX.md` and `docs/planning/SITEMAP.md` untouched per agent worktree coordination rules.