### PR TITLE
Migrate desktop-library.spec.js helpers to shared harness (v3 plan PR #5)

### DIFF
--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -5,19 +5,35 @@ const path = require('node:path');
 const { test, expect } = require('@playwright/test');
 const { createSyntheticDicomFolder, removeSyntheticDicomFolder } = require('./dicom-fixture-helper');
 const { joinPaths } = require('./helpers/desktop-test-utils');
+const { installMockDesktopTauri } = require('./helpers/mock-desktop-tauri');
 
 const TEST_BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:5001';
 const HOME_URL = `${TEST_BASE_URL}/?nolib`;
 const AUTOLOAD_URL = `${TEST_BASE_URL}/`;
 const JPEG_BASELINE_RGB_FIXTURE_PATH = path.join(__dirname, '..', 'test-fixtures', 'SC_RGB_JPEG_BASELINE_YBR422.dcm');
-const MOCK_SQL_INIT_PATH = path.join(__dirname, 'mock-tauri-sql-init.js');
 
 async function installMockDesktop(page, options = {}) {
-    await page.addInitScript({ path: MOCK_SQL_INIT_PATH });
-    await page.addInitScript((options) => {
-        const FILE_STORAGE_PREFIX = 'mock-desktop-fs:';
-        const hasOwnPropertyFn = Object.prototype.hasOwnProperty;
-        const hasOwn = (object, key) => hasOwnPropertyFn.call(object, key);
+    // Delegate the Tauri runtime to the shared harness, then layer
+    // library-spec specifics (debug settings, decode trace, readDir scans
+    // with delay/errors, in-memory fileBytes, transient read failures) on top.
+    await installMockDesktopTauri(page, {
+        // Intentionally overrides the harness default ('/mock/appdata') to match
+        // this spec's pre-migration default ('/appdata'). Tests assert on this path.
+        appDataDir: options.appDataDir || '/appdata',
+        fs: {
+            files: options.storedFiles || {},
+        },
+        sql: {
+            initialState: options.initialState || {},
+            ...(options.sql || {}),
+        },
+        invoke: {
+            legacyDesktopStores: options.legacyDesktopStores || [],
+        },
+    });
+
+    await page.addInitScript((opts) => {
+        const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
 
         function toByteArray(value) {
             if (Array.isArray(value)) {
@@ -43,174 +59,138 @@ async function installMockDesktop(page, options = {}) {
             return collapsed.replace(/\/+$/g, '');
         }
 
-        function joinPaths(...parts) {
-            const cleaned = parts
-                .filter((part) => part !== null && part !== undefined && part !== '')
-                .map((part, index) => {
-                    const value = String(part).replace(/\\/g, '/');
-                    if (index === 0) {
-                        return value.replace(/\/+$/g, '') || '/';
-                    }
-                    return value.replace(/^\/+/g, '').replace(/\/+$/g, '');
-                })
-                .filter(Boolean);
-
-            if (!cleaned.length) return '';
-            return normalizePath(cleaned.join('/'));
+        if (opts.initialConfig) {
+            localStorage.setItem('dicom-viewer-library-config', JSON.stringify(opts.initialConfig));
         }
 
-        if (options.initialConfig) {
-            localStorage.setItem('dicom-viewer-library-config', JSON.stringify(options.initialConfig));
-        }
-
+        // Normalize the spec's option maps once at install time.
         const dirs = {};
-        for (const [path, entries] of Object.entries(options.dirs || {})) {
-            dirs[normalizePath(path)] = entries;
+        for (const [p, entries] of Object.entries(opts.dirs || {})) {
+            dirs[normalizePath(p)] = entries;
         }
-
         const readDirErrors = {};
-        for (const [path, message] of Object.entries(options.readDirErrors || {})) {
-            readDirErrors[normalizePath(path)] = message;
+        for (const [p, message] of Object.entries(opts.readDirErrors || {})) {
+            readDirErrors[normalizePath(p)] = message;
         }
-
-        const readDirDelayMs = Number(options.readDirDelayMs || 0);
-
+        const readDirDelayMs = Number(opts.readDirDelayMs || 0);
         const stats = {};
-        for (const [path, value] of Object.entries(options.stats || {})) {
-            stats[normalizePath(path)] = value;
+        for (const [p, value] of Object.entries(opts.stats || {})) {
+            stats[normalizePath(p)] = value;
         }
-
+        // In-memory file bytes (distinct from harness localStorage). rename mutates
+        // this map; the original semantic was "rename only works for fileBytes,
+        // not for arbitrary persisted localStorage files." Preserved verbatim.
         const fileBytes = {};
-        for (const [path, value] of Object.entries(options.fileBytes || {})) {
-            fileBytes[normalizePath(path)] = value;
+        for (const [p, value] of Object.entries(opts.fileBytes || {})) {
+            fileBytes[normalizePath(p)] = toByteArray(value);
         }
-
-        for (const [path, value] of Object.entries(options.storedFiles || {})) {
-            localStorage.setItem(`${FILE_STORAGE_PREFIX}${normalizePath(path)}`, JSON.stringify(toByteArray(value)));
-        }
-
+        // Mutable per-path failure counter for readFile.
         const readFileFailures = {};
-        for (const [path, value] of Object.entries(options.readFileFailures || {})) {
-            readFileFailures[normalizePath(path)] = Number(value || 0);
+        for (const [p, value] of Object.entries(opts.readFileFailures || {})) {
+            readFileFailures[normalizePath(p)] = Number(value || 0);
         }
 
+        // Browser-side library-spec tracking that tests assert on.
         window.__frontendDecodeTraceCalls = [];
 
-        window.__TAURI__ = {
-            core: {
-                async invoke(cmd, args) {
-                    if (cmd === 'apply_desktop_migration') {
-                        return window.__applyMockDesktopMigration(args.db, args.batch, options);
+        // Wrap core.invoke for library-specific commands; fall through to the harness
+        // for apply_desktop_migration / load_legacy_desktop_browser_stores / etc.
+        const originalInvoke = window.__TAURI__.core.invoke;
+        window.__TAURI__.core.invoke = async (cmd, args = {}) => {
+            if (cmd === 'read_scan_manifest') {
+                return opts.nativeScanManifest || null;
+            }
+            if (cmd === 'get_debug_settings') {
+                return (
+                    opts.debugSettings || {
+                        decodeMode: 'auto',
+                        preloadMode: 'auto',
+                        frontendDecodeTrace: false,
+                        nativeDecodeDebug: false,
                     }
-                    if (cmd === 'load_legacy_desktop_browser_stores') {
-                        return options.legacyDesktopStores || [];
-                    }
-                    if (cmd === 'read_scan_manifest') {
-                        return options.nativeScanManifest || null;
-                    }
-                    if (cmd === 'get_debug_settings') {
-                        return (
-                            options.debugSettings || {
-                                decodeMode: 'auto',
-                                preloadMode: 'auto',
-                                frontendDecodeTrace: false,
-                                nativeDecodeDebug: false,
-                            }
-                        );
-                    }
-                    if (cmd === 'log_frontend_decode_event') {
-                        window.__frontendDecodeTraceCalls.push(args?.message || '');
-                        return null;
-                    }
-                    throw new Error(`Unhandled core invoke: ${cmd}`);
-                },
-            },
-            dialog: {
-                async open() {
-                    return null;
-                },
-            },
-            fs: {
-                async exists(path) {
-                    const normalized = normalizePath(path);
-                    return (
-                        hasOwn(fileBytes, normalized) ||
-                        localStorage.getItem(`${FILE_STORAGE_PREFIX}${normalized}`) !== null
-                    );
-                },
-                async readDir(path) {
-                    if (readDirDelayMs > 0) {
-                        await new Promise((resolve) => setTimeout(resolve, readDirDelayMs));
-                    }
-                    const normalized = normalizePath(path);
-                    if (hasOwn(readDirErrors, normalized)) {
-                        throw new Error(readDirErrors[normalized]);
-                    }
-                    if (!hasOwn(dirs, normalized)) {
-                        throw new Error(`Path not found: ${normalized}`);
-                    }
-                    return dirs[normalized];
-                },
-                async readFile(path) {
-                    const normalized = normalizePath(path);
-                    const remainingFailures = readFileFailures[normalized] || 0;
-                    if (remainingFailures > 0) {
-                        readFileFailures[normalized] = remainingFailures - 1;
-                        throw new Error(`Transient read failure: ${normalized}`);
-                    }
-                    const persisted = localStorage.getItem(`${FILE_STORAGE_PREFIX}${normalized}`);
-                    const bytes = fileBytes[normalized] || (persisted ? JSON.parse(persisted) : null) || [0];
-                    return Uint8Array.from(bytes);
-                },
-                async writeFile(path, bytes) {
-                    const normalized = normalizePath(path);
-                    localStorage.setItem(`${FILE_STORAGE_PREFIX}${normalized}`, JSON.stringify(Array.from(bytes)));
-                },
-                async mkdir() {
-                    return undefined;
-                },
-                async remove(path) {
-                    localStorage.removeItem(`${FILE_STORAGE_PREFIX}${normalizePath(path)}`);
-                },
-                async stat(path) {
-                    const normalized = normalizePath(path);
-                    if (!hasOwn(stats, normalized)) {
-                        throw new Error(`Stat not found: ${normalized}`);
-                    }
-                    return stats[normalized];
-                },
-                async rename(fromPath, toPath) {
-                    const normalizedFrom = normalizePath(fromPath);
-                    const normalizedTo = normalizePath(toPath);
-                    if (!hasOwn(fileBytes, normalizedFrom)) {
-                        throw new Error(`Rename source not found: ${normalizedFrom}`);
-                    }
-                    fileBytes[normalizedTo] = fileBytes[normalizedFrom];
-                    delete fileBytes[normalizedFrom];
-                },
-            },
-            path: {
-                async appDataDir() {
-                    return normalizePath(options.appDataDir || '/appdata');
-                },
-                async join(...parts) {
-                    return joinPaths(...parts);
-                },
-                async normalize(path) {
-                    return normalizePath(path);
-                },
-            },
-            sql: window.__createMockTauriSql(options),
-            webview: {
-                getCurrentWebview() {
-                    return {
-                        onDragDropEvent() {
-                            return Promise.resolve(() => {});
-                        },
-                    };
-                },
+                );
+            }
+            if (cmd === 'log_frontend_decode_event') {
+                window.__frontendDecodeTraceCalls.push(args?.message || '');
+                return null;
+            }
+            return originalInvoke(cmd, args);
+        };
+
+        // fs.exists: in-memory fileBytes OR harness fallthrough (which checks localStorage).
+        const originalExists = window.__TAURI__.fs.exists;
+        window.__TAURI__.fs.exists = async (filePath) => {
+            const normalized = normalizePath(filePath);
+            if (hasOwn(fileBytes, normalized)) return true;
+            return originalExists(filePath);
+        };
+
+        // fs.readFile: failures → in-memory fileBytes → harness fallthrough → default [0].
+        const originalReadFile = window.__TAURI__.fs.readFile;
+        window.__TAURI__.fs.readFile = async (filePath) => {
+            const normalized = normalizePath(filePath);
+            const remainingFailures = readFileFailures[normalized] || 0;
+            if (remainingFailures > 0) {
+                readFileFailures[normalized] = remainingFailures - 1;
+                throw new Error(`Transient read failure: ${normalized}`);
+            }
+            if (hasOwn(fileBytes, normalized)) {
+                return Uint8Array.from(fileBytes[normalized]);
+            }
+            try {
+                return await originalReadFile(filePath);
+            } catch {
+                return Uint8Array.from([0]);
+            }
+        };
+
+        // fs.readDir: dirs map + per-path errors + global delay; throws if path not in dirs.
+        window.__TAURI__.fs.readDir = async (dirPath) => {
+            if (readDirDelayMs > 0) {
+                await new Promise((resolve) => setTimeout(resolve, readDirDelayMs));
+            }
+            const normalized = normalizePath(dirPath);
+            if (hasOwn(readDirErrors, normalized)) {
+                throw new Error(readDirErrors[normalized]);
+            }
+            if (!hasOwn(dirs, normalized)) {
+                throw new Error(`Path not found: ${normalized}`);
+            }
+            return dirs[normalized];
+        };
+
+        // fs.stat: stats map; throws if path not present (matches the original).
+        window.__TAURI__.fs.stat = async (filePath) => {
+            const normalized = normalizePath(filePath);
+            if (!hasOwn(stats, normalized)) {
+                throw new Error(`Stat not found: ${normalized}`);
+            }
+            return stats[normalized];
+        };
+
+        // fs.rename: in-memory fileBytes mutation only. Errors if source not in fileBytes.
+        // Preserves the library spec's specific semantic: rename works only for
+        // explicitly-seeded fileBytes, NOT for arbitrary persisted localStorage files.
+        window.__TAURI__.fs.rename = async (fromPath, toPath) => {
+            const normalizedFrom = normalizePath(fromPath);
+            const normalizedTo = normalizePath(toPath);
+            if (!hasOwn(fileBytes, normalizedFrom)) {
+                throw new Error(`Rename source not found: ${normalizedFrom}`);
+            }
+            fileBytes[normalizedTo] = fileBytes[normalizedFrom];
+            delete fileBytes[normalizedFrom];
+        };
+
+        // Harness doesn't install dialog; the library spec expects dialog.open to return null.
+        window.__TAURI__.dialog = {
+            async open() {
+                return null;
             },
         };
+
+        // Normalize appDataDir for parity with the original mock (strips trailing slashes).
+        const originalAppDataDir = window.__TAURI__.path.appDataDir;
+        window.__TAURI__.path.appDataDir = async () => normalizePath(await originalAppDataDir());
     }, options);
 }
 
@@ -3333,7 +3313,7 @@ test.describe('Desktop library scanning', () => {
             };
 
             const saved = await window.DicomViewerApp.desktopLibrary.saveCachedStudies('/library', studies);
-            const rawBefore = localStorage.getItem('mock-desktop-fs:/appdata/desktop-library-cache.json');
+            const rawBefore = localStorage.getItem('mock-tauri-fs:/appdata/desktop-library-cache.json');
             const externalStudies = structuredClone(studies);
             externalStudies['1.2.840.cached.study'].series['1.2.840.cached.series'].slices[0].source.path =
                 '/external/image.dcm';
@@ -3341,7 +3321,7 @@ test.describe('Desktop library scanning', () => {
                 '/library',
                 externalStudies,
             );
-            const rawAfter = localStorage.getItem('mock-desktop-fs:/appdata/desktop-library-cache.json');
+            const rawAfter = localStorage.getItem('mock-tauri-fs:/appdata/desktop-library-cache.json');
             return {
                 saved,
                 rejectedWrite,
@@ -3401,7 +3381,7 @@ test.describe('Desktop library scanning', () => {
             };
 
             await window.DicomViewerApp.desktopLibrary.saveCachedStudies('/library', studies);
-            const raw = localStorage.getItem('mock-desktop-fs:/appdata/desktop-library-cache.json');
+            const raw = localStorage.getItem('mock-tauri-fs:/appdata/desktop-library-cache.json');
             return {
                 loaded: await window.DicomViewerApp.desktopLibrary.loadCachedStudies('/library'),
                 mismatch: await window.DicomViewerApp.desktopLibrary.loadCachedStudies('/other-library'),

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -117,12 +117,14 @@ async function installMockDesktop(page, options = {}) {
             return originalInvoke(cmd, args);
         };
 
-        // fs.exists: in-memory fileBytes OR harness fallthrough (which checks localStorage).
+        // fs.exists: in-memory fileBytes OR harness fallthrough. Both lookups use the
+        // normalized path so paths arriving with double slashes / trailing slashes
+        // resolve consistently — the original spec normalized both sides too.
         const originalExists = window.__TAURI__.fs.exists;
         window.__TAURI__.fs.exists = async (filePath) => {
             const normalized = normalizePath(filePath);
             if (hasOwn(fileBytes, normalized)) return true;
-            return originalExists(filePath);
+            return originalExists(normalized);
         };
 
         // fs.readFile: failures → in-memory fileBytes → harness fallthrough → default [0].

--- a/tests/helpers/mock-desktop-tauri.contracts.spec.js
+++ b/tests/helpers/mock-desktop-tauri.contracts.spec.js
@@ -112,6 +112,28 @@ test.describe('mock desktop Tauri contract', () => {
         ]);
     });
 
+    test('fs.files seeded with Uint8Array values round-trips through Playwright serialization', async ({ page }) => {
+        // Regression: Uint8Array doesn't survive addInitScript's JSON serialization —
+        // it arrives in the browser as a plain object with numeric-string keys, no .length.
+        // The harness's serializeBytes must reconstruct the byte sequence from those keys
+        // or the seeded file silently becomes empty.
+        const payload = new TextEncoder().encode('hello world');
+
+        await installMockDesktopTauri(page, {
+            fs: {
+                files: { '/mock/appdata/seed.bin': payload },
+            },
+        });
+        await gotoMockDesktopPage(page);
+
+        const result = await page.evaluate(async () => {
+            const bytes = await window.__TAURI__.fs.readFile('/mock/appdata/seed.bin');
+            return Array.from(bytes);
+        });
+
+        expect(result).toEqual(Array.from(payload));
+    });
+
     test('ready promises resolve to the installed runtime', async ({ page }) => {
         await installMockDesktopTauri(page);
         await gotoMockDesktopPage(page);

--- a/tests/helpers/mock-desktop-tauri.js
+++ b/tests/helpers/mock-desktop-tauri.js
@@ -67,12 +67,7 @@ async function installMockDesktopTauri(page, options = {}) {
                 // serialization arrive as plain objects with numeric-string keys (no .length).
                 // Array.from on those returns [] — silently corrupting seeded binary data.
                 // Reconstruct the byte sequence in that case.
-                if (
-                    bytes &&
-                    typeof bytes === 'object' &&
-                    !Array.isArray(bytes) &&
-                    typeof bytes.length !== 'number'
-                ) {
+                if (bytes && typeof bytes === 'object' && !Array.isArray(bytes) && typeof bytes.length !== 'number') {
                     const keys = Object.keys(bytes)
                         .filter((key) => /^\d+$/.test(key))
                         .sort((a, b) => Number(a) - Number(b));

--- a/tests/helpers/mock-desktop-tauri.js
+++ b/tests/helpers/mock-desktop-tauri.js
@@ -63,6 +63,21 @@ async function installMockDesktopTauri(page, options = {}) {
                 if (typeof bytes === 'string') {
                     return JSON.stringify(Array.from(new TextEncoder().encode(bytes)));
                 }
+                // Uint8Array values round-tripped through Playwright's addInitScript JSON
+                // serialization arrive as plain objects with numeric-string keys (no .length).
+                // Array.from on those returns [] — silently corrupting seeded binary data.
+                // Reconstruct the byte sequence in that case.
+                if (
+                    bytes &&
+                    typeof bytes === 'object' &&
+                    !Array.isArray(bytes) &&
+                    typeof bytes.length !== 'number'
+                ) {
+                    const keys = Object.keys(bytes)
+                        .filter((key) => /^\d+$/.test(key))
+                        .sort((a, b) => Number(a) - Number(b));
+                    return JSON.stringify(keys.map((key) => Number(bytes[key]) || 0));
+                }
                 return JSON.stringify(Array.from(bytes || []));
             }
 


### PR DESCRIPTION
## Summary

Implements PR #5 from the v3 desktop test harness plan — the **last migration** of the sequence. Collapses \`installMockDesktop\` in \`tests/desktop-library.spec.js\` (the 4,361-line largest spec) onto the shared harness from PR #116. After this, all four desktop specs share the Tauri runtime.

## Scope

| Helper | Before | After | Role |
|---|---|---|---|
| \`installMockDesktop\` | ~200 lines bespoke | thin wrapper around \`installMockDesktopTauri\` | unit + scan tests (63 tests) |
| \`buildRevealInFinderStudies\` | unchanged | unchanged | fixture data (domain) |
| \`seedDesktopStudies\` | unchanged | unchanged | app-state seeding via page.evaluate |
| \`installRevealInvokeSpy\` | unchanged | unchanged | post-install spy (4 tests) |

Net change: **-20 lines** (4361 → 4341 lines, 139+/159−).

## Stage 0 split — not triggered

Per the v3 plan's concrete triggers:

| Trigger | Threshold | Actual | Fires? |
|---|---|---|---|
| Migration diff | > 800 lines | 298 lines | No |
| Independent test groups needing harness extensions | > 3 | 2 (\`Desktop library scanning\` + \`Desktop library Reveal in Finder\`) sharing one helper | No |
| Focused test runtime | > 60s | unknown without running | n/a |
| Harness needs unrelated domains in one PR | yes | no (single helper, same patterns as PR #4) | No |

Single-lane sequential migration is the right shape. Stage 0 deferred indefinitely.

## What the harness now owns

- \`window.__TAURI__\` namespace install + ready Promise pre-injection
- \`apply_desktop_migration\` and \`load_legacy_desktop_browser_stores\` (via \`options.invoke.legacyDesktopStores\`)
- \`fs.writeFile\` (now persists to shared \`mock-tauri-fs:\` localStorage keyspace), \`mkdir\`, \`remove\`, \`path.join/normalize\`, \`sql\`, \`webview\`
- Loud-failure sentinel for unknown \`core.invoke\` commands (invariant #7)
- SQL plugin via \`mock-tauri-sql-init.js\`

## What stays in the spec (per the promotion rule)

- \`read_scan_manifest\` / \`get_debug_settings\` / \`log_frontend_decode_event\` invoke commands
- \`dirs\` map for \`fs.readDir\` (with delay + per-path errors)
- \`stats\` map for \`fs.stat\`
- In-memory \`fileBytes\` map (distinct from harness localStorage)
- \`readFileFailures\` mutable per-path failure counter
- \`fs.rename\` library-specific semantic (errors if source not in \`fileBytes\`)
- \`__frontendDecodeTraceCalls\` browser-side state
- \`initialConfig\` localStorage seeding
- \`dialog.open\` stub
- \`appDataDir\` trailing-slash normalization

## One intentional change worth calling out

**Three direct-localStorage assertions** at lines 3316 / 3324 / 3384 updated from \`mock-desktop-fs:\` to \`mock-tauri-fs:\`. These tests were checking the bespoke storage prefix as an implementation detail; after migration the harness owns the keyspace. This is a legitimate normalization to the shared keyspace, not a behavior change in what the tests verify.

## Promotion-rule follow-up (deferred)

The v3 plan's 3-spec promotion rule is now **triggered** for two behaviors that have been spec-local across PRs #4 and #5:

1. **\`dialog.open returns null\`** — now installed by all 4 migrated spec helpers.
2. **\`read_scan_manifest\` invoke** — installed by 3 of 4 (import unit, import integration, library), though the return value comes from different option keys (\`importMockState.manifestEntries\` vs \`opts.nativeScanManifest\`).

Both qualify for graduation to first-class harness options. NOT graduated in this PR to keep scope tight — a graduation requires updating the harness + README + contract tests + all 4 migrated specs in the same change. Recommend a follow-up TODO doc similar to \`TODO-pr118-compat-runtime-followups.md\` to track this.

## v3 plan PR #5 compliance check

| Requirement | Status |
|---|---|
| Migrate \`tests/desktop-library.spec.js\` to shared harness | ✓ |
| Keep import-specific fixtures and edge cases in the spec | ✓ |
| Stage 0 split only under concrete triggers | ✓ (none fired, skipped) |
| Same total test count | ✓ (67 tests, unchanged) |
| Full suite passes | (CI to verify) |
| No domain fixtures moved into the harness | ✓ |

## Test plan

- [ ] CI green: \`Lint and Format\`, \`Run Playwright Tests\`, \`macOS Tauri Build Smoke\`, \`Vercel\`
- [ ] All 67 tests in \`desktop-library.spec.js\` pass with same assertions
- [ ] No regression in any other spec (report-persistence, import, runtime-compat all now harness-consumers)
- [ ] PR #1 nightly real-Tauri smoke still green next morning

After this lands, the v3 plan's 5-PR migration sequence is **complete**. All four desktop specs share the runtime; the only outstanding item is the promotion-rule follow-up flagged above.

claude