### PR TITLE
Run Node unit tests in PR validation

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -46,6 +46,27 @@ jobs:
       - name: Check JS and Python lint rules
         run: npm run lint:js && npm run lint:py
 
+  node-tests:
+    name: Run Node Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run Node unit tests
+        run: npm run test:node
+
   test:
     name: Run Playwright Tests
     runs-on: ubuntu-latest
@@ -100,9 +121,6 @@ jobs:
           elif [ -d "docs/sample" ]; then
             cp -r docs/sample/* test-data/
           fi
-
-      - name: Run Node unit tests
-        run: npm run test:node
 
       - name: Run Playwright tests
         run: |

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -101,6 +101,9 @@ jobs:
             cp -r docs/sample/* test-data/
           fi
 
+      - name: Run Node unit tests
+        run: npm run test:node
+
       - name: Run Playwright tests
         run: |
           source venv/bin/activate

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:py:fix": "./scripts/run-ruff.sh check --fix app.py server/",
     "lint:rust": "cargo clippy --locked --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings",
     "test": "npx playwright test",
+    "test:node": "node --test tests/*.test.mjs",
     "test:real-tauri": "DICOM_ENABLE_REAL_TAURI=1 npx playwright test --project=real-tauri",
     "worktree:new": "./scripts/agent-worktree-new.sh",
     "worktree:list": "./scripts/agent-worktree-list.sh",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:py:fix": "./scripts/run-ruff.sh check --fix app.py server/",
     "lint:rust": "cargo clippy --locked --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings",
     "test": "npx playwright test",
-    "test:node": "node --test \"tests/**/*.test.mjs\"",
+    "test:node": "node --test tests/*.test.mjs",
     "test:real-tauri": "DICOM_ENABLE_REAL_TAURI=1 npx playwright test --project=real-tauri",
     "worktree:new": "./scripts/agent-worktree-new.sh",
     "worktree:list": "./scripts/agent-worktree-list.sh",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:py:fix": "./scripts/run-ruff.sh check --fix app.py server/",
     "lint:rust": "cargo clippy --locked --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings",
     "test": "npx playwright test",
-    "test:node": "node --test tests/*.test.mjs",
+    "test:node": "node --test \"tests/**/*.test.mjs\"",
     "test:real-tauri": "DICOM_ENABLE_REAL_TAURI=1 npx playwright test --project=real-tauri",
     "worktree:new": "./scripts/agent-worktree-new.sh",
     "worktree:list": "./scripts/agent-worktree-list.sh",


### PR DESCRIPTION
## Summary
- add `npm run test:node` for `node --test tests/*.test.mjs`
- run the Node unit tests in PR validation before Playwright
- close the manual-only coverage gap for worker tests and release-tooling tests

## Verification
- `npm run test:node` — 83 passed
- Biome 2.4.10 via main checkout binary: `biome format . && biome lint . && git diff --check` — exit 0; reports existing `noPrototypeBuiltins` warnings in desktop import/library specs outside this PR.