### PR TITLE
Harden release.sh and automate CHANGELOG promotion

### DIFF
--- a/desktop/scripts/promote-changelog.mjs
+++ b/desktop/scripts/promote-changelog.mjs
@@ -6,8 +6,8 @@
 // Usage: node desktop/scripts/promote-changelog.mjs <version> <YYYY-MM-DD>
 // Invoked by desktop/scripts/release.sh as part of cutting a release.
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const UNRELEASED_HEADING = '## [Unreleased]';
@@ -48,6 +48,19 @@ export function promoteChangelog(markdown, version, date) {
     return markdown.replace(UNRELEASED_HEADING, `${UNRELEASED_HEADING}\n\n## [${version}] - ${date}`);
 }
 
+export function writeFileAtomically(filePath, content) {
+    const parentDir = dirname(filePath);
+    const tmpDir = mkdtempSync(join(parentDir, '.promote-changelog-'));
+    const tmpPath = join(tmpDir, basename(filePath));
+
+    try {
+        writeFileSync(tmpPath, content);
+        renameSync(tmpPath, filePath);
+    } finally {
+        rmSync(tmpDir, { force: true, recursive: true });
+    }
+}
+
 function main() {
     const [version, date] = process.argv.slice(2);
     if (!version || !date) {
@@ -61,7 +74,7 @@ function main() {
 
     try {
         const current = readFileSync(changelogPath, 'utf8');
-        writeFileSync(changelogPath, promoteChangelog(current, version, date));
+        writeFileAtomically(changelogPath, promoteChangelog(current, version, date));
         console.log(`CHANGELOG: promoted [Unreleased] -> [${version}] - ${date}`);
     } catch (error) {
         console.error(error.message);

--- a/desktop/scripts/promote-changelog.mjs
+++ b/desktop/scripts/promote-changelog.mjs
@@ -11,6 +11,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const UNRELEASED_HEADING = '## [Unreleased]';
+const UNRELEASED_HEADING_PATTERN = /^## \[Unreleased\]$/gm;
 
 // Promote the [Unreleased] section to a versioned release heading. Returns the
 // rewritten changelog text. Throws if [Unreleased] is absent or has no content
@@ -23,11 +24,15 @@ export function promoteChangelog(markdown, version, date) {
         throw new Error('promoteChangelog: date is required');
     }
 
-    const markerIndex = markdown.indexOf(UNRELEASED_HEADING);
-    if (markerIndex === -1) {
+    const headings = markdown.match(UNRELEASED_HEADING_PATTERN) || [];
+    if (headings.length === 0) {
         throw new Error(`CHANGELOG: "${UNRELEASED_HEADING}" section not found`);
     }
+    if (headings.length !== 1) {
+        throw new Error(`CHANGELOG: "${UNRELEASED_HEADING}" section must appear exactly once`);
+    }
 
+    const markerIndex = markdown.search(UNRELEASED_HEADING_PATTERN);
     const afterMarker = markdown.slice(markerIndex + UNRELEASED_HEADING.length);
     const nextHeadingOffset = afterMarker.search(/\n## \[/);
     const sectionBody = nextHeadingOffset === -1 ? afterMarker : afterMarker.slice(0, nextHeadingOffset);

--- a/desktop/scripts/promote-changelog.mjs
+++ b/desktop/scripts/promote-changelog.mjs
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Divergent Health Technologies
+//
+// Promotes the CHANGELOG.md "[Unreleased]" section into a versioned, dated
+// release heading and opens a fresh, empty "[Unreleased]" section above it.
+//
+// Usage: node desktop/scripts/promote-changelog.mjs <version> <YYYY-MM-DD>
+// Invoked by desktop/scripts/release.sh as part of cutting a release.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const UNRELEASED_HEADING = '## [Unreleased]';
+
+// Promote the [Unreleased] section to a versioned release heading. Returns the
+// rewritten changelog text. Throws if [Unreleased] is absent or has no content
+// -- an empty section almost always means a forgotten entry, not a real release.
+export function promoteChangelog(markdown, version, date) {
+    if (!version) {
+        throw new Error('promoteChangelog: version is required');
+    }
+    if (!date) {
+        throw new Error('promoteChangelog: date is required');
+    }
+
+    const markerIndex = markdown.indexOf(UNRELEASED_HEADING);
+    if (markerIndex === -1) {
+        throw new Error(`CHANGELOG: "${UNRELEASED_HEADING}" section not found`);
+    }
+
+    const afterMarker = markdown.slice(markerIndex + UNRELEASED_HEADING.length);
+    const nextHeadingOffset = afterMarker.search(/\n## \[/);
+    const sectionBody = nextHeadingOffset === -1 ? afterMarker : afterMarker.slice(0, nextHeadingOffset);
+
+    if (sectionBody.trim() === '') {
+        throw new Error(`CHANGELOG: "${UNRELEASED_HEADING}" section is empty -- nothing to release`);
+    }
+
+    return markdown.replace(UNRELEASED_HEADING, `${UNRELEASED_HEADING}\n\n## [${version}] - ${date}`);
+}
+
+function main() {
+    const [version, date] = process.argv.slice(2);
+    if (!version || !date) {
+        console.error('usage: promote-changelog.mjs <version> <YYYY-MM-DD>');
+        process.exit(1);
+    }
+
+    // The script lives at <repo>/desktop/scripts/; CHANGELOG.md is at <repo>/.
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const changelogPath = join(repoRoot, 'CHANGELOG.md');
+
+    try {
+        const current = readFileSync(changelogPath, 'utf8');
+        writeFileSync(changelogPath, promoteChangelog(current, version, date));
+        console.log(`CHANGELOG: promoted [Unreleased] -> [${version}] - ${date}`);
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}
+
+// Run main() only when executed directly, not when imported by a test.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/desktop/scripts/promote-changelog.mjs
+++ b/desktop/scripts/promote-changelog.mjs
@@ -34,6 +34,8 @@ export function promoteChangelog(markdown, version, date) {
 
     const markerIndex = markdown.search(UNRELEASED_HEADING_PATTERN);
     const afterMarker = markdown.slice(markerIndex + UNRELEASED_HEADING.length);
+    // CHANGELOG sections are delimited by top-level release headings that use
+    // the "## [version]" form.
     const nextHeadingOffset = afterMarker.search(/\n## \[/);
     const sectionBody = nextHeadingOffset === -1 ? afterMarker : afterMarker.slice(0, nextHeadingOffset);
 
@@ -41,6 +43,8 @@ export function promoteChangelog(markdown, version, date) {
         throw new Error(`CHANGELOG: "${UNRELEASED_HEADING}" section is empty -- nothing to release`);
     }
 
+    // Leave the new [Unreleased] section intentionally empty. The next release
+    // should fail until a real changelog entry is added.
     return markdown.replace(UNRELEASED_HEADING, `${UNRELEASED_HEADING}\n\n## [${version}] - ${date}`);
 }
 

--- a/desktop/scripts/release.sh
+++ b/desktop/scripts/release.sh
@@ -154,7 +154,9 @@ RELEASE_FILES=(
 rollback_prep() {
     echo "" >&2
     echo "Release prep failed -- rolling back prepared files." >&2
-    git -C "$REPO_ROOT" restore --staged --worktree -- "${RELEASE_FILES[@]}" 2>/dev/null || true
+    if ! git -C "$REPO_ROOT" restore --staged --worktree -- "${RELEASE_FILES[@]}"; then
+        echo "Warning: rollback failed; inspect release files before retrying." >&2
+    fi
 }
 trap rollback_prep ERR
 

--- a/desktop/scripts/release.sh
+++ b/desktop/scripts/release.sh
@@ -199,7 +199,7 @@ echo ""
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Aborted. Reverting changes..."
     trap - ERR
-    git checkout -- .
+    git restore --staged --worktree -- "${RELEASE_FILES[@]}"
     exit 0
 fi
 

--- a/desktop/scripts/release.sh
+++ b/desktop/scripts/release.sh
@@ -121,6 +121,11 @@ case "$VERSION_ARG" in
         ;;
 esac
 
+# Assert the version actually changes -- release.sh cannot create an empty bump
+if [ "$NEW_VERSION" = "$CURRENT" ]; then
+    die "New version equals current version ($CURRENT) -- nothing to bump. Choose a higher version."
+fi
+
 # Assert tag doesn't exist
 TAG="v$NEW_VERSION"
 if git -C "$REPO_ROOT" tag -l "$TAG" | grep -q "$TAG"; then
@@ -135,6 +140,24 @@ echo ""
 
 echo "Updating version files..."
 
+# Files touched by release prep -- used for rollback and for staging the commit.
+RELEASE_FILES=(
+    desktop/src-tauri/tauri.conf.json
+    desktop/src-tauri/Cargo.toml
+    desktop/src-tauri/Cargo.lock
+    desktop/package.json
+    desktop/package-lock.json
+    CHANGELOG.md
+)
+
+# Restore every prepared file if any step below fails before the commit.
+rollback_prep() {
+    echo "" >&2
+    echo "Release prep failed -- rolling back prepared files." >&2
+    git -C "$REPO_ROOT" restore --staged --worktree -- "${RELEASE_FILES[@]}" 2>/dev/null || true
+}
+trap rollback_prep ERR
+
 # tauri.conf.json
 node -e "
 const fs = require('fs');
@@ -148,21 +171,26 @@ sed -i '' "s/^version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" "$CARGO_TOML"
 
 # package.json + package-lock.json
 cd "$DESKTOP_DIR"
-npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version > /dev/null 2>&1
+npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version > /dev/null
 
 # Cargo.lock
 echo "Updating Cargo.lock..."
 cd "$DESKTOP_DIR/src-tauri"
-cargo check --quiet 2>/dev/null
+cargo check --quiet
 
 cd "$REPO_ROOT"
+
+# CHANGELOG.md: promote the [Unreleased] section to a versioned, dated heading.
+# Exits non-zero (triggering rollback_prep) if [Unreleased] is missing or empty.
+echo "Promoting CHANGELOG.md..."
+node "$SCRIPT_DIR/promote-changelog.mjs" "$NEW_VERSION" "$(date +%F)"
 
 # Show diff
 echo ""
 echo "--- Changes ---"
 git diff --stat
 echo ""
-git diff -- desktop/src-tauri/tauri.conf.json desktop/src-tauri/Cargo.toml desktop/package.json
+git diff -- desktop/src-tauri/tauri.conf.json desktop/src-tauri/Cargo.toml desktop/package.json CHANGELOG.md
 echo ""
 
 # Confirm
@@ -170,19 +198,16 @@ read -p "Commit Release $TAG? (y/n) " -n 1 -r
 echo ""
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Aborted. Reverting changes..."
+    trap - ERR
     git checkout -- .
     exit 0
 fi
 
 # Commit
-git add \
-    desktop/src-tauri/tauri.conf.json \
-    desktop/src-tauri/Cargo.toml \
-    desktop/src-tauri/Cargo.lock \
-    desktop/package.json \
-    desktop/package-lock.json
+git add -- "${RELEASE_FILES[@]}"
 
 git commit -m "Release $TAG"
+trap - ERR
 
 echo ""
 echo "Committed: Release $TAG"

--- a/tests/promote-changelog.test.mjs
+++ b/tests/promote-changelog.test.mjs
@@ -2,8 +2,11 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
-import { promoteChangelog } from '../desktop/scripts/promote-changelog.mjs';
+import { promoteChangelog, writeFileAtomically } from '../desktop/scripts/promote-changelog.mjs';
 
 const SAMPLE = `# Changelog
 
@@ -88,4 +91,19 @@ test('promotes when [Unreleased] is the last section with content', () => {
 test('throws when version or date is missing', () => {
     assert.throws(() => promoteChangelog(SAMPLE, '', '2026-05-17'), /version is required/);
     assert.throws(() => promoteChangelog(SAMPLE, '0.4.1', ''), /date is required/);
+});
+
+test('writes changelog updates through a same-directory temporary file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'promote-changelog-'));
+    try {
+        const changelogPath = join(dir, 'CHANGELOG.md');
+        writeFileSync(changelogPath, 'old\n');
+
+        writeFileAtomically(changelogPath, 'new\n');
+
+        assert.equal(readFileSync(changelogPath, 'utf8'), 'new\n');
+        assert.deepEqual(readdirSync(dir), ['CHANGELOG.md']);
+    } finally {
+        rmSync(dir, { force: true, recursive: true });
+    }
 });

--- a/tests/promote-changelog.test.mjs
+++ b/tests/promote-changelog.test.mjs
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Divergent Health Technologies
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { promoteChangelog } from '../desktop/scripts/promote-changelog.mjs';
+
+const SAMPLE = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+- A real bug fix
+
+## [2026-04-10]
+
+### Added
+- An older feature
+`;
+
+test('promotes [Unreleased] to a versioned, dated heading', () => {
+    const result = promoteChangelog(SAMPLE, '0.4.1', '2026-05-17');
+    assert.match(result, /## \[0\.4\.1\] - 2026-05-17/);
+});
+
+test('moves existing entries under the new version heading', () => {
+    const result = promoteChangelog(SAMPLE, '0.4.1', '2026-05-17');
+    const versionIdx = result.indexOf('## [0.4.1] - 2026-05-17');
+    const bugIdx = result.indexOf('- A real bug fix');
+    const olderIdx = result.indexOf('## [2026-04-10]');
+    assert.ok(versionIdx < bugIdx, 'entry sits under the new version heading');
+    assert.ok(bugIdx < olderIdx, 'entry stays above the older section');
+});
+
+test('opens a fresh, empty [Unreleased] above the new version', () => {
+    const result = promoteChangelog(SAMPLE, '0.4.1', '2026-05-17');
+    const unreleasedIdx = result.indexOf('## [Unreleased]');
+    const versionIdx = result.indexOf('## [0.4.1] - 2026-05-17');
+    assert.notEqual(unreleasedIdx, -1, '[Unreleased] is still present');
+    assert.ok(unreleasedIdx < versionIdx, '[Unreleased] sits above the version');
+    const between = result.slice(unreleasedIdx + '## [Unreleased]'.length, versionIdx);
+    assert.equal(between.trim(), '', '[Unreleased] is empty after promotion');
+});
+
+test('leaves older sections untouched', () => {
+    const result = promoteChangelog(SAMPLE, '0.4.1', '2026-05-17');
+    assert.match(result, /## \[2026-04-10\]\n\n### Added\n- An older feature/);
+});
+
+test('throws when the [Unreleased] section is missing', () => {
+    const noUnreleased = '# Changelog\n\n## [2026-04-10]\n\n### Added\n- x\n';
+    assert.throws(() => promoteChangelog(noUnreleased, '0.4.1', '2026-05-17'), /not found/);
+});
+
+test('throws when the [Unreleased] section is empty', () => {
+    const empty = '# Changelog\n\n## [Unreleased]\n\n## [2026-04-10]\n\n### Added\n- x\n';
+    assert.throws(() => promoteChangelog(empty, '0.4.1', '2026-05-17'), /empty/);
+});
+
+test('throws when [Unreleased] is empty and is the last section', () => {
+    const empty = '# Changelog\n\n## [Unreleased]\n';
+    assert.throws(() => promoteChangelog(empty, '0.4.1', '2026-05-17'), /empty/);
+});
+
+test('promotes when [Unreleased] is the last section with content', () => {
+    const lastWithContent = '# Changelog\n\n## [Unreleased]\n\n### Fixed\n- last-section fix\n';
+    const result = promoteChangelog(lastWithContent, '0.4.1', '2026-05-17');
+    assert.match(result, /## \[0\.4\.1\] - 2026-05-17/);
+    assert.match(result, /- last-section fix/);
+});
+
+test('throws when version or date is missing', () => {
+    assert.throws(() => promoteChangelog(SAMPLE, '', '2026-05-17'), /version is required/);
+    assert.throws(() => promoteChangelog(SAMPLE, '0.4.1', ''), /date is required/);
+});

--- a/tests/promote-changelog.test.mjs
+++ b/tests/promote-changelog.test.mjs
@@ -52,6 +52,22 @@ test('throws when the [Unreleased] section is missing', () => {
     assert.throws(() => promoteChangelog(noUnreleased, '0.4.1', '2026-05-17'), /not found/);
 });
 
+test('throws when multiple [Unreleased] headings are present', () => {
+    const duplicate = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+- first entry
+
+## [Unreleased]
+
+### Added
+- second entry
+`;
+    assert.throws(() => promoteChangelog(duplicate, '0.4.1', '2026-05-17'), /exactly once/);
+});
+
 test('throws when the [Unreleased] section is empty', () => {
     const empty = '# Changelog\n\n## [Unreleased]\n\n## [2026-04-10]\n\n### Added\n- x\n';
     assert.throws(() => promoteChangelog(empty, '0.4.1', '2026-05-17'), /empty/);


### PR DESCRIPTION
## Summary

Release-tooling hardening from an audit of the release pipeline. Dev tooling only -- no user-facing or app behavior change.

- **No-op bump guard** -- `release.sh` refuses when the new version equals the current one (previously it proceeded and failed confusingly at commit time with nothing staged).
- **Mid-run rollback** -- an `ERR` trap restores all prepared version files if any prep step fails partway through, instead of leaving the tree half-edited.
- **Error visibility** -- `cargo check` and `npm version` no longer have their errors swallowed by `2>/dev/null` / `2>&1`.
- **CHANGELOG automation** -- new `desktop/scripts/promote-changelog.mjs` promotes the `[Unreleased]` section to a versioned, dated heading and opens a fresh `[Unreleased]`. `release.sh` runs it during prep and aborts (with rollback) if `[Unreleased]` is missing or empty -- closing the gap where the release body linked to a CHANGELOG nothing kept in sync.

Two redundant/unsafe local skill files (`.claude/` is gitignored here, so they are not in this diff) were handled separately: the `/update-dmg` skill was retired, and `/release`'s `git reset --hard origin/main` was replaced with a non-destructive `git merge --ff-only`.

## Test plan

- [x] `node --test tests/promote-changelog.test.mjs` -- 9/9 pass
- [x] `bash -n desktop/scripts/release.sh` -- syntax clean
- [x] `promote-changelog.mjs` CLI verified -- happy path promotes correctly; no-args prints usage and exits 1
- [ ] Exercised end-to-end by the next `/release` run

_Note: `node --test` files are not run by CI (pre-existing -- the `tests/*-worker.test.mjs` files are in the same state); the new test is run locally / on demand._

claude