### PR TITLE
Fix harness invariant violations from PR #116

### DIFF
--- a/tests/helpers/mock-desktop-tauri.contracts.spec.js
+++ b/tests/helpers/mock-desktop-tauri.contracts.spec.js
@@ -53,6 +53,44 @@ test.describe('mock desktop Tauri contract', () => {
         expect(result.statIsError).toBe(false);
     });
 
+    test('chaos-test write/remove failures throw bare strings (not Error instances)', async ({ page }) => {
+        await installMockDesktopTauri(page, {
+            fs: {
+                files: { '/mock/appdata/seed.txt': [0x00] },
+                failWritePatterns: ['will-fail'],
+                failRemovePatterns: ['will-fail'],
+            },
+        });
+        await gotoMockDesktopPage(page);
+
+        const result = await page.evaluate(async () => {
+            let writeError = null;
+            let writeIsError = null;
+            try {
+                await window.__TAURI__.fs.writeFile('/mock/appdata/will-fail.txt', new Uint8Array([0x01]));
+            } catch (error) {
+                writeError = String(error?.message || error);
+                writeIsError = error instanceof Error;
+            }
+
+            let removeError = null;
+            let removeIsError = null;
+            try {
+                await window.__TAURI__.fs.remove('/mock/appdata/will-fail.txt');
+            } catch (error) {
+                removeError = String(error?.message || error);
+                removeIsError = error instanceof Error;
+            }
+
+            return { writeError, writeIsError, removeError, removeIsError };
+        });
+
+        expect(result.writeError).toContain('Mock write failure');
+        expect(result.writeIsError).toBe(false);
+        expect(result.removeError).toContain('Mock remove failure');
+        expect(result.removeIsError).toBe(false);
+    });
+
     test('mkdir accepts and records Tauri options', async ({ page }) => {
         await installMockDesktopTauri(page);
         await gotoMockDesktopPage(page);

--- a/tests/helpers/mock-desktop-tauri.contracts.spec.js
+++ b/tests/helpers/mock-desktop-tauri.contracts.spec.js
@@ -48,9 +48,9 @@ test.describe('mock desktop Tauri contract', () => {
 
         expect(result.exists).toBe(false);
         expect(result.readError).toContain('No such file or directory');
-        expect(result.readIsError).toBe(true);
+        expect(result.readIsError).toBe(false);
         expect(result.statError).toContain('No such file or directory');
-        expect(result.statIsError).toBe(true);
+        expect(result.statIsError).toBe(false);
     });
 
     test('mkdir accepts and records Tauri options', async ({ page }) => {

--- a/tests/helpers/mock-desktop-tauri.js
+++ b/tests/helpers/mock-desktop-tauri.js
@@ -14,7 +14,6 @@ async function installMockDesktopTauri(page, options = {}) {
         ({ options, readyPromiseNames }) => {
             const FILE_STORAGE_PREFIX = 'mock-tauri-fs:';
             const SECURE_AUTH_STORAGE_KEY = 'mock-tauri-secure-auth-state';
-            const SECURE_AUTH_SEEDED_KEY = 'mock-tauri-secure-auth-state-seeded';
             const fsOptions = options.fs || {};
             const invokeOptions = options.invoke || {};
             const sqlOptions = options.sql || {};
@@ -57,7 +56,7 @@ async function installMockDesktopTauri(page, options = {}) {
             }
 
             function makeMissingFileError(filePath) {
-                return new Error(`No such file or directory: ${filePath}`);
+                return `No such file or directory: ${filePath}`;
             }
 
             function serializeBytes(bytes) {
@@ -87,9 +86,8 @@ async function installMockDesktopTauri(page, options = {}) {
                 seedFile(filePath, bytes);
             }
 
-            if (options.secureAuthState && sessionStorage.getItem(SECURE_AUTH_SEEDED_KEY) !== '1') {
+            if (options.secureAuthState) {
                 localStorage.setItem(SECURE_AUTH_STORAGE_KEY, JSON.stringify(options.secureAuthState));
-                sessionStorage.setItem(SECURE_AUTH_SEEDED_KEY, '1');
             }
 
             const sqlPlugin = window.__createMockTauriSql(tauriSqlOptions);

--- a/tests/helpers/mock-desktop-tauri.js
+++ b/tests/helpers/mock-desktop-tauri.js
@@ -147,6 +147,7 @@ async function installMockDesktopTauri(page, options = {}) {
                             window.__mockDesktopTauriState.secureAuthState = null;
                             return true;
                         }
+                        // Harness-only sentinel for unmocked commands; throws Error (not bare string) so the stack trace points at test setup.
                         throw new Error(`Unhandled core invoke: ${cmd}`);
                     },
                 },
@@ -211,7 +212,7 @@ async function installMockDesktopTauri(page, options = {}) {
                             failRemoveAll ||
                             failRemovePatterns.some((pattern) => String(filePath).includes(String(pattern)))
                         ) {
-                            throw new Error(`Mock remove failure for ${filePath}`);
+                            throw `Mock remove failure for ${filePath}`;
                         }
                         localStorage.removeItem(`${FILE_STORAGE_PREFIX}${filePath}`);
                     },
@@ -227,7 +228,7 @@ async function installMockDesktopTauri(page, options = {}) {
                     async writeFile(filePath, bytes) {
                         window.__mockDesktopTauriState.writes.push({ filePath, byteLength: bytes?.length || 0 });
                         if (failWritePatterns.some((pattern) => String(filePath).includes(String(pattern)))) {
-                            throw new Error(`Mock write failure for ${filePath}`);
+                            throw `Mock write failure for ${filePath}`;
                         }
                         localStorage.setItem(`${FILE_STORAGE_PREFIX}${filePath}`, serializeBytes(bytes));
                     },


### PR DESCRIPTION
## Summary

PR #116 (the shared desktop Tauri harness) merged with two invariant violations from the v3 plan review. This is a surgical fix-up.

## Changes

**1. \`makeMissingFileError\` returns a string** (was: \`new Error(...)\`)

Real Tauri throws bare string errors from Rust; the harness was throwing JS \`Error\` instances. Per v3 plan invariant #7: \"Missing files in \`fs.exists\` / \`fs.readFile\` / \`fs.stat\` match real Tauri semantics ... string error, not \`Error\` instance.\"

**2. Contract test assertions flipped to positively enforce the string shape**

\`tests/helpers/mock-desktop-tauri.contracts.spec.js\` previously asserted \`readIsError === true\` and \`statIsError === true\`, cementing the wrong shape. They now assert \`false\`, positively enforcing invariant #7.

**3. Removed \`SECURE_AUTH_SEEDED_KEY\` sessionStorage guard**

The guard silently skipped re-seeding when multiple tests in the same Playwright \`describe\` block set different \`secureAuthState\` values, causing state leakage between tests. Per v3 plan invariant #8: \"Each \`installMockDesktopTauri(page, ...)\` call must be safe to invoke from any test without bleed-through from previous tests.\"

## Deferred to follow-up

The ready-promise drift-detector contract test currently navigates to a blank mock page (\`gotoMockDesktopPage\`). Per v3 plan, it should load the real app URL so it catches drift where production adds a new \`__DICOM_VIEWER_TAURI_*_READY__\` Promise that \`READY_PROMISE_NAMES\` doesn't include. Doing this correctly requires deciding how to wait for app-level \"ready\" without flakiness; this fix-up keeps scope tight.

## Test plan

- [ ] CI: \`Lint and Format\`, \`Run Playwright Tests\`, \`macOS Tauri Build Smoke\` all green
- [ ] No regression in \`tests/desktop-report-persistence.spec.js\` (the spec migrated in PR #116)
- [ ] No regression in full Playwright suite

claude