### PR TITLE
Export installCompatFromInternals + direct unit tests (v3 plan PR #3)

### DIFF
--- a/docs/js/tauri-compat.js
+++ b/docs/js/tauri-compat.js
@@ -399,6 +399,18 @@
         waitForRuntime,
         hasReadyDesktopApis,
         hasReadyDesktopStorageApis,
+        /**
+         * @private — exported for the desktop runtime-compat contract tests.
+         * Not part of the public API. The guard test in
+         * tests/desktop-runtime-compat.spec.js fails if any file under
+         * docs/js/ (except this one) references `_testInternals`. If
+         * production code needs this behavior, call the public
+         * `DicomViewerTauriCompat` surface above — do NOT import from
+         * `_testInternals` directly.
+         */
+        _testInternals: Object.freeze({
+            installCompatFromInternals,
+        }),
     });
     resolveDesktopRuntime(hasReadyDesktopStorageApis) || resolveDesktopRuntime();
 })();

--- a/docs/planning/SITEMAP.md
+++ b/docs/planning/SITEMAP.md
@@ -132,6 +132,7 @@ asks to preserve the research process itself.
 | `REMEDIATION-PLAN.md` | Prioritized remediation plan cross-referencing both audits. 5 tiers from image correctness to accept-as-is |
 | `CODEBASE-AUDIT-2026-04-08.md` | Multi-agent codebase audit: hardening, security, and correctness findings captured as historical planning input |
 | `TODO-pr42-hardener-findings.md` | PR #42 hardener follow-up list for desktop security, sync, and context-menu improvements |
+| `TODO-pr118-compat-runtime-followups.md` | PR #118 compat-runtime refactor follow-ups: Node-side unit test migration, immutability assertion, `window.__TAURI__` restoration |
 
 ### Other
 

