### PR TITLE
[codex] Use Object.hasOwn in desktop test mocks

### DIFF
--- a/tests/desktop-import.spec.js
+++ b/tests/desktop-import.spec.js
@@ -162,7 +162,7 @@ async function installMockDesktop(page, options = {}) {
     });
 
     await page.addInitScript((opts) => {
-        const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+        const hasOwn = (object, key) => Object.hasOwn(object, key);
 
         function normalizePath(input) {
             const text = String(input || '').replace(/\\/g, '/');
@@ -1154,7 +1154,7 @@ async function installMockDesktopIntegration(page, options = {}) {
     });
 
     await page.addInitScript((opts) => {
-        const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+        const hasOwn = (object, key) => Object.hasOwn(object, key);
 
         function normalizePath(input) {
             const text = String(input || '').replace(/\\/g, '/');

--- a/tests/desktop-library.spec.js
+++ b/tests/desktop-library.spec.js
@@ -33,7 +33,7 @@ async function installMockDesktop(page, options = {}) {
     });
 
     await page.addInitScript((opts) => {
-        const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+        const hasOwn = (object, key) => Object.hasOwn(object, key);
 
         function toByteArray(value) {
             if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary
- replace hand-rolled `hasOwnProperty.call(...)` helpers in desktop test mocks with `Object.hasOwn(...)`
- clear the current Biome `noPrototypeBuiltins` warnings in the desktop import/library specs

## Verification
- `"/Users/gabriel/claude 0/dicom-viewer/node_modules/.bin/biome" format . && "/Users/gabriel/claude 0/dicom-viewer/node_modules/.bin/biome" lint . && git diff --check`
- `NODE_PATH="/Users/gabriel/claude 0/dicom-viewer/node_modules" "/Users/gabriel/claude 0/dicom-viewer/node_modules/.bin/playwright" test tests/desktop-import.spec.js tests/desktop-library.spec.js --reporter=line` (95 passed; used the main checkout dependencies/venv because this fresh worktree has no local install)
