### PR TITLE
Consolidate unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@ Copyright 2026 Divergent Health Technologies
 
 ## [Unreleased]
 
-### Fixed
-- DX/CR radiographs with full-range placeholder W/L now use pixel-statistics auto W/L instead of rendering washed out (BUG-012)
-
-## [2026-04-10]
-
 ### Added
 - Optional Usage Stats panel in Help for app opens and studies imported
 - Opt-in anonymous instrumentation snapshot support for desktop and personal modes
@@ -22,6 +17,7 @@ Copyright 2026 Divergent Health Technologies
 - Added repo-wide linting and formatting infrastructure to tighten release quality
 
 ### Fixed
+- DX/CR radiographs with full-range placeholder W/L now use pixel-statistics auto W/L instead of rendering washed out (BUG-012)
 - macOS app icon refresh after in-app updates
 - Several instrumentation correctness issues before first release
 


### PR DESCRIPTION
## Summary
- move the post-v0.3.2 2026-04-10 changelog entries under `[Unreleased]`
- keep the BUG-012 fix under the same unreleased section
- remove the misleading dated heading so release promotion captures the full v0.4.1 scope

## Verification
- `git diff --check`

## Notes
This is release prep for v0.4.1. It intentionally touches only `CHANGELOG.md`.