--- a/docs/planning/TODO-pr118-compat-runtime-followups.md
+++ b/docs/planning/TODO-pr118-compat-runtime-followups.md
@@ -1,0 +1,15 @@
+# PR #118 Compat Runtime Refactor Follow-Ups
+
+Filed: 2026-05-16. Hardener review of PR #118 surfaced items deferred out of scope. To be addressed before or after merge.
+
+Context: PR #118 ("Export installCompatFromInternals + direct unit tests") is the 3rd PR in the v3 plan to make `installCompatFromInternals` unit-testable. The PR exports the function from `_testInternals` and adds direct Playwright tests. Hardener review flagged structural improvements deferred out of scope to keep the PR small.
+
+## Medium
+
+1. **Migrate `installCompatFromInternals` direct tests to a Node-side harness** -- `tests/desktop-runtime-compat.spec.js` (the `installCompatFromInternals (direct unit tests via _testInternals)` describe block). The function has zero DOM/browser dependencies once given an `internals` object. A Node-side test runner (Vitest, `node:test`, or `vm.runInNewContext` with `window` stubbed) eliminates the `page.evaluate` JSON serialization boundary that drove the duplication bug fixed in PR #118, runs 10-100x faster than Playwright, and allows direct assertions on returned objects without `page.evaluate` round-trips. After this lands, the Playwright describe block can be thinned to a single smoke test that asserts the no-library page bootstrap doesn't throw -- keeping the integration-flavored coverage without duplicating the unit coverage.
+
+## Low
+
+2. **Add an immutability assertion to `installCompatFromInternals` tests** -- same describe block. Production callers may pass the same `internals` (or share references with native code) and depend on the function not mutating its input. Verify by deep-cloning the input before the call and deep-comparing after. No test currently asserts this property.
+
+3. **Restore `window.__TAURI__` after `installCompatFromInternals` tests** -- two tests in the describe block set `window.__TAURI__ = undefined` without restoring it. Playwright isolates pages per test by default, so this is not currently failing. Worth a `beforeEach`/`afterEach` save-and-restore pair (or `test.use({ storageState: ... })`) to make the test idempotent if Playwright's isolation behavior ever changes or if these tests are reused in a shared-context runner.

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -517,20 +517,7 @@ test('desktop storage ready promise resolves before the full desktop shell is av
 });
 
 test.describe('installCompatFromInternals (direct unit tests via _testInternals)', () => {
-    // Follow-ups (do not address in this PR):
-    //   1. Migrate these direct unit tests to a Node-side harness (Vitest or
-    //      node:test) since installCompatFromInternals has no DOM dependencies.
-    //      Faster than Playwright, eliminates the page.evaluate JSON boundary
-    //      that drove the buildMinimalInternals duplication bug in PR #118, and
-    //      lets us assert on returned objects directly. Once the Node test
-    //      exists, this Playwright describe block can be thinned to a single
-    //      smoke test ("bootstrap doesn't throw") covering the no-library page
-    //      load path end-to-end.
-    //   2. Add an assertion that installCompatFromInternals does not mutate its
-    //      input internals object. Production callers may pass the same
-    //      internals (or share references with native code) and depend on
-    //      immutability. Verify by deep-cloning the input before the call and
-    //      deep-comparing after.
+    // Deferred follow-ups tracked in docs/planning/TODO-pr118-compat-runtime-followups.md
     const NOLIB_URL = 'http://127.0.0.1:5001/?nolib';
 
     test('returns null when internals are missing or have no invoke', async ({ page }) => {

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -516,6 +516,160 @@ test('desktop storage ready promise resolves before the full desktop shell is av
     expect(result.fullSettledEarly).toBe(false);
 });
 
+test.describe('installCompatFromInternals (direct unit tests via _testInternals)', () => {
+    const NOLIB_URL = 'http://127.0.0.1:5001/?nolib';
+
+    function buildMinimalInternals() {
+        return {
+            metadata: {
+                currentWindow: { label: 'main' },
+                currentWebview: { label: 'main', windowLabel: 'main' },
+            },
+            convertFileSrc(filePath, protocol = 'asset') {
+                return `${protocol}://localhost/${encodeURIComponent(filePath)}`;
+            },
+            transformCallback(callback) {
+                return callback;
+            },
+            unregisterCallback() {},
+            invoke: () => Promise.resolve(null),
+        };
+    }
+
+    test('returns null when internals are missing or have no invoke', async ({ page }) => {
+        await page.goto(NOLIB_URL);
+
+        const result = await page.evaluate(() => {
+            const { installCompatFromInternals } = window.DicomViewerTauriCompat._testInternals;
+            // Reset to ensure the early-return falls through to null, not a stale __TAURI__.
+            window.__TAURI__ = undefined;
+            return {
+                nullCase: installCompatFromInternals(null),
+                emptyCase: installCompatFromInternals({}),
+                noInvokeCase: installCompatFromInternals({ transformCallback: () => null }),
+            };
+        });
+
+        expect(result.nullCase).toBeNull();
+        expect(result.emptyCase).toBeNull();
+        expect(result.noInvokeCase).toBeNull();
+    });
+
+    test('builds a complete Tauri surface from a minimal internals stub', async ({ page }) => {
+        await page.goto(NOLIB_URL);
+
+        const result = await page.evaluate((internalsStub) => {
+            window.__TAURI__ = undefined;
+            const { installCompatFromInternals } = window.DicomViewerTauriCompat._testInternals;
+            // Re-attach functions stripped by JSON serialization across the page boundary.
+            const internals = {
+                ...internalsStub,
+                convertFileSrc: (filePath, protocol = 'asset') =>
+                    `${protocol}://localhost/${encodeURIComponent(filePath)}`,
+                transformCallback: (callback) => callback,
+                unregisterCallback: () => {},
+                invoke: () => Promise.resolve(null),
+            };
+            const tauri = installCompatFromInternals(internals);
+            return {
+                hasCoreInvoke: typeof tauri?.core?.invoke === 'function',
+                hasCoreConvertFileSrc: typeof tauri?.core?.convertFileSrc === 'function',
+                hasDialogOpen: typeof tauri?.dialog?.open === 'function',
+                hasEventListen: typeof tauri?.event?.listen === 'function',
+                hasFsExists: typeof tauri?.fs?.exists === 'function',
+                hasFsReadFile: typeof tauri?.fs?.readFile === 'function',
+                hasFsWriteFile: typeof tauri?.fs?.writeFile === 'function',
+                hasFsStat: typeof tauri?.fs?.stat === 'function',
+                hasFsRename: typeof tauri?.fs?.rename === 'function',
+                hasFsMkdir: typeof tauri?.fs?.mkdir === 'function',
+                hasFsReadDir: typeof tauri?.fs?.readDir === 'function',
+                hasFsRemove: typeof tauri?.fs?.remove === 'function',
+                hasPathAppDataDir: typeof tauri?.path?.appDataDir === 'function',
+                hasPathJoin: typeof tauri?.path?.join === 'function',
+                hasPathNormalize: typeof tauri?.path?.normalize === 'function',
+                hasSqlLoad: typeof tauri?.sql?.load === 'function',
+                hasWebviewGetCurrent: typeof tauri?.webview?.getCurrentWebview === 'function',
+                globalAssigned: window.__TAURI__ === tauri,
+            };
+        }, buildMinimalInternals());
+
+        expect(result).toEqual({
+            hasCoreInvoke: true,
+            hasCoreConvertFileSrc: true,
+            hasDialogOpen: true,
+            hasEventListen: true,
+            hasFsExists: true,
+            hasFsReadFile: true,
+            hasFsWriteFile: true,
+            hasFsStat: true,
+            hasFsRename: true,
+            hasFsMkdir: true,
+            hasFsReadDir: true,
+            hasFsRemove: true,
+            hasPathAppDataDir: true,
+            hasPathJoin: true,
+            hasPathNormalize: true,
+            hasSqlLoad: true,
+            hasWebviewGetCurrent: true,
+            globalAssigned: true,
+        });
+    });
+
+    test('preserves existing __TAURI__ members when augmenting from internals', async ({ page }) => {
+        await page.goto(NOLIB_URL);
+
+        const result = await page.evaluate(() => {
+            const nativeInvokeSentinel = () => Promise.resolve('native-invoke');
+            window.__TAURI__ = { core: { invoke: nativeInvokeSentinel } };
+
+            const { installCompatFromInternals } = window.DicomViewerTauriCompat._testInternals;
+            const internals = {
+                metadata: { currentWindow: { label: 'main' }, currentWebview: { label: 'main' } },
+                convertFileSrc: (filePath, protocol = 'asset') =>
+                    `${protocol}://localhost/${encodeURIComponent(filePath)}`,
+                transformCallback: (callback) => callback,
+                unregisterCallback: () => {},
+                invoke: () => Promise.resolve('shim-invoke'),
+            };
+            const tauri = installCompatFromInternals(internals);
+            return {
+                preservedCoreInvoke: tauri.core.invoke === nativeInvokeSentinel,
+                augmentedFsExists: typeof tauri?.fs?.exists === 'function',
+                augmentedPathAppDataDir: typeof tauri?.path?.appDataDir === 'function',
+                augmentedSqlLoad: typeof tauri?.sql?.load === 'function',
+            };
+        });
+
+        expect(result.preservedCoreInvoke).toBe(true);
+        expect(result.augmentedFsExists).toBe(true);
+        expect(result.augmentedPathAppDataDir).toBe(true);
+        expect(result.augmentedSqlLoad).toBe(true);
+    });
+
+    test('guard: no file under docs/js/ (except tauri-compat.js) references _testInternals', () => {
+        const docsJsRoot = path.join(__dirname, '..', 'docs', 'js');
+        const violations = [];
+
+        function walk(dir) {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const fullPath = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    walk(fullPath);
+                } else if (entry.isFile() && entry.name.endsWith('.js') && entry.name !== 'tauri-compat.js') {
+                    const content = fs.readFileSync(fullPath, 'utf8');
+                    if (content.includes('_testInternals')) {
+                        violations.push(path.relative(docsJsRoot, fullPath));
+                    }
+                }
+            }
+        }
+        walk(docsJsRoot);
+
+        // Empty array means no production file references the test-only surface.
+        expect(violations).toEqual([]);
+    });
+});
+
 test('OpenJPEG asset URL resolves when the decoder bundle is worker-loaded', async ({ page }) => {
     await page.goto('http://127.0.0.1:5001/?nolib');
 

--- a/tests/desktop-runtime-compat.spec.js
+++ b/tests/desktop-runtime-compat.spec.js
@@ -517,24 +517,21 @@ test('desktop storage ready promise resolves before the full desktop shell is av
 });
 
 test.describe('installCompatFromInternals (direct unit tests via _testInternals)', () => {
+    // Follow-ups (do not address in this PR):
+    //   1. Migrate these direct unit tests to a Node-side harness (Vitest or
+    //      node:test) since installCompatFromInternals has no DOM dependencies.
+    //      Faster than Playwright, eliminates the page.evaluate JSON boundary
+    //      that drove the buildMinimalInternals duplication bug in PR #118, and
+    //      lets us assert on returned objects directly. Once the Node test
+    //      exists, this Playwright describe block can be thinned to a single
+    //      smoke test ("bootstrap doesn't throw") covering the no-library page
+    //      load path end-to-end.
+    //   2. Add an assertion that installCompatFromInternals does not mutate its
+    //      input internals object. Production callers may pass the same
+    //      internals (or share references with native code) and depend on
+    //      immutability. Verify by deep-cloning the input before the call and
+    //      deep-comparing after.
     const NOLIB_URL = 'http://127.0.0.1:5001/?nolib';
-
-    function buildMinimalInternals() {
-        return {
-            metadata: {
-                currentWindow: { label: 'main' },
-                currentWebview: { label: 'main', windowLabel: 'main' },
-            },
-            convertFileSrc(filePath, protocol = 'asset') {
-                return `${protocol}://localhost/${encodeURIComponent(filePath)}`;
-            },
-            transformCallback(callback) {
-                return callback;
-            },
-            unregisterCallback() {},
-            invoke: () => Promise.resolve(null),
-        };
-    }
 
     test('returns null when internals are missing or have no invoke', async ({ page }) => {
         await page.goto(NOLIB_URL);
@@ -558,12 +555,15 @@ test.describe('installCompatFromInternals (direct unit tests via _testInternals)
     test('builds a complete Tauri surface from a minimal internals stub', async ({ page }) => {
         await page.goto(NOLIB_URL);
 
-        const result = await page.evaluate((internalsStub) => {
+        const result = await page.evaluate(() => {
             window.__TAURI__ = undefined;
             const { installCompatFromInternals } = window.DicomViewerTauriCompat._testInternals;
-            // Re-attach functions stripped by JSON serialization across the page boundary.
+            // Build internals in-page: functions cannot cross the page.evaluate JSON boundary.
             const internals = {
-                ...internalsStub,
+                metadata: {
+                    currentWindow: { label: 'main' },
+                    currentWebview: { label: 'main', windowLabel: 'main' },
+                },
                 convertFileSrc: (filePath, protocol = 'asset') =>
                     `${protocol}://localhost/${encodeURIComponent(filePath)}`,
                 transformCallback: (callback) => callback,
@@ -591,7 +591,7 @@ test.describe('installCompatFromInternals (direct unit tests via _testInternals)
                 hasWebviewGetCurrent: typeof tauri?.webview?.getCurrentWebview === 'function',
                 globalAssigned: window.__TAURI__ === tauri,
             };
-        }, buildMinimalInternals());
+        });
 
         expect(result).toEqual({
             hasCoreInvoke: true,


### PR DESCRIPTION
## Summary

Implements PR #3 from the v3 desktop test harness plan: export the pure compat-shim function \`installCompatFromInternals\` via a test-only surface so it can be unit-tested directly, rather than only through the runtime-injection plumbing that the existing integration tests rely on.

## Production change

\`docs/js/tauri-compat.js\` — added \`_testInternals\` sub-object to the \`DicomViewerTauriCompat\` frozen namespace:

\`\`\`js
_testInternals: Object.freeze({
    installCompatFromInternals,
}),
\`\`\`

The export carries a JSDoc \`@private\` tag and a comment explaining the constraint. The underscore prefix and frozen-inner-object pattern signal test-only intent. Per the v3 plan's PR #3 constraints (\"Export name signals test-only intent\").

## Test changes

\`tests/desktop-runtime-compat.spec.js\` — new \`test.describe\` block with 4 direct unit tests against the exported function:

1. **Null/empty internals return null** — verifies the early-return safety check (\`if (!internals?.invoke) return window.__TAURI__ || null\`).
2. **Minimal internals stub produces complete Tauri surface** — verifies the function populates \`core\`, \`dialog\`, \`event\`, \`fs.*\`, \`path.*\`, \`sql\`, \`webview\` and assigns to \`window.__TAURI__\`.
3. **Preserves existing \`__TAURI__\` members** — verifies the \`typeof tauri.X !== 'function'\` augmentation guards work (a sentinel \`core.invoke\` survives the call).
4. **Guard: no production file references \`_testInternals\`** — meta-test that walks \`docs/js/\` and fails if any file other than \`tauri-compat.js\` references the test-only surface. This is the lint mechanism the v3 plan calls for, implemented as a normal test (no new CI infrastructure).

## What this doesn't do (deferred)

- The existing \`installMockTauriInternals\` helper at the top of the spec is duplicated inline in the \"late-arrival\" test (lines 162-265 of the original). Consolidating the duplicates requires a page-context factory; out of scope for this PR.
- The 3 existing IIFE-level integration tests (auto-install on present internals, late-arriving internals, partial-global augmentation) are kept. They cover scenarios the direct unit tests don't (timing, IIFE auto-detection, deployment-mode integration). The bespoke \`__TAURI_INTERNALS__\` mock helper shrinks naturally over time as more behaviors get tested directly.

## v3 plan compliance check

| Requirement | Status |
|---|---|
| Export under test-only namespace OR @private tag | ✓ both (\`_testInternals\` + JSDoc \`@private\`) |
| Lint/grep guard / unit test that fails if production imports it | ✓ guard test in spec |
| Comment at export site | ✓ JSDoc block explaining the constraint |
| \`installCompatFromInternals\` behaves identically | ✓ no change to function body, only added to export |
| Runtime-compat spec passes with same scenarios | ✓ existing tests unchanged, new tests added |

## Test plan

- [ ] CI green: \`Lint and Format\`, \`Run Playwright Tests\`, \`macOS Tauri Build Smoke\`, \`Vercel\`
- [ ] Existing runtime-compat tests still pass (auto-install, late-arrival, partial-global, ready-promise, decode/JPEG tests, capability test)
- [ ] 4 new direct unit tests pass
- [ ] Guard test passes (no production file currently references \`_testInternals\`)
- [ ] PR #1 nightly real-Tauri smoke still green next morning

claude